### PR TITLE
feat: experimental generative UI in chat (OpenUI)

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -160,6 +160,7 @@ export default defineSchema({
     userId: v.string(),
     theme: v.union(v.literal('light'), v.literal('dark')),
     useSecondarySidebar: v.boolean(),
+    experimentalGenerativeUI: v.optional(v.boolean()),
     createdAt: v.number(),
     updatedAt: v.number(),
   }).index('by_userId', ['userId']),

--- a/convex/uiSettings.ts
+++ b/convex/uiSettings.ts
@@ -6,12 +6,14 @@ const themeValidator = v.union(v.literal('light'), v.literal('dark'))
 const uiSettingsValidator = v.object({
   theme: themeValidator,
   useSecondarySidebar: v.boolean(),
+  experimentalGenerativeUI: v.optional(v.boolean()),
 })
 
 function defaultUiSettings() {
   return {
     theme: 'light' as const,
     useSecondarySidebar: false,
+    experimentalGenerativeUI: false,
   }
 }
 
@@ -38,6 +40,7 @@ export const getByServer = query({
     return {
       theme: existing.theme,
       useSecondarySidebar: existing.useSecondarySidebar,
+      experimentalGenerativeUI: existing.experimentalGenerativeUI ?? false,
     }
   },
 })
@@ -48,6 +51,7 @@ export const upsertByServer = mutation({
     serverSecret: v.string(),
     theme: v.optional(themeValidator),
     useSecondarySidebar: v.optional(v.boolean()),
+    experimentalGenerativeUI: v.optional(v.boolean()),
   },
   returns: uiSettingsValidator,
   handler: async (ctx, args) => {
@@ -57,6 +61,7 @@ export const upsertByServer = mutation({
     const next = {
       theme: args.theme ?? existing?.theme ?? 'light',
       useSecondarySidebar: args.useSecondarySidebar ?? existing?.useSecondarySidebar ?? false,
+      experimentalGenerativeUI: args.experimentalGenerativeUI ?? existing?.experimentalGenerativeUI ?? false,
     }
 
     if (existing) {

--- a/src/app/api/app/conversations/ask/route.ts
+++ b/src/app/api/app/conversations/ask/route.ts
@@ -42,6 +42,7 @@ import {
   summarizeToolSetForLog,
 } from '@/lib/safe-log'
 import { resolveAuthenticatedAppUser } from '@/lib/app-api-auth'
+import { buildOpenUISystemPrompt } from '@/lib/openui-library'
 import type { Entitlements } from '@/lib/app-contracts'
 import {
   buildInsufficientCreditsPayload,
@@ -86,6 +87,7 @@ export async function POST(request: NextRequest) {
       replyContextForModel,
       accessToken,
       userId: requestedUserId,
+      experimentalGenerativeUI,
     }: {
       messages: UIMessage[]
       modelId?: string
@@ -101,6 +103,8 @@ export async function POST(request: NextRequest) {
       replyContextForModel?: string
       accessToken?: string
       userId?: string
+      /** When true, append the OpenUI system prompt so the model can generate structured UI blocks. */
+      experimentalGenerativeUI?: boolean
     } = await request.json()
     const auth = await resolveAuthenticatedAppUser(request, {
       accessToken,
@@ -296,6 +300,7 @@ export async function POST(request: NextRequest) {
       memoryContext,
       autoRetrieval,
       indexedNote,
+      experimentalGenerativeUI ? buildOpenUISystemPrompt() : '',
     ].filter(Boolean).join('\n\n')
 
     const browserToolNote =

--- a/src/app/api/app/settings/route.ts
+++ b/src/app/api/app/settings/route.ts
@@ -6,6 +6,7 @@ import { resolveAuthenticatedAppUser } from '@/lib/app-api-auth'
 type UiSettings = {
   theme: 'light' | 'dark'
   useSecondarySidebar: boolean
+  experimentalGenerativeUI?: boolean
 }
 
 export async function GET(request: NextRequest) {
@@ -33,6 +34,7 @@ export async function PATCH(request: NextRequest) {
     const body = (await request.json()) as {
       theme?: 'light' | 'dark'
       useSecondarySidebar?: boolean
+      experimentalGenerativeUI?: boolean
       accessToken?: string
       userId?: string
     }
@@ -49,6 +51,7 @@ export async function PATCH(request: NextRequest) {
       serverSecret: string
       theme?: 'light' | 'dark'
       useSecondarySidebar?: boolean
+      experimentalGenerativeUI?: boolean
     } = {
       userId: auth.userId,
       serverSecret: getInternalApiSecret(),
@@ -59,6 +62,9 @@ export async function PATCH(request: NextRequest) {
     }
     if (body.useSecondarySidebar !== undefined) {
       mutationArgs.useSecondarySidebar = body.useSecondarySidebar
+    }
+    if (body.experimentalGenerativeUI !== undefined) {
+      mutationArgs.experimentalGenerativeUI = body.experimentalGenerativeUI
     }
 
     const settings = await convex.mutation<UiSettings>(

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Mail, Moon, PanelsLeftRight, Sun } from 'lucide-react'
+import { FlaskConical, Mail, Moon, PanelsLeftRight, Sun } from 'lucide-react'
 import { TopUpPreferenceControl } from '@/components/billing/TopUpPreferenceControl'
 import { useAppSettings } from '@/components/app/AppSettingsProvider'
 import { SettingsSectionSkeleton } from '@/components/ui/Skeleton'
@@ -13,6 +13,7 @@ const SECTIONS = [
   { id: 'account', label: 'Account' },
   { id: 'customization', label: 'Customization' },
   { id: 'models', label: 'Models' },
+  { id: 'experimental', label: 'Experimental' },
   { id: 'contact', label: 'Contact' },
 ] as const
 
@@ -282,6 +283,32 @@ export default function SettingsPage() {
                 Go to chat →
               </Link>
             </SectionPlaceholder>
+          )}
+
+          {!isLoading && section === 'experimental' && (
+            <>
+              <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-elevated)] p-5 shadow-sm">
+                <div className="flex items-start gap-3 mb-4">
+                  <div className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface-subtle)] text-[var(--foreground)]">
+                    <FlaskConical size={18} strokeWidth={1.8} />
+                  </div>
+                  <div className="min-w-0">
+                    <h2 className="text-sm font-medium text-[var(--foreground)]">Experimental features</h2>
+                    <p className="mt-1 text-sm leading-relaxed text-[var(--muted)]">
+                      These features are in active development. Behavior may change or be removed in future releases.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <SettingRow
+                icon={<FlaskConical size={18} strokeWidth={1.8} />}
+                title="Generative UI"
+                description="When enabled, certain responses render as interactive UI components — metrics, tables, and structured data — instead of plain text."
+                checked={settings.experimentalGenerativeUI}
+                disabled={busy}
+                onChange={() => void updateSettings({ experimentalGenerativeUI: !settings.experimentalGenerativeUI })}
+              />
+            </>
           )}
 
           {!isLoading && section === 'contact' && (

--- a/src/components/app/AppSettingsProvider.tsx
+++ b/src/components/app/AppSettingsProvider.tsx
@@ -15,6 +15,7 @@ export type ThemePreference = 'light' | 'dark'
 export type AppSettings = {
   theme: ThemePreference
   useSecondarySidebar: boolean
+  experimentalGenerativeUI: boolean
 }
 
 type AppSettingsContextValue = {
@@ -28,6 +29,7 @@ type AppSettingsContextValue = {
 export const DEFAULT_APP_SETTINGS: AppSettings = {
   theme: 'light',
   useSecondarySidebar: false,
+  experimentalGenerativeUI: false,
 }
 
 const AppSettingsContext = createContext<AppSettingsContextValue | null>(null)
@@ -40,6 +42,18 @@ function isAppSettings(value: unknown): value is AppSettings {
     (candidate.theme === 'light' || candidate.theme === 'dark') &&
     typeof candidate.useSecondarySidebar === 'boolean'
   )
+}
+
+function hydrateAppSettings(raw: unknown): AppSettings {
+  const base = isAppSettings(raw) ? raw : DEFAULT_APP_SETTINGS
+  return {
+    ...DEFAULT_APP_SETTINGS,
+    ...base,
+    // Coerce optional booleans that older stored values may not have
+    experimentalGenerativeUI: typeof (raw as Partial<AppSettings>).experimentalGenerativeUI === 'boolean'
+      ? (raw as Partial<AppSettings>).experimentalGenerativeUI!
+      : false,
+  }
 }
 
 function readStoredSettings(): AppSettings | null {
@@ -71,17 +85,17 @@ export function AppSettingsProvider({ children }: { children: React.ReactNode })
   const refresh = useCallback(async () => {
     const stored = readStoredSettings()
     if (stored) {
-      setSettings(stored)
+      setSettings(hydrateAppSettings(stored))
     }
 
     try {
       const res = await fetch('/api/app/settings', { cache: 'no-store' })
       if (res.ok) {
-        const next = await res.json() as AppSettings
+        const next = hydrateAppSettings(await res.json())
         setSettings(next)
         persistSettings(next)
       } else if (res.status === 401) {
-        setSettings(stored ?? DEFAULT_APP_SETTINGS)
+        setSettings(stored ? hydrateAppSettings(stored) : DEFAULT_APP_SETTINGS)
       }
     } catch {
       if (!stored) {

--- a/src/components/app/AppSidebar.tsx
+++ b/src/components/app/AppSidebar.tsx
@@ -49,6 +49,7 @@ const SETTINGS_SECTIONS = [
   { id: 'account', label: 'Account' },
   { id: 'customization', label: 'Customization' },
   { id: 'models', label: 'Models' },
+  { id: 'experimental', label: 'Experimental' },
   { id: 'contact', label: 'Contact' },
 ] as const
 

--- a/src/components/app/ChatInterface.tsx
+++ b/src/components/app/ChatInterface.tsx
@@ -4183,6 +4183,7 @@ async function hydrateCompletedAskTurnFromServer(
               skipUserMessage: persistedUserMessage || idx !== 0,
               ...(indexedFileNames.length > 0 ? { indexedFileNames } : {}),
               ...(replyCtxSnapshot?.bodyForModel ? { replyContextForModel: replyCtxSnapshot.bodyForModel } : {}),
+              ...(settings.experimentalGenerativeUI ? { experimentalGenerativeUI: true } : {}),
             },
           },
         ),

--- a/src/components/app/MarkdownMessage.tsx
+++ b/src/components/app/MarkdownMessage.tsx
@@ -13,6 +13,8 @@ import { stripThinkingPlaceholderMarkdown } from '@/lib/agent-assistant-text'
 import type { SourceCitationMap } from '@/lib/ask-knowledge-context'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import { OpenUIRenderer } from './OpenUIRenderer'
+import { isOpenUILang } from '@/lib/openui-parser'
 
 function useDocumentThemeIsDark(): boolean {
   return useSyncExternalStore(
@@ -215,9 +217,15 @@ const mdComponents = {
     const match = /language-(\w+)/.exec(className || '')
     // Block code = has a language class from the fence
     if (match) {
+      const lang = match[1]
+      const codeStr = String(children).replace(/\n$/, '')
+      // Render OpenUI Lang blocks as structured UI
+      if (lang === 'openui' || isOpenUILang(codeStr)) {
+        return <OpenUIRenderer code={codeStr} />
+      }
       return (
-        <CodeBlock language={match[1]}>
-          {String(children).replace(/\n$/, '')}
+        <CodeBlock language={lang}>
+          {codeStr}
         </CodeBlock>
       )
     }

--- a/src/components/app/OpenUIRenderer.tsx
+++ b/src/components/app/OpenUIRenderer.tsx
@@ -1,0 +1,319 @@
+'use client'
+
+import React from 'react'
+import { parseOpenUILang, resolveArg } from '@/lib/openui-parser'
+import type { OpenUINode, OpenUIDefinitions, OpenUIArg } from '@/lib/openui-parser'
+
+// ─── Component Renderers ────────────────────────────────────────────────────
+
+function RenderStack({ node, defs }: { node: OpenUINode; defs: OpenUIDefinitions }) {
+  const children = resolveChildren(node.args[0], defs)
+  return (
+    <div className="flex flex-col gap-3">
+      {children}
+    </div>
+  )
+}
+
+function RenderGrid({ node, defs }: { node: OpenUINode; defs: OpenUIDefinitions }) {
+  const children = resolveChildren(node.args[0], defs)
+  const count = React.Children.count(children)
+  const colClass = count <= 2 ? 'grid-cols-2' : count === 3 ? 'grid-cols-3' : 'grid-cols-2 sm:grid-cols-4'
+  return (
+    <div className={`grid gap-3 ${colClass}`}>
+      {children}
+    </div>
+  )
+}
+
+function RenderCard({ node }: { node: OpenUINode }) {
+  const headline = argStr(node.args[0])
+  const body = argStr(node.args[1])
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] p-4 shadow-sm">
+      {headline && <p className="text-sm font-semibold text-[var(--foreground)]">{headline}</p>}
+      {body && <p className="mt-1.5 text-sm leading-relaxed text-[var(--muted)]">{body}</p>}
+    </div>
+  )
+}
+
+function RenderStatCard({ node }: { node: OpenUINode }) {
+  const label = argStr(node.args[0])
+  const value = argStr(node.args[1])
+  const trend = argStr(node.args[2])
+
+  const trendEl = trend ? (
+    <span
+      className={`inline-flex items-center gap-0.5 text-xs font-medium ${
+        trend === 'up'
+          ? 'text-emerald-600 dark:text-emerald-400'
+          : trend === 'down'
+          ? 'text-red-600 dark:text-red-400'
+          : 'text-[var(--muted)]'
+      }`}
+    >
+      {trend === 'up' ? '↑' : trend === 'down' ? '↓' : '→'}
+      <span className="capitalize">{trend}</span>
+    </span>
+  ) : null
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] p-4 shadow-sm">
+      <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted)]">{label}</p>
+      <p className="mt-1 text-2xl font-bold text-[var(--foreground)] leading-tight">{value}</p>
+      {trendEl && <div className="mt-1.5">{trendEl}</div>}
+    </div>
+  )
+}
+
+function RenderDataTable({ node, defs }: { node: OpenUINode; defs: OpenUIDefinitions }) {
+  const columnsStr = argStr(node.args[0])
+  const columns = columnsStr ? columnsStr.split(',').map((c) => c.trim()) : []
+  const rowRefs = node.args[1]
+  const rows: string[][] = []
+
+  if (Array.isArray(rowRefs)) {
+    for (const ref of rowRefs) {
+      if (typeof ref === 'string') {
+        const rowNode = defs.get(ref)
+        if (rowNode?.component === 'DataRow') {
+          const valStr = argStr(rowNode.args[0])
+          rows.push(valStr ? valStr.split(',').map((v) => v.trim()) : [])
+        }
+      }
+    }
+  }
+
+  if (columns.length === 0) return null
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] shadow-sm">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-[var(--border)] bg-[var(--surface-subtle)]">
+            {columns.map((col, i) => (
+              <th
+                key={i}
+                className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-[var(--muted)]"
+              >
+                {col}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, ri) => (
+            <tr
+              key={ri}
+              className={`border-b border-[var(--border)] last:border-0 ${ri % 2 === 1 ? 'bg-[var(--surface-subtle)]' : ''}`}
+            >
+              {columns.map((_, ci) => (
+                <td key={ci} className="px-4 py-2.5 text-[var(--foreground)]">
+                  {row[ci] ?? ''}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function RenderBadge({ node }: { node: OpenUINode }) {
+  const label = argStr(node.args[0])
+  const variant = argStr(node.args[1]) || 'default'
+
+  const variantClass: Record<string, string> = {
+    default: 'bg-[var(--surface-subtle)] text-[var(--foreground)]',
+    success: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+    warning: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+    error: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+    info: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${variantClass[variant] ?? variantClass.default}`}
+    >
+      {label}
+    </span>
+  )
+}
+
+function RenderAlert({ node }: { node: OpenUINode }) {
+  const type = argStr(node.args[0]) || 'info'
+  const message = argStr(node.args[1])
+  const title = argStr(node.args[2])
+
+  const typeStyles: Record<string, { container: string; icon: string }> = {
+    info: {
+      container: 'border-blue-200 bg-blue-50 dark:border-blue-800/50 dark:bg-blue-900/20',
+      icon: 'text-blue-600 dark:text-blue-400',
+    },
+    success: {
+      container: 'border-emerald-200 bg-emerald-50 dark:border-emerald-800/50 dark:bg-emerald-900/20',
+      icon: 'text-emerald-600 dark:text-emerald-400',
+    },
+    warning: {
+      container: 'border-amber-200 bg-amber-50 dark:border-amber-800/50 dark:bg-amber-900/20',
+      icon: 'text-amber-600 dark:text-amber-400',
+    },
+    error: {
+      container: 'border-red-200 bg-red-50 dark:border-red-800/50 dark:bg-red-900/20',
+      icon: 'text-red-600 dark:text-red-400',
+    },
+  }
+  const s = typeStyles[type] ?? typeStyles.info
+
+  const icons: Record<string, string> = {
+    info: 'ℹ',
+    success: '✓',
+    warning: '⚠',
+    error: '✕',
+  }
+
+  return (
+    <div className={`rounded-xl border p-4 ${s.container}`}>
+      <div className="flex items-start gap-3">
+        <span className={`mt-0.5 text-base font-bold shrink-0 ${s.icon}`}>{icons[type] ?? 'ℹ'}</span>
+        <div className="min-w-0">
+          {title && <p className={`text-sm font-semibold mb-0.5 ${s.icon}`}>{title}</p>}
+          <p className="text-sm text-[var(--foreground)] leading-relaxed">{message}</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function RenderKeyValueList({ node, defs }: { node: OpenUINode; defs: OpenUIDefinitions }) {
+  const pairRefs = node.args[0]
+  const pairs: { label: string; value: string }[] = []
+
+  if (Array.isArray(pairRefs)) {
+    for (const ref of pairRefs) {
+      if (typeof ref === 'string') {
+        const pNode = defs.get(ref)
+        if (pNode?.component === 'KeyValuePair') {
+          pairs.push({
+            label: argStr(pNode.args[0]) ?? '',
+            value: argStr(pNode.args[1]) ?? '',
+          })
+        }
+      }
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] shadow-sm overflow-hidden">
+      {pairs.map((pair, i) => (
+        <div
+          key={i}
+          className={`flex items-center justify-between px-4 py-2.5 ${
+            i < pairs.length - 1 ? 'border-b border-[var(--border)]' : ''
+          } ${i % 2 === 1 ? 'bg-[var(--surface-subtle)]' : ''}`}
+        >
+          <span className="text-sm text-[var(--muted)] shrink-0 mr-4">{pair.label}</span>
+          <span className="text-sm font-medium text-[var(--foreground)] text-right">{pair.value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function RenderTextContent({ node }: { node: OpenUINode }) {
+  const text = argStr(node.args[0])
+  const style = argStr(node.args[1]) || 'normal'
+
+  const styleClass: Record<string, string> = {
+    heading: 'text-base font-bold text-[var(--foreground)]',
+    subheading: 'text-sm font-semibold text-[var(--foreground)]',
+    muted: 'text-sm text-[var(--muted)]',
+    normal: 'text-sm text-[var(--foreground)]',
+  }
+
+  return <p className={styleClass[style] ?? styleClass.normal}>{text}</p>
+}
+
+function RenderSection({ node, defs }: { node: OpenUINode; defs: OpenUIDefinitions }) {
+  const title = argStr(node.args[0])
+  const children = resolveChildren(node.args[1], defs)
+  return (
+    <div className="flex flex-col gap-3">
+      {title && (
+        <p className="text-xs font-semibold uppercase tracking-wider text-[var(--muted)]">{title}</p>
+      )}
+      {children}
+    </div>
+  )
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function argStr(arg: OpenUIArg | undefined): string | null {
+  if (typeof arg === 'string') return arg
+  return null
+}
+
+function resolveChildren(arg: OpenUIArg | undefined, defs: OpenUIDefinitions): React.ReactNode[] {
+  if (!arg) return []
+  if (!Array.isArray(arg)) return []
+
+  return arg.map((ref, i) => {
+    if (typeof ref !== 'string') return null
+    const node = defs.get(ref)
+    if (!node) return null
+    return <RenderNode key={`${ref}-${i}`} node={node} defs={defs} />
+  })
+}
+
+function RenderNode({ node, defs }: { node: OpenUINode; defs: OpenUIDefinitions }): React.ReactElement | null {
+  switch (node.component) {
+    case 'Stack': return <RenderStack node={node} defs={defs} />
+    case 'Grid': return <RenderGrid node={node} defs={defs} />
+    case 'Card': return <RenderCard node={node} />
+    case 'StatCard': return <RenderStatCard node={node} />
+    case 'DataTable': return <RenderDataTable node={node} defs={defs} />
+    case 'DataRow': return null // rendered via DataTable
+    case 'Badge': return <RenderBadge node={node} />
+    case 'Alert': return <RenderAlert node={node} />
+    case 'KeyValueList': return <RenderKeyValueList node={node} defs={defs} />
+    case 'KeyValuePair': return null // rendered via KeyValueList
+    case 'TextContent': return <RenderTextContent node={node} />
+    case 'Section': return <RenderSection node={node} defs={defs} />
+    default: return null
+  }
+}
+
+// ─── Public Component ────────────────────────────────────────────────────────
+
+interface OpenUIRendererProps {
+  code: string
+}
+
+export function OpenUIRenderer({ code }: OpenUIRendererProps) {
+  const parsed = parseOpenUILang(code)
+
+  if (!parsed) {
+    // Fallback: show as plain code if parsing fails
+    return (
+      <pre className="rounded-xl border border-[var(--border)] bg-[var(--surface-subtle)] p-4 text-xs font-mono text-[var(--muted)] overflow-x-auto">
+        {code}
+      </pre>
+    )
+  }
+
+  return (
+    <div className="my-2 flex flex-col gap-2">
+      <div className="flex items-center gap-1.5">
+        <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border)] bg-[var(--surface-subtle)] px-2 py-0.5 text-[10px] font-medium text-[var(--muted)]">
+          <span className="text-[9px]">✦</span>
+          Generated UI
+        </span>
+      </div>
+      <div className="min-w-0">
+        <RenderNode node={parsed.root} defs={parsed.defs} />
+      </div>
+    </div>
+  )
+}

--- a/src/lib/openui-library.ts
+++ b/src/lib/openui-library.ts
@@ -1,0 +1,160 @@
+/**
+ * OpenUI Lang component library definition for Overlay.
+ *
+ * Defines the components the LLM can use and generates the system prompt
+ * fragment that teaches it to output OpenUI Lang.
+ *
+ * NO npm package required — this is a pure description used to build the
+ * system prompt. Rendering happens in OpenUIRenderer.tsx.
+ */
+
+export const OPENUI_COMPONENTS = [
+  {
+    name: 'Stack',
+    description: 'Vertical flex container for grouping components.',
+    args: [{ name: 'children', type: 'array of refs', description: 'Components to stack vertically' }],
+    example: 'Stack([header, body])',
+  },
+  {
+    name: 'Grid',
+    description: 'Horizontal grid of equal-width columns.',
+    args: [{ name: 'children', type: 'array of refs', description: 'Components arranged in a grid' }],
+    example: 'Grid([c1, c2, c3])',
+  },
+  {
+    name: 'Card',
+    description: 'Bordered card with a headline and optional body text.',
+    args: [
+      { name: 'headline', type: 'string', description: 'Card title' },
+      { name: 'body', type: 'string', description: 'Body text (optional)' },
+    ],
+    example: 'Card("Revenue Summary", "Q4 results were strong.")',
+  },
+  {
+    name: 'StatCard',
+    description: 'Metric display card with label, value, and optional trend indicator.',
+    args: [
+      { name: 'label', type: 'string', description: 'Metric name' },
+      { name: 'value', type: 'string', description: 'Metric value (e.g. "$1.2M", "94%")' },
+      { name: 'trend', type: 'string', description: 'Trend: "up", "down", or "flat" (optional)' },
+    ],
+    example: 'StatCard("Revenue", "$1.2M", "up")',
+  },
+  {
+    name: 'DataTable',
+    description: 'A two-dimensional data table. Columns are comma-separated in a string. Rows are DataRow refs.',
+    args: [
+      { name: 'columns', type: 'string', description: 'Comma-separated column headers (e.g. "Name,Value,Status")' },
+      { name: 'rows', type: 'array of DataRow refs', description: 'Array of DataRow components' },
+    ],
+    example: 'DataTable("Name,Score,Grade", [r1, r2, r3])',
+  },
+  {
+    name: 'DataRow',
+    description: 'A single row inside a DataTable. Values are comma-separated in a string.',
+    args: [
+      { name: 'values', type: 'string', description: 'Comma-separated cell values matching the table columns' },
+    ],
+    example: 'DataRow("Alice,98,A+")',
+  },
+  {
+    name: 'Badge',
+    description: 'A small inline label badge.',
+    args: [
+      { name: 'label', type: 'string', description: 'Badge text' },
+      { name: 'variant', type: 'string', description: 'Visual style: "default", "success", "warning", "error", "info" (optional, defaults to "default")' },
+    ],
+    example: 'Badge("Active", "success")',
+  },
+  {
+    name: 'Alert',
+    description: 'An inline alert or callout block.',
+    args: [
+      { name: 'type', type: 'string', description: 'Alert type: "info", "success", "warning", "error"' },
+      { name: 'message', type: 'string', description: 'Alert body text' },
+      { name: 'title', type: 'string', description: 'Optional alert title' },
+    ],
+    example: 'Alert("warning", "Disk usage is above 90%", "Storage Warning")',
+  },
+  {
+    name: 'KeyValueList',
+    description: 'A vertical list of label-value pairs. Each pair is a KeyValuePair ref.',
+    args: [
+      { name: 'pairs', type: 'array of KeyValuePair refs', description: 'Array of KeyValuePair components' },
+    ],
+    example: 'KeyValueList([p1, p2, p3])',
+  },
+  {
+    name: 'KeyValuePair',
+    description: 'A single label-value pair used inside KeyValueList.',
+    args: [
+      { name: 'label', type: 'string', description: 'Key/label text' },
+      { name: 'value', type: 'string', description: 'Value text' },
+    ],
+    example: 'KeyValuePair("Status", "Running")',
+  },
+  {
+    name: 'TextContent',
+    description: 'A text block with optional semantic style.',
+    args: [
+      { name: 'text', type: 'string', description: 'The text to display' },
+      { name: 'style', type: 'string', description: 'Optional style: "heading", "subheading", "muted", "normal" (default)' },
+    ],
+    example: 'TextContent("System Overview", "heading")',
+  },
+  {
+    name: 'Section',
+    description: 'A named section with a title and child components.',
+    args: [
+      { name: 'title', type: 'string', description: 'Section heading text' },
+      { name: 'children', type: 'array of refs', description: 'Components inside the section' },
+    ],
+    example: 'Section("Performance", [chart, summary])',
+  },
+] as const
+
+/**
+ * Generates the system prompt fragment that teaches the model to output OpenUI Lang
+ * when a response would benefit from structured UI.
+ */
+export function buildOpenUISystemPrompt(): string {
+  const componentDocs = OPENUI_COMPONENTS.map((c) => {
+    const argList = c.args.map((a) => `  - ${a.name} (${a.type}): ${a.description}`).join('\n')
+    return `${c.name}(${c.args.map((a) => a.name).join(', ')})\n  ${c.description}\n${argList}\n  Example: \`${c.example}\``
+  }).join('\n\n')
+
+  return `## Generative UI (Experimental)
+
+When a response would benefit from structured visual presentation — such as metrics, comparisons, tables, key-value data, or status summaries — you MAY render it as a UI block using OpenUI Lang instead of plain markdown.
+
+### When to use generative UI
+Use it for: dashboards, metric summaries, comparison tables, structured data, status overviews, key-value lists.
+Do NOT use it for: conversational text, explanations, code, long-form writing, or content that flows naturally as markdown.
+
+### How to output a UI block
+Wrap the OpenUI Lang inside a fenced code block with language \`openui\`:
+
+\`\`\`openui
+root = Stack([title, stats])
+title = TextContent("Q4 Summary", "heading")
+stats = Grid([s1, s2])
+s1 = StatCard("Revenue", "$1.2M", "up")
+s2 = StatCard("Users", "45k", "flat")
+\`\`\`
+
+### OpenUI Lang rules
+1. One statement per line: \`identifier = ComponentName(args)\`
+2. The FIRST statement MUST assign to \`root\`
+3. Arguments map to component props in order (positional)
+4. Strings use double quotes. Arrays use \`[ref1, ref2]\` syntax
+5. Define referenced identifiers AFTER the root, top-to-bottom
+6. Keep it minimal — 3-12 lines is ideal
+
+### Available components
+${componentDocs}
+
+### Composing UI
+You can mix UI blocks with surrounding markdown text. Put the \`\`\`openui block where the visual summary belongs, and use regular markdown for the surrounding explanation.
+
+Only generate UI when it clearly improves the response. When in doubt, use markdown.`
+}

--- a/src/lib/openui-parser.ts
+++ b/src/lib/openui-parser.ts
@@ -1,0 +1,170 @@
+/**
+ * Minimal OpenUI Lang parser.
+ *
+ * Grammar (subset):
+ *   statement  ::= identifier "=" expr
+ *   expr       ::= ComponentName "(" args ")"
+ *   args       ::= arg ("," arg)*
+ *   arg        ::= string | array | identifier
+ *   string     ::= '"' .* '"'
+ *   array      ::= "[" (identifier ("," identifier)*)? "]"
+ *
+ * The first statement must assign to `root`.
+ */
+
+export type OpenUIArg = string | OpenUIArg[] | OpenUINode | null
+
+export interface OpenUINode {
+  component: string
+  args: OpenUIArg[]
+}
+
+export type OpenUIDefinitions = Map<string, OpenUINode>
+
+/**
+ * Parse OpenUI Lang text into a definitions map.
+ * Returns null if the text doesn't look like valid OpenUI Lang.
+ */
+export function parseOpenUILang(text: string): { root: OpenUINode; defs: OpenUIDefinitions } | null {
+  const lines = text.split('\n').map((l) => l.trim()).filter(Boolean)
+  if (lines.length === 0) return null
+
+  const defs: OpenUIDefinitions = new Map()
+  let hasRoot = false
+
+  for (const line of lines) {
+    // Skip comment lines
+    if (line.startsWith('#') || line.startsWith('//')) continue
+
+    const eqIdx = line.indexOf('=')
+    if (eqIdx === -1) continue
+
+    const identifier = line.slice(0, eqIdx).trim()
+    const exprStr = line.slice(eqIdx + 1).trim()
+    if (!identifier || !exprStr) continue
+
+    const node = parseExpr(exprStr)
+    if (!node) continue
+
+    defs.set(identifier, node)
+    if (identifier === 'root') hasRoot = true
+  }
+
+  if (!hasRoot) return null
+  const root = defs.get('root')!
+  return { root, defs }
+}
+
+function parseExpr(str: string): OpenUINode | null {
+  const parenIdx = str.indexOf('(')
+  if (parenIdx === -1) return null
+
+  const component = str.slice(0, parenIdx).trim()
+  if (!component || !/^[A-Z]/.test(component)) return null
+
+  // Find matching closing paren
+  const inner = str.slice(parenIdx + 1)
+  const closeParen = findMatchingParen(inner)
+  if (closeParen === -1) return null
+
+  const argsStr = inner.slice(0, closeParen).trim()
+  const args = parseArgs(argsStr)
+
+  return { component, args }
+}
+
+function findMatchingParen(str: string): number {
+  let depth = 0
+  let inString = false
+  let i = 0
+  for (; i < str.length; i++) {
+    const ch = str[i]
+    if (ch === '"' && str[i - 1] !== '\\') {
+      inString = !inString
+    }
+    if (!inString) {
+      if (ch === '(' || ch === '[') depth++
+      else if (ch === ')' || ch === ']') {
+        if (depth === 0) return i
+        depth--
+      }
+    }
+  }
+  return -1
+}
+
+function parseArgs(str: string): OpenUIArg[] {
+  if (!str.trim()) return []
+
+  const args: OpenUIArg[] = []
+  let i = 0
+
+  while (i < str.length) {
+    // Skip whitespace
+    while (i < str.length && str[i] === ' ') i++
+    if (i >= str.length) break
+
+    const ch = str[i]
+
+    if (ch === '"') {
+      // String literal
+      let j = i + 1
+      while (j < str.length && !(str[j] === '"' && str[j - 1] !== '\\')) j++
+      args.push(str.slice(i + 1, j))
+      i = j + 1
+    } else if (ch === '[') {
+      // Array of identifiers
+      let depth = 1
+      let j = i + 1
+      while (j < str.length && depth > 0) {
+        if (str[j] === '[') depth++
+        else if (str[j] === ']') depth--
+        j++
+      }
+      const innerArr = str.slice(i + 1, j - 1).trim()
+      const refs = innerArr ? innerArr.split(',').map((r) => r.trim()).filter(Boolean) : []
+      args.push(refs)
+      i = j
+    } else if (/[a-zA-Z_]/.test(ch)) {
+      // Identifier (forward reference)
+      let j = i
+      while (j < str.length && /\w/.test(str[j])) j++
+      args.push(str.slice(i, j))
+      i = j
+    } else {
+      i++
+    }
+
+    // Skip comma
+    while (i < str.length && (str[i] === ',' || str[i] === ' ')) i++
+  }
+
+  return args
+}
+
+/**
+ * Detect if a text block is likely OpenUI Lang.
+ * Heuristic: starts with `root = SomeComponent(` within the first 3 non-empty lines.
+ */
+export function isOpenUILang(text: string): boolean {
+  const lines = text.split('\n').map((l) => l.trim()).filter(Boolean)
+  for (let i = 0; i < Math.min(lines.length, 3); i++) {
+    if (/^root\s*=\s*[A-Z]/.test(lines[i])) return true
+  }
+  return false
+}
+
+/**
+ * Resolve an arg to its final node using the defs map.
+ * If the arg is a string identifier that maps to a node, return that node.
+ */
+export function resolveArg(arg: OpenUIArg, defs: OpenUIDefinitions): OpenUINode | string | OpenUIArg[] | null {
+  if (typeof arg === 'string') {
+    // Could be a forward ref or a plain string value
+    const resolved = defs.get(arg)
+    return resolved ?? arg
+  }
+  if (Array.isArray(arg)) return arg
+  if (arg && typeof arg === 'object') return arg
+  return null
+}


### PR DESCRIPTION
## Summary

- Adds an **Experimental Generative UI** toggle in **Settings → Experimental**
- When enabled, Claude can emit ` ```openui ` fenced blocks that render as interactive UI components (metrics cards, data tables, grids, alerts, key-value lists) instead of plain text
- No new API key or npm dependency required — custom parser + renderer built from scratch, styled with the existing CSS variable system

## What changed

| File | Change |
|------|--------|
| `src/lib/openui-parser.ts` | Custom OpenUI Lang parser — `parseOpenUILang`, `isOpenUILang` |
| `src/lib/openui-library.ts` | 12-component library + `buildOpenUISystemPrompt()` |
| `src/components/app/OpenUIRenderer.tsx` | React renderer, light/dark aware, "✦ Generated UI" chip |
| `src/components/app/MarkdownMessage.tsx` | Routes `openui` fenced blocks to `OpenUIRenderer` |
| `src/components/app/ChatInterface.tsx` | Passes `experimentalGenerativeUI` flag in ask body |
| `src/app/api/app/conversations/ask/route.ts` | Injects system prompt when flag is set |
| `src/app/api/app/settings/route.ts` | PATCH/GET handle `experimentalGenerativeUI` |
| `src/app/app/settings/page.tsx` | Experimental section with toggle |
| `src/components/app/AppSettingsProvider.tsx` | Adds field to `AppSettings` type + hydration |
| `convex/schema.ts` + `convex/uiSettings.ts` | Optional `experimentalGenerativeUI` field |

## Test plan

- [ ] Go to Settings → Experimental, toggle "Generative UI" on
- [ ] Send a message asking for a dashboard, metrics summary, or table — Claude should emit a `\`\`\`openui` block
- [ ] Verify components render correctly in both light and dark themes
- [ ] Toggle off — subsequent responses should render as plain markdown
- [ ] Verify existing conversations unaffected when flag is off
- [ ] Verify settings persist across page refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)