### PR TITLE
perf: near-instant chat switching for previously loaded chats

### DIFF
--- a/src/components/app/ChatInterface.tsx
+++ b/src/components/app/ChatInterface.tsx
@@ -3232,8 +3232,15 @@ export default function ChatInterface({
     setActiveChatId(chatId)
     syncStandaloneChatUrl(chatId)
     const runtime = ensureConversationRuntime(chatId)
-    const existingChat = chats.find((chat) => chat._id === chatId)
     pendingTitleRef.current = null
+
+    // Fast path: runtime already loaded — switch instantly with no spinner or API calls.
+    if (runtime.hydrated) {
+      applyUiStateToView(runtime.ui)
+      return
+    }
+
+    const existingChat = chats.find((chat) => chat._id === chatId)
     setIsSwitchingChat(true)
     runtime.hydrated = false
     try {


### PR DESCRIPTION
## Summary

- Adds a fast path in `loadChat` (`ChatInterface.tsx`): when switching to a chat whose runtime is already hydrated (previously visited in the session), the UI state is applied immediately with no API calls and no loading spinner.
- First visit to a chat still follows the full load path (3 parallel fetches, spinner).
- Plans for word-level streaming and loading state redesign (pulsating logo, blinking cursor, `prefers-reduced-motion` support) are in `.context/` ready for the next implementation pass.

## Test plan
- Load 3–4 chats, then switch between them — second+ visits should be instant with zero network requests (verify in DevTools Network tab).
- First visit to a new chat should still show the header spinner and fetch messages normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)