### PR TITLE
feat: word-level streaming with settings toggle

### DIFF
--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Mail, Moon, PanelsLeftRight, Sun } from 'lucide-react'
+import { AlignLeft, Mail, Moon, PanelsLeftRight, Sun } from 'lucide-react'
 import { TopUpPreferenceControl } from '@/components/billing/TopUpPreferenceControl'
 import { useAppSettings } from '@/components/app/AppSettingsProvider'
+import { useWordLevelStreaming } from '@/lib/use-word-level-streaming'
 import { SettingsSectionSkeleton } from '@/components/ui/Skeleton'
 
 const SECTIONS = [
@@ -114,6 +115,7 @@ export default function SettingsPage() {
     isSaving,
     updateSettings,
   } = useAppSettings()
+  const [wordLevelStreaming, setWordLevelStreaming] = useWordLevelStreaming()
   const [billingSettings, setBillingSettings] = useState<BillingSettings | null>(null)
   const [billingBusy, setBillingBusy] = useState(false)
   const [topUpDraftCents, setTopUpDraftCents] = useState(800)
@@ -189,7 +191,7 @@ export default function SettingsPage() {
       <div className="min-h-0 flex-1 overflow-auto px-6 py-6">
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
           {isLoading ? (
-            <SettingsSectionSkeleton rows={section === 'general' ? 2 : 1} />
+            <SettingsSectionSkeleton rows={section === 'general' ? 3 : 1} />
           ) : null}
           {!isLoading && section === 'general' && (
             <>
@@ -208,6 +210,13 @@ export default function SettingsPage() {
                 checked={settings.useSecondarySidebar}
                 disabled={busy}
                 onChange={() => void updateSettings({ useSecondarySidebar: !settings.useSecondarySidebar })}
+              />
+              <SettingRow
+                icon={<AlignLeft size={18} strokeWidth={1.8} />}
+                title="Word-level streaming"
+                description="Show AI responses word-by-word as they arrive instead of waiting for each paragraph to complete."
+                checked={wordLevelStreaming}
+                onChange={() => setWordLevelStreaming(!wordLevelStreaming)}
               />
             </>
           )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -554,6 +554,52 @@ html {
   animation-delay: 0.4s;
 }
 
+/* Word-level streaming tail */
+.md-stream-tail {
+  animation: md-tail-fade 0.15s ease-out;
+}
+@keyframes md-tail-fade {
+  from { opacity: 0.6; }
+  to { opacity: 1; }
+}
+
+/* Blinking text cursor at end of stream tail */
+.md-stream-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: currentColor;
+  opacity: 0.5;
+  animation: cursor-blink 1s step-end infinite;
+  vertical-align: text-bottom;
+  margin-left: 1px;
+}
+@keyframes cursor-blink {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 0; }
+}
+
+/* Overlay logo pulse — inline loading state */
+.overlay-pulse {
+  animation: overlay-pulse 1.2s ease-in-out infinite;
+}
+@keyframes overlay-pulse {
+  0%, 100% { opacity: 0.25; }
+  50% { opacity: 0.7; }
+}
+
+/* Accessibility: no motion */
+@media (prefers-reduced-motion: reduce) {
+  .overlay-pulse {
+    animation: none;
+    opacity: 0.5;
+  }
+  .md-stream-cursor {
+    animation: none;
+    opacity: 0.5;
+  }
+}
+
 /* Message row appear animation */
 @keyframes messageAppear {
   from {

--- a/src/components/app/ChatInterface.tsx
+++ b/src/components/app/ChatInterface.tsx
@@ -55,6 +55,7 @@ import {
   type ChatTitleUpdatedDetail,
 } from '@/lib/chat-title'
 import { useAsyncSessions } from '@/lib/async-sessions-store'
+import { useWordLevelStreaming } from '@/lib/use-word-level-streaming'
 import { MarkdownMessage } from './MarkdownMessage'
 import { DelayedTooltip } from './DelayedTooltip'
 import { normalizeAgentAssistantText } from '@/lib/agent-assistant-text'
@@ -1435,6 +1436,7 @@ function ExchangeBlock({
                 isStreaming={isStreaming && isLastText}
                 sourceCitations={isLastText ? sourceCitations : undefined}
                 suppressTypingIndicator
+                wordLevelStreaming={wordLevelStreaming}
               />
             </div>
           )
@@ -2149,6 +2151,7 @@ export default function ChatInterface({
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const { settings } = useAppSettings()
+  const [wordLevelStreaming] = useWordLevelStreaming()
   const { startSession, completeSession, markRead, setActiveViewer, getUnread, sessions } = useAsyncSessions()
   const activeChatIdRef = useRef<string | null>(null)
   const loadChatRequestRef = useRef(0)

--- a/src/components/app/MarkdownMessage.tsx
+++ b/src/components/app/MarkdownMessage.tsx
@@ -298,6 +298,11 @@ interface Props {
    * Still renders completed paragraph blocks plus the in-flight tail so text streams without duplicate dots mid-message.
    */
   suppressTypingIndicator?: boolean
+  /**
+   * When true, render the in-flight stream tail as plain pre-wrap text with a blinking cursor instead of hiding it
+   * behind three dots. Defaults to false (paragraph-chunk mode).
+   */
+  wordLevelStreaming?: boolean
 }
 
 function splitStreamingMarkdown(text: string): { completedBlocks: string[]; streamTail: string } {
@@ -323,7 +328,13 @@ function splitStreamingMarkdown(text: string): { completedBlocks: string[]; stre
   return { completedBlocks, streamTail: text.slice(offset) }
 }
 
-export function MarkdownMessage({ text, isStreaming, sourceCitations, suppressTypingIndicator = false }: Props) {
+export function MarkdownMessage({
+  text,
+  isStreaming,
+  sourceCitations,
+  suppressTypingIndicator = false,
+  wordLevelStreaming = false,
+}: Props) {
   const hasCitationMap = !!(sourceCitations && Object.keys(sourceCitations).length > 0)
   const normalizedDisplay = useMemo(
     () =>
@@ -338,7 +349,9 @@ export function MarkdownMessage({ text, isStreaming, sourceCitations, suppressTy
     [normalizedDisplay],
   )
   const trailingBlock = !isStreaming && streamTail.trim() ? streamTail.trim() : ''
-  const showInlineTypingDots = isStreaming && !suppressTypingIndicator
+  // Show dots only when: streaming, not suppressed, and either paragraph mode OR no text yet in word mode
+  const showInlineTypingDots =
+    isStreaming && !suppressTypingIndicator && (!wordLevelStreaming || !normalizedDisplay.trim())
 
   if (!normalizedDisplay.trim() && !isStreaming) {
     return null
@@ -367,6 +380,13 @@ export function MarkdownMessage({ text, isStreaming, sourceCitations, suppressTy
           >
             {trailingBlock}
           </ReactMarkdown>
+        </div>
+      ) : null}
+
+      {isStreaming && wordLevelStreaming && streamTail ? (
+        <div className="md-stream-tail" style={{ whiteSpace: 'pre-wrap' }}>
+          {streamTail}
+          <span className="md-stream-cursor" aria-hidden />
         </div>
       ) : null}
 

--- a/src/lib/use-word-level-streaming.ts
+++ b/src/lib/use-word-level-streaming.ts
@@ -1,0 +1,24 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+const KEY = 'overlay:wordLevelStreaming'
+
+export function useWordLevelStreaming(): [boolean, (v: boolean) => void] {
+  const [value, setValue] = useState(true)
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(KEY)
+      if (stored !== null) setValue(stored !== 'false')
+    } catch {}
+  }, [])
+
+  function set(v: boolean) {
+    setValue(v)
+    try {
+      localStorage.setItem(KEY, String(v))
+    } catch {}
+  }
+
+  return [value, set]
+}


### PR DESCRIPTION
Replaces paragraph-chunk streaming (text hidden behind 3 dots until a `\n\n` boundary) with word-level streaming that renders the in-flight `streamTail` as plain `pre-wrap` text with a blinking cursor. A new `overlay:wordLevelStreaming` localStorage key (default `true`) controls the mode, toggled from Settings > General. The stream tail is rendered as plain text (no ReactMarkdown pipeline), eliminating any XSS surface on in-flight LLM output. Also adds `overlay-pulse`, `md-stream-cursor`, and `prefers-reduced-motion` CSS rules for the upcoming loading states redesign.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)