### PR TITLE
feat: image editing support in image generation mode

### DIFF
--- a/src/app/api/app/generate-image/route.ts
+++ b/src/app/api/app/generate-image/route.ts
@@ -98,12 +98,9 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // ── Build provider-specific options (image editing support) ─────────────
-    // Extract base64 from data URL if provided
-    const referenceBase64 = imageUrl?.startsWith('data:')
-      ? imageUrl.split(',')[1]
-      : undefined
-    const referenceUrl = imageUrl && !imageUrl.startsWith('data:') ? imageUrl : undefined
+    // ── Build reference image for editing (if provided) ──────────────────────
+    // Accept data URLs (base64) or plain https URLs
+    const referenceImage: string | undefined = imageUrl || undefined
 
     // ── Model selection: when user picks a model, use only that model ─────────
     // Fall back through all models only when no model is specified
@@ -119,29 +116,16 @@ export async function POST(request: NextRequest) {
       try {
         const imageModel = await getGatewayImageModel(tryModelId, auth.accessToken || undefined)
 
-        // Build providerOptions for image editing when a reference image is supplied
-        // Each provider has a different key — we try the most common patterns
-        const providerKey = tryModelId.split('/')[0] // e.g. 'openai', 'google', 'bfl'
-        const providerOptions = (referenceBase64 || referenceUrl)
-          ? {
-              [providerKey]: {
-                // OpenAI gpt-image: pass as input image for editing
-                ...(referenceBase64 ? { image: referenceBase64 } : {}),
-                ...(referenceUrl ? { imageUrl: referenceUrl } : {}),
-              },
-            }
-          : undefined
-
-        // Build a contextual prompt for follow-up requests
-        const finalPrompt = imageUrl
-          ? `Based on the previous image, ${prompt.trim()}`
+        // Use the AI SDK prompt-with-images format for image editing
+        // When no reference image is provided, pass a plain string prompt
+        const finalPrompt = referenceImage
+          ? { text: prompt.trim(), images: [referenceImage] }
           : prompt.trim()
 
         const result = await generateImage({
           model: imageModel,
           prompt: finalPrompt,
           aspectRatio: (aspectRatio as `${number}:${number}` | undefined) ?? '1:1',
-          providerOptions,
         })
         imageBase64 = result.image.base64
         usedModelId = tryModelId

--- a/src/components/app/ChatInterface.tsx
+++ b/src/components/app/ChatInterface.tsx
@@ -3695,6 +3695,7 @@ async function hydrateCompletedAskTurnFromServer(
     const activeChatTitleSnapshot = activeChatTitle
     const selectedImageModelsSnapshot = [...selectedImageModels]
     const selectedVideoModelsSnapshot = [...selectedVideoModels]
+    const attachedImagesSnapshot = [...attachedImages]
     if (isActiveLoading) return
 
     if (pendingChatDocuments.some((d) => d.status === 'uploading')) {
@@ -3717,6 +3718,7 @@ async function hydrateCompletedAskTurnFromServer(
       const targetRuntime = ensureConversationRuntime(chatId)
 
       setInput('')
+      setAttachedImages([])
       setGenerationChip(null)
       setReplyContext(null)
       const wasFirst = isFirstMessage
@@ -3750,10 +3752,15 @@ async function hydrateCompletedAskTurnFromServer(
         }
       })
 
+      const mediaUserMessageParts: { type: string; text?: string; url?: string; mediaType?: string }[] = []
+      if (text) mediaUserMessageParts.push({ type: 'text', text })
+      for (const img of attachedImagesSnapshot) {
+        mediaUserMessageParts.push({ type: 'file', url: img.dataUrl, mediaType: img.mimeType })
+      }
       const mediaUserMessage = {
         id: mediaTurnId,
         role: 'user',
-        parts: [{ type: 'text', text }],
+        parts: mediaUserMessageParts,
         ...(replyCtxSnapshot?.replyToTurnId
           ? {
               metadata: {
@@ -3791,7 +3798,8 @@ async function hydrateCompletedAskTurnFromServer(
       startSession(chatId, mediaSessionMode, activeChatTitleSnapshot ?? '', targetRuntime.askChats[0].messages.length)
 
       if (effectiveGenType === 'image') {
-        const imageUrl = targetRuntime.ui.lastGeneratedImageUrl
+        // Prefer an explicitly attached reference image; fall back to the last generated image
+        const imageUrl = attachedImagesSnapshot[0]?.dataUrl ?? targetRuntime.ui.lastGeneratedImageUrl
         const generationTasks = activeModels.map((modelId, mIdx) =>
           fetch('/api/app/generate-image', {
             method: 'POST',
@@ -4863,6 +4871,18 @@ async function hydrateCompletedAskTurnFromServer(
                       )}
                       <div className="flex justify-end">
                         <div className="chat-user-bubble min-w-0 max-w-[min(92%,36rem)] break-words select-text rounded-2xl rounded-br-sm border border-[var(--border)] bg-[var(--surface-subtle)] px-3 py-2.5 text-sm leading-relaxed text-[var(--foreground)] sm:max-w-[75%] sm:px-4">
+                          {getMessageImages(msg).length > 0 && (
+                            <div className="mb-2 flex flex-wrap gap-1.5">
+                              {getMessageImages(msg).map((imgUrl, imgIdx) => (
+                                <img
+                                  key={imgIdx}
+                                  src={imgUrl}
+                                  alt="Reference image"
+                                  className="max-h-36 rounded-lg object-cover"
+                                />
+                              ))}
+                            </div>
+                          )}
                           <span className="whitespace-pre-wrap">{promptText}</span>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- Attached images are now passed as reference to the `/api/app/generate-image` API using the AI SDK `prompt: { text, images: [...] }` format
- Falls back to `lastGeneratedImageUrl` when no image is explicitly attached (preserving existing continuity behaviour)
- Clears attached images from the composer after sending in image generation mode
- Shows the reference image thumbnail in the user message bubble in the chat

## Test plan
- [ ] Switch to Image generation mode, attach a photo, type an edit prompt (e.g. "remove the background"), verify the edited image is returned
- [ ] Verify the reference thumbnail appears in the sent user message
- [ ] Verify normal (no attachment) image generation still works
- [ ] Verify sequential editing still works (second prompt uses last generated image as reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)