### PR TITLE
Replace TopUpPreferenceControl with inline quick-pick + custom top-up UI and pricing presets

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          allowlist='NEXT_PUBLIC_(MIXPANEL_TOKEN|SENTRY_DSN|CONVEX_URL|APP_URL|MIXPANEL_API_HOST)'
+          allowlist='NEXT_PUBLIC_(SENTRY_DSN|CONVEX_URL|APP_URL)'
           matches="$(
             {
               git grep -nE 'NEXT_PUBLIC_[A-Z0-9_]*(SECRET|TOKEN|KEY|PASSWORD)' -- \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          allowlist='NEXT_PUBLIC_(SENTRY_DSN|CONVEX_URL|APP_URL)'
+          allowlist='NEXT_PUBLIC_(SENTRY_DSN|CONVEX_URL|APP_URL|POSTHOG_TOKEN|POSTHOG_HOST)'
           matches="$(
             {
               git grep -nE 'NEXT_PUBLIC_[A-Z0-9_]*(SECRET|TOKEN|KEY|PASSWORD)' -- \

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ plans/*
 
 src/remotion/*
 renders/*
+.env.local
+
+.cursor/*
+.claude/*
+.windsurf/*

--- a/convex/keys.ts
+++ b/convex/keys.ts
@@ -8,7 +8,6 @@ const PROVIDER_ENV_VARS: Record<string, string> = {
   minimax: 'MINIMAX_API_KEY',
   composio: 'COMPOSIO_API_KEY',
   ai_gateway: 'AI_GATEWAY_API_KEY',
-  mixpanel: 'MIXPANEL_TOKEN'
 }
 
 export const getAPIKey = action({

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,8 @@
         "next": "^15.5.15",
         "pdf-parse": "^1.1.1",
         "picomatch": "^2.3.2",
+        "posthog-js": "^1.369.0",
+        "posthog-node": "^5.29.2",
         "proxy-from-env": "^2.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -5457,6 +5459,18 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.25.2.tgz",
+      "integrity": "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==",
+      "license": "MIT"
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.369.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.0.tgz",
+      "integrity": "sha512-iFkLrg/+QRQHc8KSjO9parN6H3rftM2ld2sCJ/GeBRRO9MJYCdc6jXSFRgF7aGJPzb79syqksz+CrnBzdZnBKg==",
+      "license": "MIT"
+    },
     "node_modules/@prisma/instrumentation": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.4.2.tgz",
@@ -10011,6 +10025,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -12851,6 +12872,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -13133,6 +13165,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -14296,6 +14337,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -18812,6 +18859,196 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.369.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.0.tgz",
+      "integrity": "sha512-fOJzwpCb/TWxJBsUNKJ5PhHNl0+X7zRrVTuUrIH+EfsIfxJGSkOa0lWPJJGr3xzg810JHCUpuhn5sFBBxfHqIQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.25.2",
+        "@posthog/types": "1.369.0",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/posthog-node": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.29.2.tgz",
+      "integrity": "sha512-rI7kkF0XqDc0G1qjx+Hb4iuY9NAlL+XQNoGOpnEpRNTUcXvjY6WlsRGZ9m2whgc39emrrYdszi/YT8wZkr2xsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.25.2"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -19245,6 +19482,12 @@
       "dependencies": {
         "tweetnacl": "^1.0.3"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "lowlight": "^3.3.0",
         "lucide-react": "^0.575.0",
         "mammoth": "^1.12.0",
-        "mixpanel-browser": "^2.77.0",
         "next": "^15.5.15",
         "pdf-parse": "^1.1.1",
         "picomatch": "^2.3.2",
@@ -3160,62 +3159,6 @@
       "peerDependencies": {
         "mediabunny": "^1.0.0"
       }
-    },
-    "node_modules/@mixpanel/rrdom": {
-      "version": "2.0.0-alpha.18.4",
-      "resolved": "https://registry.npmjs.org/@mixpanel/rrdom/-/rrdom-2.0.0-alpha.18.4.tgz",
-      "integrity": "sha512-58sWLQDPRU0VQn8VzB1tx4ujih9X327Vr6xAzbJ4zge9GENm2L696T4TbWvrRGWPW6w99tHIHbv6SvcLhjjmcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18"
-      }
-    },
-    "node_modules/@mixpanel/rrweb": {
-      "version": "2.0.0-alpha.18.4",
-      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb/-/rrweb-2.0.0-alpha.18.4.tgz",
-      "integrity": "sha512-ICpEYDFEEiCoUuQg+de3VvQCsolF4lNHfEM9DBp5Pwuc7EgXqwWV4wUpiRF/NbhoKk+82X1Qe+oqqlKJb/CGFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mixpanel/rrdom": "^2.0.0-alpha.18",
-        "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18",
-        "@mixpanel/rrweb-types": "^2.0.0-alpha.18",
-        "@mixpanel/rrweb-utils": "^2.0.0-alpha.18",
-        "@types/css-font-loading-module": "0.0.7",
-        "@xstate/fsm": "^1.4.0",
-        "base64-arraybuffer": "^1.0.1",
-        "mitt": "^3.0.0"
-      }
-    },
-    "node_modules/@mixpanel/rrweb-plugin-console-record": {
-      "version": "2.0.0-alpha.18.4",
-      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-plugin-console-record/-/rrweb-plugin-console-record-2.0.0-alpha.18.4.tgz",
-      "integrity": "sha512-gGxEnNpfWurQht+fpSJbwPV60ug0LAENlk4Ux3XRmYooNJGPBO1TiQHcM7g0yhrKf4tfbTiKKZ4EXzFlOZs/pw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@mixpanel/rrweb": "^2.0.0-alpha.18",
-        "@mixpanel/rrweb-utils": "^2.0.0-alpha.18"
-      }
-    },
-    "node_modules/@mixpanel/rrweb-snapshot": {
-      "version": "2.0.0-alpha.18.4",
-      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.4.tgz",
-      "integrity": "sha512-ubLGwgPiMMi0rl7zJRh1uMScQ480lT95tkHkIAHkiZOemMY4JSkYZh2v9fpMNwJhaGwB5n/76KI7Cwy8F5qixQ==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^8.4.38"
-      }
-    },
-    "node_modules/@mixpanel/rrweb-types": {
-      "version": "2.0.0-alpha.18.4",
-      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-types/-/rrweb-types-2.0.0-alpha.18.4.tgz",
-      "integrity": "sha512-7kRuk7pK6Firrb26Mm235Po7s/z+9k0gUKZU/DZkzg5U1yQRcsu4byIrnWTiTQr+LFLUrIiyRKnpGK/QneAhTw==",
-      "license": "MIT"
-    },
-    "node_modules/@mixpanel/rrweb-utils": {
-      "version": "2.0.0-alpha.18.4",
-      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-utils/-/rrweb-utils-2.0.0-alpha.18.4.tgz",
-      "integrity": "sha512-c3nUbQl19kxHjf8nowFMeXlJw0ZqLesIVBb9t4g1nC4WtaNEPkFotWRdGt5V2cJNQ+aY38/v2uYb8Ren4IcdSQ==",
-      "license": "MIT"
     },
     "node_modules/@module-federation/error-codes": {
       "version": "0.22.0",
@@ -9864,12 +9807,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/css-font-loading-module": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -9937,12 +9874,6 @@
       "dependencies": {
         "@types/unist": "*"
       }
-    },
-    "node_modules/@types/json-logic-js": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/json-logic-js/-/json-logic-js-2.0.5.tgz",
-      "integrity": "sha512-hu/FTi0zwCjQEFfbPur275cNoZj6NsuOBhhYNzqoSdfmMhuxFr58OZ957lyIOWc9+kO+2tFlBthRjcxuytD4HA==",
-      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -11845,12 +11776,6 @@
         "node": ">=14.6"
       }
     },
-    "node_modules/@xstate/fsm": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
-      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
-      "license": "MIT"
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -12352,15 +12277,6 @@
         "bare-abort-controller": {
           "optional": true
         }
-      }
-    },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/base64-js": {
@@ -16192,12 +16108,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-logic-js": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.5.tgz",
-      "integrity": "sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==",
-      "license": "MIT"
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -17917,28 +17827,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT"
-    },
-    "node_modules/mixpanel-browser": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.77.0.tgz",
-      "integrity": "sha512-gU3J7osa+ZiX0gQ6UBjUw5YLfz4lb9B4X3yiXNxBQW+mVDkg9L+0VNWa+QnpWJi/ehAHuvl2nN1XTHp5NIL3HQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mixpanel/rrweb": "2.0.0-alpha.18.4",
-        "@mixpanel/rrweb-plugin-console-record": "2.0.0-alpha.18.4",
-        "@mixpanel/rrweb-utils": "2.0.0-alpha.18.4",
-        "@types/json-logic-js": "2.0.5",
-        "json-logic-js": "2.0.5"
-      },
-      "engines": {
-        "node": ">=20 <26"
-      }
-    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -18854,6 +18742,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "lowlight": "^3.3.0",
     "lucide-react": "^0.575.0",
     "mammoth": "^1.12.0",
-    "mixpanel-browser": "^2.77.0",
     "next": "^15.5.15",
     "pdf-parse": "^1.1.1",
     "picomatch": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     "next": "^15.5.15",
     "pdf-parse": "^1.1.1",
     "picomatch": "^2.3.2",
+    "posthog-js": "^1.369.0",
+    "posthog-node": "^5.29.2",
     "proxy-from-env": "^2.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/posthog-setup-report.md
+++ b/posthog-setup-report.md
@@ -1,0 +1,47 @@
+<wizard-report>
+# PostHog post-wizard report
+
+The wizard has completed a deep integration of your project. PostHog was already partially instrumented — this run extended the coverage with 11 new events across 7 files, added server-side user identification for returning logins, and wired up a PostHog dashboard with 5 insights.
+
+**What was already in place:**
+- Client-side PostHog init in `instrumentation-client.ts` using `NEXT_PUBLIC_POSTHOG_TOKEN` / `NEXT_PUBLIC_POSTHOG_HOST`
+- Server-side PostHog client in `src/lib/posthog-server.ts`
+- User `identify()` in `ObservabilityClient.tsx` (client-side, on session hydration)
+- Events: `user_signed_out`, `user_signed_up`, `auth_callback_success`, `voice_recording_started`, `voice_transcription_completed`, `voice_demo_interacted`, `automation_created`, `automation_deleted`, `automation_run_triggered`, `integration_disconnected`, `integration_connect_initiated`, `knowledge_file_created`, `chat_message_sent`, `$pageview`
+
+**New events added in this session:**
+
+| Event | Description | File |
+|---|---|---|
+| `auth_callback_error` | Fired when the auth callback receives an error or missing code | `src/app/auth/callback/page.tsx` |
+| `user_signed_in` | Server-side event for returning user sign-ins (complements `user_signed_up`) | `src/app/api/auth/sync-profile/route.ts` |
+| `integration_connect_completed` | Fired when a Composio OAuth callback succeeds | `src/app/auth/composio/callback/page.tsx` |
+| `integration_connect_failed` | Fired when a Composio OAuth callback fails | `src/app/auth/composio/callback/page.tsx` |
+| `automation_updated` | Fired when an existing automation is saved with edits | `src/components/app/AutomationsView.tsx` |
+| `automation_status_toggled` | Fired when an automation's status changes (active ↔ paused) | `src/components/app/AutomationsView.tsx` |
+| `knowledge_file_deleted` | Fired when a file or folder is deleted from the knowledge base | `src/components/app/KnowledgeView.tsx` |
+| `knowledge_folder_created` | Fired when a new folder is created in the knowledge base | `src/components/app/KnowledgeView.tsx` |
+| `voice_transcription_error` | Fired when a voice transcription request fails | `src/components/app/VoiceRecorder.tsx` |
+| `voice_saved_as_note` | Fired when a voice transcript is saved as a note | `src/components/app/VoiceRecorder.tsx` |
+| `chat_new_chat_created` | Fired when a new chat session is created | `src/components/app/ChatInterface.tsx` |
+
+**Other changes:**
+- `src/app/api/auth/sync-profile/route.ts`: `posthog.identify()` is now called for both new and returning users (was previously only called for new users).
+- `.env.local`: Confirmed `NEXT_PUBLIC_POSTHOG_TOKEN` and `NEXT_PUBLIC_POSTHOG_HOST` are set to the correct values.
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+- **Dashboard — Analytics basics**: https://us.posthog.com/project/384169/dashboard/1477005
+- **Auth Funnel** (auth callback → signup / signin): https://us.posthog.com/project/384169/insights/8pmv5EHO
+- **Integration Connection Funnel** (initiated → completed): https://us.posthog.com/project/384169/insights/j7mtdM9o
+- **Chat & Automation Activity** (trend): https://us.posthog.com/project/384169/insights/mWPaSf7Z
+- **Voice Feature Usage** (trend): https://us.posthog.com/project/384169/insights/24jQgbrn
+- **Knowledge Base Activity** (trend): https://us.posthog.com/project/384169/insights/C31tStuw
+
+### Agent skill
+
+We've left an agent skill folder in your project at `.claude/skills/integration-nextjs-app-router/`. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
+
+</wizard-report>

--- a/scripts/smoke-vault.ts
+++ b/scripts/smoke-vault.ts
@@ -23,7 +23,6 @@ const EXPECTED_VAULT_NAMES = [
   'OPENROUTER_API_KEY',
   'COMPOSIO_API_KEY',
   'AI_GATEWAY_API_KEY',
-  'MIXPANEL_TOKEN',
   'MINIMAX_API_KEY',
 ]
 
@@ -79,8 +78,6 @@ async function main() {
   for (const vaultName of EXPECTED_VAULT_NAMES) {
     if (names.has(vaultName)) {
       logOk(`${vaultName}: present`)
-    } else if (vaultName === 'MIXPANEL_TOKEN') {
-      console.warn(`[VaultSmoke] ⚠ ${vaultName}: missing — add it in the WorkOS Vault dashboard`)
     } else {
       logErr(`${vaultName}: NOT found — add it in the WorkOS Vault dashboard`)
       allFound = false

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, Suspense, useCallback } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { RefreshCw, ArrowRight, Check, AlertCircle } from 'lucide-react'
-import { TopUpPreferenceControl } from '@/components/billing/TopUpPreferenceControl'
 import { useAuth } from '@/contexts/AuthContext'
 import { LandingThemeProvider, useLandingTheme } from '@/contexts/LandingThemeContext'
 import { PageNavbar } from '@/components/PageNavbar'
@@ -153,6 +152,7 @@ function ProgressBar({
 }
 
 function AccountPageContent() {
+  const topUpQuickPicks = [800, 2_400, 9_400] as const
   const { isLandingDark } = useLandingTheme()
   const panel = marketingPanel(isLandingDark)
   const panelLg = marketingPanelLg(isLandingDark)
@@ -181,6 +181,7 @@ function AccountPageContent() {
   const [billingSettings, setBillingSettings] = useState<BillingSettings | null>(null)
   const [topUpHistory, setTopUpHistory] = useState<TopUpHistoryItem[]>([])
   const [topUpAmountDraftCents, setTopUpAmountDraftCents] = useState(800)
+  const [topUpAmountMode, setTopUpAmountMode] = useState<'8' | '24' | '94' | 'custom'>('8')
   const [autoTopUpEnabledDraft, setAutoTopUpEnabledDraft] = useState(false)
 
   // Get userId from AuthContext (session-based)
@@ -237,7 +238,13 @@ function AccountPageContent() {
     if (settingsResponse.ok) {
       const settingsData = await settingsResponse.json()
       setBillingSettings(settingsData)
-      setTopUpAmountDraftCents(settingsData.topUpAmountCents ?? settingsData.autoTopUpAmountCents ?? settingsData.topUpMinAmountCents ?? 800)
+      const resolvedTopUpAmountCents =
+        settingsData.topUpAmountCents ?? settingsData.autoTopUpAmountCents ?? settingsData.topUpMinAmountCents ?? 800
+      setTopUpAmountDraftCents(resolvedTopUpAmountCents)
+      if (resolvedTopUpAmountCents === 800) setTopUpAmountMode('8')
+      else if (resolvedTopUpAmountCents === 2_400) setTopUpAmountMode('24')
+      else if (resolvedTopUpAmountCents === 9_400) setTopUpAmountMode('94')
+      else setTopUpAmountMode('custom')
       setAutoTopUpEnabledDraft(Boolean(settingsData.autoTopUpEnabled))
     }
 
@@ -409,7 +416,13 @@ function AccountPageContent() {
         if (settingsResponse.ok) {
           const settingsData = await settingsResponse.json()
           setBillingSettings(settingsData)
-          setTopUpAmountDraftCents(settingsData.topUpAmountCents ?? settingsData.autoTopUpAmountCents ?? settingsData.topUpMinAmountCents ?? 800)
+          const resolvedTopUpAmountCents =
+            settingsData.topUpAmountCents ?? settingsData.autoTopUpAmountCents ?? settingsData.topUpMinAmountCents ?? 800
+          setTopUpAmountDraftCents(resolvedTopUpAmountCents)
+          if (resolvedTopUpAmountCents === 800) setTopUpAmountMode('8')
+          else if (resolvedTopUpAmountCents === 2_400) setTopUpAmountMode('24')
+          else if (resolvedTopUpAmountCents === 9_400) setTopUpAmountMode('94')
+          else setTopUpAmountMode('custom')
           setAutoTopUpEnabledDraft(Boolean(settingsData.autoTopUpEnabled))
         }
 
@@ -825,57 +838,141 @@ function AccountPageContent() {
                     <div className={panel}>
                       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
                         <div>
-                          <h2 className={`text-lg font-medium ${t.h}`}>Top-ups and billing controls</h2>
+                          <h2 className={`text-lg font-medium ${t.h}`}>Extra usage + auto recharge</h2>
                           <p className={`mt-1 text-sm ${t.muted}`}>
-                            Use one top-up amount everywhere. Add it once now, or save it for future automatic recharges.
+                            Purchase extra usage instantly, and optionally keep auto recharge on so the same amount refills when your budget reaches $0.
                           </p>
                         </div>
                       </div>
 
-                      <div className="mt-5">
-                        <TopUpPreferenceControl
-                          variant="marketing"
-                          isDark={isLandingDark}
-                          title="Top-up amount"
-                          description="The same amount is used for manual top-ups and, if enabled, future automatic recharges."
-                          amountCents={topUpAmountDraftCents}
-                          minAmountCents={billingSettings?.topUpMinAmountCents ?? 800}
-                          maxAmountCents={billingSettings?.topUpMaxAmountCents ?? 20_000}
-                          stepAmountCents={billingSettings?.topUpStepAmountCents ?? 100}
-                          onAmountChange={setTopUpAmountDraftCents}
-                          autoTopUpEnabled={autoTopUpEnabledDraft}
-                          onAutoTopUpEnabledChange={setAutoTopUpEnabledDraft}
-                          checkboxDescription="If enabled, this same amount will recharge automatically whenever your cumulative budget reaches zero."
-                          note="Saving or checking the box authorizes off-session recharges for the selected amount."
-                          footer={
-                            <>
+                      <div className={`mt-5 rounded-2xl border p-5 ${isLandingDark ? 'border-zinc-700 bg-zinc-950/60' : 'border-zinc-200 bg-zinc-50/80'}`}>
+                        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                          <div>
+                            <h3 className={`text-base font-medium ${t.h}`}>Purchase extra usage</h3>
+                            <p className={`mt-1 text-sm ${t.muted}`}>Use one amount for manual purchases and optional auto recharge.</p>
+                          </div>
+                          <div className="text-left md:text-right">
+                            <p className={`text-xs uppercase tracking-[0.18em] ${t.muted}`}>Selected amount</p>
+                            <p className={`mt-1 text-2xl font-medium ${t.h}`}>${(topUpAmountDraftCents / 100).toFixed(0)}</p>
+                          </div>
+                        </div>
+
+                        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                          {topUpQuickPicks.map((amountCents) => {
+                            const isSelected = topUpAmountDraftCents === amountCents && topUpAmountMode !== 'custom'
+                            return (
                               <button
+                                key={amountCents}
                                 type="button"
-                                onClick={() => void handleStartTopUp(topUpAmountDraftCents, autoTopUpEnabledDraft)}
-                                disabled={actionLoading === `topup-${topUpAmountDraftCents}`}
-                                className={`rounded-lg border px-4 py-2 text-sm font-medium transition-all disabled:opacity-50 ${
-                                  isLandingDark
-                                    ? 'border-zinc-600 bg-zinc-800 text-zinc-100 hover:bg-zinc-700'
-                                    : 'border-zinc-200 bg-white text-zinc-900 hover:bg-zinc-50'
+                                onClick={() => {
+                                  setTopUpAmountDraftCents(amountCents)
+                                  if (amountCents === 800) setTopUpAmountMode('8')
+                                  else if (amountCents === 2_400) setTopUpAmountMode('24')
+                                  else setTopUpAmountMode('94')
+                                }}
+                                className={`rounded-xl border px-4 py-3 text-left transition-all ${
+                                  isSelected
+                                    ? isLandingDark
+                                      ? 'border-zinc-100 bg-zinc-900 text-zinc-100'
+                                      : 'border-zinc-900 bg-zinc-900 text-white'
+                                    : isLandingDark
+                                      ? 'border-zinc-700 bg-zinc-950 text-zinc-200 hover:bg-zinc-900'
+                                      : 'border-zinc-200 bg-white text-zinc-900 hover:bg-zinc-50'
                                 }`}
                               >
-                                {actionLoading === `topup-${topUpAmountDraftCents}` ? 'Opening…' : `Add $${(topUpAmountDraftCents / 100).toFixed(0)} top-up`}
+                                <p className="text-xl font-medium">${(amountCents / 100).toFixed(0)}</p>
                               </button>
-                              <button
-                                type="button"
-                                onClick={() => void handleTopUpPreferenceSave()}
-                                disabled={actionLoading === 'topup-settings'}
-                                className={`rounded-lg px-4 py-2 text-sm font-medium transition-all disabled:opacity-50 ${
-                                  isLandingDark
+                            )
+                          })}
+                          <button
+                            type="button"
+                            onClick={() => setTopUpAmountMode('custom')}
+                            className={`rounded-xl border px-4 py-3 text-left transition-all ${
+                              topUpAmountMode === 'custom'
+                                ? isLandingDark
+                                  ? 'border-zinc-100 bg-zinc-900 text-zinc-100'
+                                  : 'border-zinc-900 bg-zinc-900 text-white'
+                                : isLandingDark
+                                  ? 'border-zinc-700 bg-zinc-950 text-zinc-200 hover:bg-zinc-900'
+                                  : 'border-zinc-200 bg-white text-zinc-900 hover:bg-zinc-50'
+                            }`}
+                          >
+                            <p className="text-xl font-medium">Custom</p>
+                          </button>
+                        </div>
+
+                        {topUpAmountMode === 'custom' ? (
+                          <div className="mt-5">
+                            <div className="flex items-center justify-between text-sm">
+                              <span className={t.muted}>Custom amount</span>
+                              <span className={t.h}>${(topUpAmountDraftCents / 100).toFixed(0)}</span>
+                            </div>
+                            <input
+                              type="range"
+                              min={(billingSettings?.topUpMinAmountCents ?? 800) / 100}
+                              max={(billingSettings?.topUpMaxAmountCents ?? 20_000) / 100}
+                              step={(billingSettings?.topUpStepAmountCents ?? 100) / 100}
+                              value={topUpAmountDraftCents / 100}
+                              onChange={(event) => setTopUpAmountDraftCents(Math.round(Number(event.target.value) * 100))}
+                              className={`mt-3 h-2 w-full cursor-pointer appearance-none rounded-full ${isLandingDark ? 'bg-zinc-800 accent-zinc-100' : 'bg-zinc-200 accent-zinc-900'}`}
+                            />
+                          </div>
+                        ) : null}
+
+                        <div className={`mt-5 rounded-xl border px-4 py-4 ${isLandingDark ? 'border-zinc-700 bg-zinc-900/60' : 'border-zinc-200 bg-white'}`}>
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                              <p className={`text-base font-medium ${t.h}`}>
+                                Auto recharge is {autoTopUpEnabledDraft ? 'on' : 'off'}
+                              </p>
+                              <p className={`mt-1 text-sm ${t.muted}`}>
+                                When enabled, Overlay recharges ${(topUpAmountDraftCents / 100).toFixed(0)} automatically whenever your budget reaches $0.
+                              </p>
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => setAutoTopUpEnabledDraft((value) => !value)}
+                              className={`rounded-lg px-4 py-2 text-sm font-medium transition-all ${
+                                autoTopUpEnabledDraft
+                                  ? isLandingDark
                                     ? 'bg-zinc-100 text-zinc-900 hover:bg-white'
                                     : 'bg-zinc-900 text-white hover:bg-zinc-800'
-                                }`}
-                              >
-                                {actionLoading === 'topup-settings' ? 'Saving...' : 'Save top-up preference'}
-                              </button>
-                            </>
-                          }
-                        />
+                                  : isLandingDark
+                                    ? 'border border-zinc-600 bg-zinc-900 text-zinc-100 hover:bg-zinc-800'
+                                    : 'border border-zinc-200 bg-white text-zinc-900 hover:bg-zinc-50'
+                              }`}
+                            >
+                              {autoTopUpEnabledDraft ? 'Disable' : 'Enable'}
+                            </button>
+                          </div>
+                        </div>
+
+                        <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+                          <button
+                            type="button"
+                            onClick={() => void handleStartTopUp(topUpAmountDraftCents, autoTopUpEnabledDraft)}
+                            disabled={actionLoading === `topup-${topUpAmountDraftCents}`}
+                            className={`rounded-lg border px-4 py-2 text-sm font-medium transition-all disabled:opacity-50 ${
+                              isLandingDark
+                                ? 'border-zinc-600 bg-zinc-800 text-zinc-100 hover:bg-zinc-700'
+                                : 'border-zinc-200 bg-white text-zinc-900 hover:bg-zinc-50'
+                            }`}
+                          >
+                            {actionLoading === `topup-${topUpAmountDraftCents}` ? 'Opening…' : `Purchase $${(topUpAmountDraftCents / 100).toFixed(0)} usage`}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => void handleTopUpPreferenceSave()}
+                            disabled={actionLoading === 'topup-settings'}
+                            className={`rounded-lg px-4 py-2 text-sm font-medium transition-all disabled:opacity-50 ${
+                              isLandingDark
+                                ? 'bg-zinc-100 text-zinc-900 hover:bg-white'
+                                : 'bg-zinc-900 text-white hover:bg-zinc-800'
+                            }`}
+                          >
+                            {actionLoading === 'topup-settings' ? 'Saving...' : 'Save auto recharge'}
+                          </button>
+                        </div>
                       </div>
 
                       <div className="mt-6">

--- a/src/app/api/auth/sync-profile/route.ts
+++ b/src/app/api/auth/sync-profile/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { convex } from '@/lib/convex'
 import { getInternalApiSecret } from '@/lib/internal-api-secret'
 import { getSession } from '@/lib/workos-auth'
+import { getPostHogClient } from '@/lib/posthog-server'
 
 export async function POST() {
   try {
@@ -28,6 +29,37 @@ export async function POST() {
         { error: 'Failed to sync profile' },
         { status: 502 }
       )
+    }
+
+    const posthog = getPostHogClient()
+    if (posthog) {
+      if (result.isNewUser) {
+        posthog.capture({
+          distinctId: session.user.id,
+          event: 'user_signed_up',
+          properties: {
+            email: session.user.email,
+            first_name: session.user.firstName,
+            last_name: session.user.lastName,
+          },
+        })
+      } else {
+        posthog.capture({
+          distinctId: session.user.id,
+          event: 'user_signed_in',
+          properties: {
+            email: session.user.email,
+          },
+        })
+      }
+      posthog.identify({
+        distinctId: session.user.id,
+        properties: {
+          email: session.user.email,
+          first_name: session.user.firstName,
+          last_name: session.user.lastName,
+        },
+      })
     }
 
     return NextResponse.json({

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import Link from "next/link";
+import posthog from "posthog-js";
 
 // Always use overlay:// for deep links (registered in WorkOS for both environments)
 const APP_PROTOCOL = 'overlay';
@@ -31,18 +32,24 @@ function AuthCallbackContent() {
 
   useEffect(() => {
     if (code && !error) {
+      posthog.capture('auth_callback_success');
       // Redirect to the Electron app via deep link (electron:// in dev, overlay:// in prod)
       const deepLink = `${APP_PROTOCOL}://auth/callback?code=${encodeURIComponent(code)}`;
       window.location.href = deepLink;
-      
+
       // Show success message after a short delay
       const timer = setTimeout(() => {
         setHasRedirected(true);
       }, 1000);
-      
+
       return () => clearTimeout(timer);
+    } else if (error || !code) {
+      posthog.capture('auth_callback_error', {
+        error: error ?? 'missing_code',
+        error_description: errorDescription ?? undefined,
+      });
     }
-  }, [code, error]);
+  }, [code, error, errorDescription]);
 
   return (
     <div className="min-h-screen bg-[#0a0a0a] text-[#fafafa] flex items-center justify-center px-6">

--- a/src/app/auth/composio/callback/page.tsx
+++ b/src/app/auth/composio/callback/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { notifyOpenerIntegrationsChanged } from '@/lib/integrations-events'
+import posthog from 'posthog-js'
 
 function CallbackContent() {
   const searchParams = useSearchParams()
@@ -13,19 +14,25 @@ function CallbackContent() {
   const isSuccess = status === 'success' && !error
 
   useEffect(() => {
-    if (!isSuccess) return
-    notifyOpenerIntegrationsChanged()
-    const interval = setInterval(() => {
-      setCountdown((n) => {
-        if (n <= 1) {
-          clearInterval(interval)
-          window.close()
-        }
-        return n - 1
+    if (isSuccess) {
+      posthog.capture('integration_connect_completed')
+      notifyOpenerIntegrationsChanged()
+      const interval = setInterval(() => {
+        setCountdown((n) => {
+          if (n <= 1) {
+            clearInterval(interval)
+            window.close()
+          }
+          return n - 1
+        })
+      }, 1000)
+      return () => clearInterval(interval)
+    } else {
+      posthog.capture('integration_connect_failed', {
+        error: error ?? 'unknown',
       })
-    }, 1000)
-    return () => clearInterval(interval)
-  }, [isSuccess])
+    }
+  }, [isSuccess, error])
 
   return (
     <div className="flex h-screen flex-col items-center justify-center bg-white">

--- a/src/app/auth/mobile-complete/page.tsx
+++ b/src/app/auth/mobile-complete/page.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import {
+  clearStoredMobilePkceChallenge,
+  getStoredMobilePkceChallenge,
+} from '@/lib/mobile-auth-client'
 
 export default function MobileCompletePage() {
   const [status, setStatus] = useState<'loading' | 'error'>('loading')
@@ -12,9 +16,17 @@ export default function MobileCompletePage() {
 
     async function transferSession() {
       try {
+        const codeChallenge = getStoredMobilePkceChallenge()
+        if (!codeChallenge) {
+          throw new Error(
+            'Missing mobile auth handshake. Open Overlay on your phone and start sign-in from the app.',
+          )
+        }
+
         const response = await fetch('/api/auth/desktop-link', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ codeChallenge }),
         })
 
         const data = await response.json().catch(() => ({}))
@@ -22,6 +34,8 @@ export default function MobileCompletePage() {
         if (!response.ok || typeof data.deepLink !== 'string') {
           throw new Error(data.error || 'Failed to hand off session to the app')
         }
+
+        clearStoredMobilePkceChallenge()
 
         if (!cancelled) {
           window.location.replace(data.deepLink)

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -7,6 +7,10 @@ import { PageNavbar } from "@/components/PageNavbar";
 import { LandingThemeProvider, useLandingTheme } from "@/contexts/LandingThemeContext";
 import { sanitizeClientAuthRedirect } from "@/lib/auth-redirect";
 import {
+  persistMobilePkceChallengeFromUrl,
+  resolveCodeChallengeForSso,
+} from "@/lib/mobile-auth-client";
+import {
   marketingAuthCard,
   marketingAuthMuted,
   marketingDividerLabel,
@@ -37,6 +41,10 @@ function SignInContent() {
     if (errorParam) {
       setError(decodeURIComponent(errorParam));
     }
+  }, [searchParams]);
+
+  useEffect(() => {
+    persistMobilePkceChallengeFromUrl(searchParams);
   }, [searchParams]);
 
   useEffect(() => {
@@ -97,7 +105,11 @@ function SignInContent() {
   const handleSSO = (provider: "google" | "apple" | "microsoft") => {
     setSsoLoading(provider);
     const forceParam = isDesktopAuth || forceLogin ? "&force=true" : "";
-    const ssoUrl = `/api/auth/sso/${provider}?redirect=${encodeURIComponent(redirectUrl)}${forceParam}`;
+    const codeChallenge = resolveCodeChallengeForSso(searchParams);
+    const pkceParam = codeChallenge
+      ? `&codeChallenge=${encodeURIComponent(codeChallenge)}`
+      : "";
+    const ssoUrl = `/api/auth/sso/${provider}?redirect=${encodeURIComponent(redirectUrl)}${forceParam}${pkceParam}`;
     window.location.href = ssoUrl;
   };
 

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -1,11 +1,15 @@
 'use client'
 
-import { useState, Suspense } from 'react'
+import { useState, Suspense, useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { PageNavbar } from '@/components/PageNavbar'
 import { LandingThemeProvider, useLandingTheme } from '@/contexts/LandingThemeContext'
 import { sanitizeClientAuthRedirect } from '@/lib/auth-redirect'
+import {
+  persistMobilePkceChallengeFromUrl,
+  resolveCodeChallengeForSso,
+} from '@/lib/mobile-auth-client'
 import {
   marketingAuthCard,
   marketingAuthMuted,
@@ -43,6 +47,10 @@ function SignUpContent() {
 
   // Get redirect URL from params (for desktop app auth)
   const redirectUrl = sanitizeClientAuthRedirect(searchParams?.get('redirect'))
+
+  useEffect(() => {
+    persistMobilePkceChallengeFromUrl(searchParams)
+  }, [searchParams])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -149,7 +157,11 @@ function SignUpContent() {
 
   const handleSSO = (provider: 'google' | 'apple' | 'microsoft') => {
     setSsoLoading(provider)
-    const ssoUrl = `/api/auth/sso/${provider}?redirect=${encodeURIComponent(redirectUrl)}`
+    const codeChallenge = resolveCodeChallengeForSso(searchParams)
+    const pkceParam = codeChallenge
+      ? `&codeChallenge=${encodeURIComponent(codeChallenge)}`
+      : ''
+    const ssoUrl = `/api/auth/sso/${provider}?redirect=${encodeURIComponent(redirectUrl)}${pkceParam}`
     window.location.href = ssoUrl
   }
 

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import { useScroll, useTransform } from "framer-motion";
+import { motion, useScroll, useTransform } from "framer-motion";
+import { Globe } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
+import { AllInOnePlace } from "@/components/AllInOnePlace";
 import { Navbar } from "@/components/Navbar";
-import { AgentsPipeline } from "@/components/landing/AgentsPipeline";
-import { ClosingCTA } from "@/components/landing/ClosingCTA";
-import { ContextHub } from "@/components/landing/ContextHub";
-import { CreationBento } from "@/components/landing/CreationBento";
-import { ExtensionsStrip } from "@/components/landing/ExtensionsStrip";
-import { HeroSection } from "@/components/landing/HeroSection";
-import { ModelsShowcase } from "@/components/landing/ModelsShowcase";
 import { LANDING_THEME_STORAGE_KEY } from "@/lib/landingThemeConstants";
 
 export default function HomeLandingPage() {
@@ -22,6 +19,7 @@ export default function HomeLandingPage() {
     try {
       const t = window.localStorage.getItem(LANDING_THEME_STORAGE_KEY);
       if (t === "dark" || t === "light") {
+        // Hydration: default light on server; sync stored preference after mount.
         // eslint-disable-next-line react-hooks/set-state-in-effect -- external persisted theme
         setLandingTheme(t);
       }
@@ -49,25 +47,48 @@ export default function HomeLandingPage() {
       try {
         const response = await fetch("/api/auth/session");
         const contentType = response.headers.get("content-type") || "";
-        if (!response.ok || !contentType.includes("application/json")) return;
+
+        if (!response.ok || !contentType.includes("application/json")) {
+          return;
+        }
+
         const data = await response.json();
-        if (!cancelled) setIsAuthenticated(Boolean(data?.authenticated));
+        if (!cancelled) {
+          setIsAuthenticated(Boolean(data?.authenticated));
+        }
       } catch {
         /* ignore */
       }
     }
 
     checkAuth();
-    return () => { cancelled = true; };
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const navLogoOpacity = useTransform(scrollYProgress, [0, 0.08], [0, 1]);
   const navLogoX = useTransform(scrollYProgress, [0, 0.08], [-12, 0]);
 
   const webAppHref = isAuthenticated ? "/app/chat" : "/auth/sign-in?redirect=%2Fapp%2Fchat";
-  const isDark = landingTheme === "dark";
 
-  const dividerClass = isDark ? "border-zinc-800" : "border-zinc-100";
+  const isDark = landingTheme === "dark";
+  const muted = isDark ? "text-zinc-400" : "text-[#71717a]";
+  const heading = isDark ? "text-zinc-100" : "text-[#0a0a0a]";
+  const ctaClass = isDark
+    ? "inline-flex min-w-[184px] items-center justify-center gap-3 rounded-full border border-zinc-600 bg-zinc-900 px-6 py-3 text-sm font-medium text-zinc-100 transition-all duration-300 hover:bg-zinc-800"
+    : "inline-flex min-w-[184px] items-center justify-center gap-3 rounded-full border border-[#d4d4d8] bg-white px-6 py-3 text-sm font-medium text-[#0a0a0a] transition-all duration-300 hover:bg-[#f4f4f5]";
+  const ctaDarkClass = isDark
+    ? "group inline-flex items-center gap-3 rounded-full bg-zinc-100 px-8 py-4 text-sm font-medium text-zinc-900 transition-all duration-300 hover:bg-white"
+    : "group inline-flex items-center gap-3 rounded-full bg-[#0a0a0a] px-8 py-4 text-sm font-medium text-white transition-all duration-300 hover:bg-[#27272a]";
+
+  const sectionInView = {
+    initial: { opacity: 0, y: 28 },
+    whileInView: { opacity: 1, y: 0 },
+    viewport: { once: true, amount: 0.35 },
+    transition: { duration: 0.55, ease: [0.22, 1, 0.36, 1] as [number, number, number, number] },
+  };
 
   return (
     <div
@@ -79,7 +100,6 @@ export default function HomeLandingPage() {
       }
     >
       <div className="liquid-glass" />
-
       <Navbar
         scrollYProgress={scrollYProgress}
         landingTheme={landingTheme}
@@ -88,25 +108,189 @@ export default function HomeLandingPage() {
         navLogoX={navLogoX}
       />
 
-      <HeroSection theme={landingTheme} webAppHref={webAppHref} />
+      {/* Hero */}
+      <section className="relative z-10 flex min-h-screen flex-col items-center justify-center px-6 pb-24 pt-32">
+        <motion.div {...sectionInView} className="flex flex-col items-center text-center">
+          <div className="-mb-5">
+            <Image
+              src="/assets/overlay-logo.png"
+              alt="Overlay"
+              width={180}
+              height={180}
+              className="drop-shadow-2xl"
+              priority
+            />
+          </div>
+          <h1 className="mb-3 font-serif text-6xl tracking-tight md:text-8xl">overlay</h1>
+          <p className={`mb-8 text-lg font-light tracking-wide md:text-xl ${muted}`}>
+            your personal, unified ai interaction layer
+          </p>
+          <Link href={webAppHref} className={ctaClass}>
+            <Globe className="h-4 w-4" />
+            open app
+          </Link>
+        </motion.div>
+      </section>
 
-      <div className={`mx-auto max-w-4xl border-t ${dividerClass}`} />
-      <ModelsShowcase theme={landingTheme} />
+      {/* Combo headline */}
+      <motion.section
+        {...sectionInView}
+        className="relative z-10 flex min-h-[85vh] flex-col items-center justify-center px-6 py-20"
+      >
+        <div className="flex max-w-4xl flex-col items-center gap-4 text-center">
+          <p className={`font-serif text-4xl leading-tight md:text-5xl lg:text-6xl ${heading}`}>
+            everything you need from AI
+          </p>
+          <p className={`min-h-[1.35em] pb-[0.12em] font-serif text-3xl leading-[1.15] whitespace-normal md:text-4xl lg:text-5xl ${heading}`}>
+            <span className="inline-block">notes</span>
+            <span className={`mx-1 inline-block ${muted}`}>+</span>
+            <span className="inline-block">chats</span>
+            <span className={`mx-1 inline-block ${muted}`}>+</span>
+            <span className="inline-block">browser</span>
+            <span className={`mx-1 inline-block ${muted}`}>+</span>
+            <span className="inline-block">agents</span>
+          </p>
+        </div>
+      </motion.section>
 
-      <div className={`mx-auto max-w-4xl border-t ${dividerClass}`} />
-      <CreationBento theme={landingTheme} />
+      {/* All in one */}
+      <section className="relative z-10 flex min-h-[90vh] items-center justify-center px-6 py-20">
+        <AllInOnePlace theme={landingTheme} />
+      </section>
 
-      <div className={`mx-auto max-w-4xl border-t ${dividerClass}`} />
-      <AgentsPipeline theme={landingTheme} />
+      <motion.section
+        {...sectionInView}
+        className="relative z-10 flex min-h-[75vh] flex-col items-center justify-center px-6 py-20 text-center"
+      >
+        <div className="mx-auto w-full max-w-3xl">
+          <h3 className="mb-4 font-serif text-5xl md:text-6xl lg:text-7xl">notes</h3>
+          <p className={`text-lg md:text-xl ${muted}`}>
+            capture ideas instantly without leaving your current task
+          </p>
+        </div>
+      </motion.section>
 
-      <div className={`mx-auto max-w-4xl border-t ${dividerClass}`} />
-      <ContextHub theme={landingTheme} />
+      <motion.section
+        {...sectionInView}
+        className="relative z-10 flex min-h-[75vh] flex-col items-center justify-center px-6 py-20 text-center"
+      >
+        <div className="mx-auto w-full max-w-4xl">
+          <h3 className="mb-4 font-serif text-5xl md:text-6xl lg:text-7xl">chats</h3>
+          <p className={`text-lg md:text-xl ${muted}`}>
+            get ai help anywhere, no app switching needed
+          </p>
+        </div>
+      </motion.section>
 
-      <div className={`mx-auto max-w-4xl border-t ${dividerClass}`} />
-      <ExtensionsStrip theme={landingTheme} />
+      <motion.section
+        {...sectionInView}
+        className="relative z-10 flex min-h-[75vh] flex-col items-center justify-center px-6 py-20 text-center"
+      >
+        <div className="mx-auto w-full max-w-4xl">
+          <h3 className="mb-4 font-serif text-5xl md:text-6xl lg:text-7xl">browser</h3>
+          <p className={`text-lg md:text-xl ${muted}`}>
+            quick search without disrupting your workflow
+          </p>
+        </div>
+      </motion.section>
 
-      <div className={`mx-auto max-w-4xl border-t ${dividerClass}`} />
-      <ClosingCTA theme={landingTheme} webAppHref={webAppHref} />
+      <motion.section
+        {...sectionInView}
+        className="relative z-10 flex min-h-[70vh] flex-col items-center justify-center px-6 py-20 text-center"
+      >
+        <div className="mx-auto max-w-3xl">
+          <h3 className="mb-4 font-serif text-5xl md:text-6xl lg:text-7xl">agents</h3>
+          <p className={`text-lg md:text-xl ${muted}`}>let ai work for you</p>
+        </div>
+      </motion.section>
+
+      <motion.section
+        {...sectionInView}
+        className="relative z-10 flex min-h-[75vh] flex-col items-center justify-center px-6 py-20 text-center"
+      >
+        <p className={`max-w-3xl font-serif text-4xl leading-tight md:text-5xl lg:text-6xl ${heading}`}>
+          reduce <span className={muted}>the friction in</span> your work
+        </p>
+      </motion.section>
+
+      <motion.section
+        {...sectionInView}
+        className="relative z-10 flex min-h-[80vh] flex-col items-center justify-center px-6 py-20 text-center"
+      >
+        <div className={`max-w-3xl font-serif text-4xl leading-[1.08] md:text-5xl lg:text-6xl ${heading}`}>
+          <p>welcome to</p>
+          <p className="mt-2">overlay first computing</p>
+        </div>
+        <p className={`mt-5 text-lg font-light tracking-wide md:text-xl ${muted}`}>
+          personal computing reimagined
+        </p>
+      </motion.section>
+
+      <motion.section
+        {...sectionInView}
+        className="relative z-10 flex min-h-screen flex-col px-6 pb-16 pt-20"
+      >
+        <div className="flex flex-1 flex-col items-center justify-center text-center">
+          <h2 className={`mb-8 font-serif text-4xl md:text-5xl lg:text-6xl ${heading}`}>begin</h2>
+          <Link href={webAppHref} className={ctaDarkClass}>
+            <Globe className="h-5 w-5" />
+            open app
+          </Link>
+          <p className={`mt-4 text-sm ${isDark ? "text-zinc-500" : "text-[#a1a1aa]"}`}>
+            desktop download coming soon
+          </p>
+        </div>
+
+        <footer
+          className={`mt-auto w-full max-w-4xl self-center border-t pt-12 ${
+            isDark ? "border-zinc-800" : "border-zinc-200"
+          }`}
+        >
+          <div className="flex flex-col items-stretch justify-between gap-4 px-0 pb-4 md:flex-row md:items-center">
+            <div className="flex items-center gap-3">
+              <Image
+                src="/assets/overlay-logo.png"
+                alt="Overlay"
+                width={24}
+                height={24}
+                className="opacity-60"
+              />
+              <p className={`text-sm ${muted}`}>© 2026 overlay</p>
+            </div>
+            <p className={`text-sm ${muted}`}>
+              made with care by{" "}
+              <a
+                href="https://divyan.sh"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`underline transition-colors ${isDark ? "hover:text-zinc-200" : "hover:text-[#0a0a0a]"}`}
+              >
+                divyan.sh
+              </a>
+            </p>
+            <div className="flex gap-8">
+              <a
+                href="/terms"
+                className={`text-sm transition-colors ${muted} ${isDark ? "hover:text-zinc-200" : "hover:text-[#0a0a0a]"}`}
+              >
+                terms
+              </a>
+              <a
+                href="/privacy"
+                className={`text-sm transition-colors ${muted} ${isDark ? "hover:text-zinc-200" : "hover:text-[#0a0a0a]"}`}
+              >
+                privacy
+              </a>
+              <a
+                href="mailto:divyansh@layernorm.co"
+                className={`text-sm transition-colors ${muted} ${isDark ? "hover:text-zinc-200" : "hover:text-[#0a0a0a]"}`}
+              >
+                contact
+              </a>
+            </div>
+          </div>
+        </footer>
+      </motion.section>
     </div>
   );
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -4,7 +4,6 @@ import { Suspense, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { ArrowRight, Check, CreditCard, GaugeCircle, MessageSquare, PlusCircle, Wallet } from 'lucide-react'
-import { TopUpPreferenceControl } from '@/components/billing/TopUpPreferenceControl'
 import { PageNavbar } from '@/components/PageNavbar'
 import { useAuth } from '@/contexts/AuthContext'
 import { LandingThemeProvider, useLandingTheme } from '@/contexts/LandingThemeContext'
@@ -40,15 +39,17 @@ function UserIdExtractor() {
 }
 
 function PricingContent() {
+  const planQuickPicks = [800, 2_400, 9_400] as const
   const router = useRouter()
   const { isLandingDark } = useLandingTheme()
   const { user, isAuthenticated, isLoading: authLoading } = useAuth()
-  const [selectedPlanAmountCents, setSelectedPlanAmountCents] = useState(2_000)
+  const [selectedPlanAmountCents, setSelectedPlanAmountCents] = useState(2_400)
+  const [selectedPlanPreset, setSelectedPlanPreset] = useState<'8' | '24' | '94' | 'custom'>('24')
   const [topUpAmountCents, setTopUpAmountCents] = useState(800)
   const [autoTopUpEnabled, setAutoTopUpEnabled] = useState(false)
   const [currentPlanKind, setCurrentPlanKind] = useState<'free' | 'paid'>('free')
   const [currentPlanAmountCents, setCurrentPlanAmountCents] = useState(0)
-  const [loading, setLoading] = useState<'checkout' | 'portal' | 'topup-settings' | null>(null)
+  const [loading, setLoading] = useState<'checkout' | 'portal' | null>(null)
   const [subscriptionLoading, setSubscriptionLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -77,6 +78,10 @@ function PricingContent() {
           setCurrentPlanAmountCents(planAmountCents)
           if (planKind === 'paid' && planAmountCents >= PAID_PLAN_MIN_AMOUNT_CENTS) {
             setSelectedPlanAmountCents(planAmountCents)
+            if (planAmountCents === 800) setSelectedPlanPreset('8')
+            else if (planAmountCents === 2_400) setSelectedPlanPreset('24')
+            else if (planAmountCents === 9_400) setSelectedPlanPreset('94')
+            else setSelectedPlanPreset('custom')
           }
         }
         if (settingsData) {
@@ -209,32 +214,6 @@ function PricingContent() {
     }
   }
 
-  async function handleSaveTopUpPreference() {
-    setLoading('topup-settings')
-    setError(null)
-
-    try {
-      const response = await fetch('/api/subscription/settings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          topUpAmountCents,
-          autoTopUpEnabled,
-          grantOffSessionConsent: autoTopUpEnabled,
-        }),
-      })
-      const data = await response.json().catch(() => ({}))
-      if (!response.ok) {
-        setError(data.error || 'Failed to save top-up preference.')
-      }
-    } catch (saveError) {
-      console.error('[Pricing] Top-up settings error:', saveError)
-      setError('Failed to save top-up preference.')
-    } finally {
-      setLoading(null)
-    }
-  }
-
   return (
     <div className="flex min-h-screen w-full flex-col gradient-bg">
       <Suspense fallback={null}>
@@ -316,7 +295,7 @@ function PricingContent() {
                 </div>
                 <div>
                   <h2 className={`text-xl font-medium ${theme.heading}`}>Paid</h2>
-                  <p className={`text-sm ${theme.muted}`}>Full product—you choose the monthly budget.</p>
+                  <p className={`text-sm ${theme.muted}`}>Full product—pick a plan in one tap, or choose custom.</p>
                 </div>
               </div>
 
@@ -333,25 +312,78 @@ function PricingContent() {
                   </div>
 
                   <div className={`mt-5 ${theme.subtleCard}`}>
-                    <div className="flex items-center justify-between text-sm">
-                      <span className={theme.muted}>Choose your monthly budget</span>
-                      <span className={theme.heading}>{formatDollarAmount(selectedPlanAmountCents)}</span>
+                    <p className={`text-sm ${theme.muted}`}>Choose your monthly budget</p>
+                    <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                      {planQuickPicks.map((amountCents) => {
+                        const isSelected = selectedPlanAmountCents === amountCents && selectedPlanPreset !== 'custom'
+                        return (
+                          <button
+                            key={amountCents}
+                            type="button"
+                            onClick={() => {
+                              setSelectedPlanAmountCents(amountCents)
+                              if (amountCents === 800) setSelectedPlanPreset('8')
+                              else if (amountCents === 2_400) setSelectedPlanPreset('24')
+                              else setSelectedPlanPreset('94')
+                            }}
+                            className={`rounded-xl border px-4 py-3 text-left transition-all ${
+                              isSelected
+                                ? isLandingDark
+                                  ? 'border-zinc-100 bg-zinc-900 text-zinc-100'
+                                  : 'border-zinc-900 bg-zinc-900 text-white'
+                                : isLandingDark
+                                  ? 'border-zinc-700 bg-zinc-950/50 text-zinc-200 hover:bg-zinc-900'
+                                  : 'border-zinc-200 bg-white text-zinc-900 hover:bg-zinc-50'
+                            }`}
+                          >
+                            <p className="text-xl font-medium">{formatDollarAmount(amountCents)}</p>
+                            <p className={`mt-1 text-xs ${isSelected ? (isLandingDark ? 'text-zinc-300' : 'text-zinc-200') : theme.muted}`}>per month</p>
+                          </button>
+                        )
+                      })}
+                      <button
+                        type="button"
+                        onClick={() => setSelectedPlanPreset('custom')}
+                        className={`rounded-xl border px-4 py-3 text-left transition-all ${
+                          selectedPlanPreset === 'custom'
+                            ? isLandingDark
+                              ? 'border-zinc-100 bg-zinc-900 text-zinc-100'
+                              : 'border-zinc-900 bg-zinc-900 text-white'
+                            : isLandingDark
+                              ? 'border-zinc-700 bg-zinc-950/50 text-zinc-200 hover:bg-zinc-900'
+                              : 'border-zinc-200 bg-white text-zinc-900 hover:bg-zinc-50'
+                        }`}
+                      >
+                        <p className="text-xl font-medium">Custom</p>
+                        <p className={`mt-1 text-xs ${selectedPlanPreset === 'custom' ? (isLandingDark ? 'text-zinc-300' : 'text-zinc-200') : theme.muted}`}>
+                          Use slider
+                        </p>
+                      </button>
                     </div>
-                    <input
-                      type="range"
-                      min={PAID_PLAN_MIN_AMOUNT_CENTS / 100}
-                      max={PAID_PLAN_MAX_AMOUNT_CENTS / 100}
-                      step={PAID_PLAN_STEP_AMOUNT_CENTS / 100}
-                      value={selectedPlanDollars}
-                      onChange={(event) => {
-                        setSelectedPlanAmountCents(Math.round(Number(event.target.value) * 100))
-                      }}
-                      className={theme.sliderTrack}
-                    />
-                    <div className={`mt-2 flex items-center justify-between text-xs ${theme.muted}`}>
-                      <span>$8</span>
-                      <span>$200</span>
-                    </div>
+
+                    {selectedPlanPreset === 'custom' ? (
+                      <>
+                        <div className="mt-5 flex items-center justify-between text-sm">
+                          <span className={theme.muted}>Custom monthly budget</span>
+                          <span className={theme.heading}>{formatDollarAmount(selectedPlanAmountCents)}</span>
+                        </div>
+                        <input
+                          type="range"
+                          min={PAID_PLAN_MIN_AMOUNT_CENTS / 100}
+                          max={PAID_PLAN_MAX_AMOUNT_CENTS / 100}
+                          step={PAID_PLAN_STEP_AMOUNT_CENTS / 100}
+                          value={selectedPlanDollars}
+                          onChange={(event) => {
+                            setSelectedPlanAmountCents(Math.round(Number(event.target.value) * 100))
+                          }}
+                          className={theme.sliderTrack}
+                        />
+                        <div className={`mt-2 flex items-center justify-between text-xs ${theme.muted}`}>
+                          <span>$8</span>
+                          <span>$200</span>
+                        </div>
+                      </>
+                    ) : null}
                   </div>
 
                   <div className="mt-6 grid gap-3 sm:grid-cols-3">
@@ -364,26 +396,12 @@ function PricingContent() {
                       <p className={`mt-2 text-lg font-medium ${theme.heading}`}>{formatBytes(selectedStorageBytes)}</p>
                     </div>
                     <div className={theme.elevatedCard}>
-                      <p className={`text-xs uppercase tracking-[0.18em] ${theme.muted}`}>Top-ups</p>
-                      <p className={`mt-2 text-lg font-medium ${theme.heading}`}>${(topUpAmountCents / 100).toFixed(0)}</p>
+                      <p className={`text-xs uppercase tracking-[0.18em] ${theme.muted}`}>Auto recharge</p>
+                      <p className={`mt-2 text-lg font-medium ${theme.heading}`}>
+                        {autoTopUpEnabled ? `$${(topUpAmountCents / 100).toFixed(0)}` : 'Off'}
+                      </p>
+                      <p className={`mt-1 text-xs ${theme.muted}`}>Manage in Account</p>
                     </div>
-                  </div>
-
-                  <div className="mt-6">
-                    <TopUpPreferenceControl
-                      variant="marketing"
-                      isDark={isLandingDark}
-                      title="Future top-up amount"
-                      description="Set the amount used for future recharges. This is not charged during signup."
-                      amountCents={topUpAmountCents}
-                      minAmountCents={800}
-                      maxAmountCents={20_000}
-                      stepAmountCents={100}
-                      onAmountChange={setTopUpAmountCents}
-                      autoTopUpEnabled={autoTopUpEnabled}
-                      onAutoTopUpEnabledChange={setAutoTopUpEnabled}
-                      checkboxDescription="If enabled, the same amount will recharge automatically whenever your cumulative budget reaches zero."
-                    />
                   </div>
 
                   <div className="mt-6 flex flex-col gap-3 sm:flex-row">
@@ -403,11 +421,11 @@ function PricingContent() {
                         </button>
                         <button
                           type="button"
-                          onClick={() => void handleSaveTopUpPreference()}
-                          disabled={loading === 'topup-settings' || subscriptionLoading}
+                          onClick={() => router.push('/account')}
+                          disabled={subscriptionLoading}
                           className={`inline-flex items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-medium transition-colors disabled:opacity-50 ${theme.secondaryButton}`}
                         >
-                          {loading === 'topup-settings' ? 'Saving preference...' : 'Save top-up preference'}
+                          Manage auto recharge
                         </button>
                       </>
                     ) : (

--- a/src/components/ObservabilityClient.tsx
+++ b/src/components/ObservabilityClient.tsx
@@ -1,60 +1,15 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
-import mixpanel from 'mixpanel-browser'
 import { useAuth } from '@/contexts/AuthContext'
 
-let mixpanelInitialized = false
-
-function getMixpanelToken(): string | null {
-  const token = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN?.trim()
-  return token && token.length > 0 ? token : null
-}
-
 export default function ObservabilityClient() {
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
   const { user } = useAuth()
-  const lastTrackedUrlRef = useRef<string | null>(null)
-
-  useEffect(() => {
-    const token = getMixpanelToken()
-    if (!token || mixpanelInitialized) return
-
-    mixpanel.init(token, {
-      api_host: process.env.NEXT_PUBLIC_MIXPANEL_API_HOST || undefined,
-      autocapture: false,
-      persistence: 'localStorage',
-      track_pageview: false,
-      debug: process.env.NODE_ENV === 'development',
-    })
-    mixpanelInitialized = true
-  }, [])
-
-  useEffect(() => {
-    const token = getMixpanelToken()
-    if (!token || !pathname || !mixpanelInitialized) return
-
-    const query = searchParams?.toString() ?? ''
-    const url = query ? `${pathname}?${query}` : pathname
-    if (lastTrackedUrlRef.current === url) return
-    lastTrackedUrlRef.current = url
-
-    mixpanel.track('page_view', {
-      path: pathname,
-      query: query || undefined,
-      url,
-    })
-  }, [pathname, searchParams])
 
   useEffect(() => {
     if (!user) {
       Sentry.setUser(null)
-      if (mixpanelInitialized) {
-        mixpanel.reset()
-      }
       return
     }
 
@@ -62,15 +17,6 @@ export default function ObservabilityClient() {
       id: user.id,
       email: user.email,
       username: [user.firstName, user.lastName].filter(Boolean).join(' ') || undefined,
-    })
-
-    if (!mixpanelInitialized) return
-
-    mixpanel.identify(user.id)
-    mixpanel.people.set({
-      $email: user.email,
-      $first_name: user.firstName,
-      $last_name: user.lastName,
     })
   }, [user])
 

--- a/src/components/ObservabilityClient.tsx
+++ b/src/components/ObservabilityClient.tsx
@@ -1,15 +1,43 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
 import * as Sentry from '@sentry/nextjs'
+import posthog from 'posthog-js'
 import { useAuth } from '@/contexts/AuthContext'
 
+function posthogConfigured(): boolean {
+  return Boolean(
+    process.env.NEXT_PUBLIC_POSTHOG_TOKEN?.trim() && process.env.NEXT_PUBLIC_POSTHOG_HOST?.trim(),
+  )
+}
+
 export default function ObservabilityClient() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
   const { user } = useAuth()
+  const lastPageviewUrlRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!posthogConfigured()) return
+    const query = searchParams?.toString() ?? ''
+    const pathWithQuery = query ? `${pathname}?${query}` : pathname
+    if (!pathname) return
+    const url =
+      typeof window !== 'undefined' ? `${window.location.origin}${pathWithQuery}` : pathWithQuery
+    if (lastPageviewUrlRef.current === url) return
+    lastPageviewUrlRef.current = url
+    posthog.capture('$pageview', {
+      $current_url: url,
+    })
+  }, [pathname, searchParams])
 
   useEffect(() => {
     if (!user) {
       Sentry.setUser(null)
+      if (posthogConfigured()) {
+        posthog.reset()
+      }
       return
     }
 
@@ -17,6 +45,14 @@ export default function ObservabilityClient() {
       id: user.id,
       email: user.email,
       username: [user.firstName, user.lastName].filter(Boolean).join(' ') || undefined,
+    })
+
+    if (!posthogConfigured()) return
+
+    posthog.identify(user.id, {
+      email: user.email,
+      first_name: user.firstName ?? undefined,
+      last_name: user.lastName ?? undefined,
     })
   }, [user])
 

--- a/src/components/VoiceDemo.tsx
+++ b/src/components/VoiceDemo.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import posthog from "posthog-js";
 
 const WAVEFORM_BAR_COUNT = 7;
 const WAVEFORM_BAR_WIDTH = 3;
@@ -103,6 +104,7 @@ export function VoiceDemo({ scrollProgress = 0, isActive = false }: VoiceDemoPro
       // Check for Option/Alt + Space
       if (e.altKey && e.code === "Space" && !isRecording && !isProcessing) {
         e.preventDefault();
+        posthog.capture('voice_demo_interacted', { trigger: 'keyboard' });
         setHasUserActivated(true);
         setIsRecording(true);
         recordingStartTime.current = Date.now();
@@ -350,6 +352,7 @@ export function VoiceDemo({ scrollProgress = 0, isActive = false }: VoiceDemoPro
                   to{" "}
                   <button
                     onClick={() => {
+                      posthog.capture('voice_demo_interacted', { trigger: 'click' });
                       setHasUserActivated(true);
                       setIsRecording(true);
                       recordingStartTime.current = Date.now();

--- a/src/components/app/AutomationsView.tsx
+++ b/src/components/app/AutomationsView.tsx
@@ -20,6 +20,7 @@ import {
   X,
 } from 'lucide-react'
 import { AutomationListSkeleton, RunDetailSkeleton } from '@/components/ui/Skeleton'
+import posthog from 'posthog-js'
 import { AVAILABLE_MODELS, DEFAULT_MODEL_ID, getChatModelDisplayName } from '@/lib/models'
 import {
   formatAutomationSchedule,
@@ -586,6 +587,21 @@ function AutomationDialog({
           scheduleConfig: payload.scheduleConfig,
           updatedAt: Date.now(),
         } as AutomationSummary)
+        posthog.capture('automation_updated', {
+          automation_id: initial!._id,
+          title: payload.title,
+          schedule_kind: payload.scheduleKind,
+          mode: payload.mode,
+          source_type: payload.sourceType,
+          status: payload.status,
+        })
+        if (initial!.status !== payload.status) {
+          posthog.capture('automation_status_toggled', {
+            automation_id: initial!._id,
+            previous_status: initial!.status,
+            new_status: payload.status,
+          })
+        }
       } else {
         const data = (await res.json()) as { id: string }
         onSaved({
@@ -605,6 +621,14 @@ function AutomationDialog({
           createdAt: Date.now(),
           updatedAt: Date.now(),
         } as AutomationSummary)
+        posthog.capture('automation_created', {
+          automation_id: data.id,
+          title: payload.title,
+          schedule_kind: payload.scheduleKind,
+          mode: payload.mode,
+          source_type: payload.sourceType,
+          status: payload.status,
+        })
       }
       onClose()
     } finally {
@@ -626,6 +650,7 @@ function AutomationDialog({
         method: 'DELETE',
       })
       if (!res.ok) return
+      posthog.capture('automation_deleted', { automation_id: initial!._id, title: initial!.title })
       onDeleted(initial!._id)
       onClose()
     } finally {
@@ -1122,6 +1147,7 @@ export default function AutomationsView({ userId: _userId }: { userId: string })
     try {
       const res = await fetch(`/api/app/automations?automationId=${encodeURIComponent(automationId)}`, { method: 'DELETE' })
       if (!res.ok) return
+      posthog.capture('automation_deleted', { automation_id: automationId })
       handleDeleted(automationId)
     } finally {
       setDeletingIds((prev) => ({ ...prev, [automationId]: false }))
@@ -1130,6 +1156,7 @@ export default function AutomationsView({ userId: _userId }: { userId: string })
 
   async function handleRunNow(automationId: string) {
     setRunningIds((prev) => ({ ...prev, [automationId]: true }))
+    posthog.capture('automation_run_triggered', { automation_id: automationId })
     try {
       const res = await fetch('/api/app/automations/run-now', {
         method: 'POST',

--- a/src/components/app/ChatInterface.tsx
+++ b/src/components/app/ChatInterface.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import posthog from 'posthog-js'
 import {
   Send,
   Plus,
@@ -3193,6 +3194,7 @@ export default function ChatInterface({
       }
       setChats((prev) => [newChat, ...prev])
       dispatchChatCreated({ chat: newChat })
+      posthog.capture('chat_new_chat_created', { mode: composerMode })
       const runtime = ensureConversationRuntime(data.id, {
         composerMode,
         selectedActModel,
@@ -3705,6 +3707,13 @@ async function hydrateCompletedAskTurnFromServer(
       setAttachmentError('Remove failed documents before sending.')
       return
     }
+
+    posthog.capture('chat_message_sent', {
+      mode: composerMode,
+      generation_type: effectiveGenType,
+      has_attachments: attachedImages.length > 0 || pendingChatDocuments.length > 0,
+      is_first_message: isFirstMessage,
+    })
 
     setIsOptimisticLoading(true)
 

--- a/src/components/app/IntegrationsView.tsx
+++ b/src/components/app/IntegrationsView.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo, UIEvent } from 'react'
 import { Loader2, Plus, X, Search } from 'lucide-react'
 import { IntegrationDialogRowSkeleton, IntegrationListSkeleton } from '@/components/ui/Skeleton'
+import posthog from 'posthog-js'
 import { INTEGRATIONS_BC_CHANNEL, notifyIntegrationsChanged } from '@/lib/integrations-events'
 
 interface Integration {
@@ -473,6 +474,7 @@ export default function IntegrationsView({ userId: _userId }: { userId: string }
         if (res.ok) {
           setConnected((prev) => { const next = new Set(prev); next.delete(integration.composioId); return next })
           notifyIntegrationsChanged()
+          posthog.capture('integration_disconnected', { integration: integration.composioId, integration_name: integration.name })
         } else {
           const data = await res.json().catch(() => ({}))
           setConnectError(data.error || 'Failed to disconnect')
@@ -490,6 +492,7 @@ export default function IntegrationsView({ userId: _userId }: { userId: string }
         } else if (data.redirectUrl) {
           if (oauthTab) oauthTab.location.href = data.redirectUrl
           else window.open(data.redirectUrl, '_blank')
+          posthog.capture('integration_connect_initiated', { integration: integration.composioId, integration_name: integration.name })
         } else {
           oauthTab?.close()
           setConnectError('No OAuth URL returned — this integration may require manual setup')
@@ -523,10 +526,12 @@ export default function IntegrationsView({ userId: _userId }: { userId: string }
         else window.open(data.redirectUrl, '_blank')
         setConnected((prev) => new Set([...prev, slug]))
         notifyIntegrationsChanged()
+        posthog.capture('integration_connect_initiated', { integration: slug })
       } else if (data.connectionId) {
         oauthTab?.close()
         setConnected((prev) => new Set([...prev, slug]))
         notifyIntegrationsChanged()
+        posthog.capture('integration_connect_initiated', { integration: slug })
       } else {
         oauthTab?.close()
         throw new Error('No OAuth URL returned')
@@ -546,6 +551,7 @@ export default function IntegrationsView({ userId: _userId }: { userId: string }
     if (!res.ok) throw new Error('Failed to disconnect')
     setConnected((prev) => { const next = new Set(prev); next.delete(slug); return next })
     notifyIntegrationsChanged()
+    posthog.capture('integration_disconnected', { integration: slug })
   }, [])
 
   const integrationForSlug = useCallback(

--- a/src/components/app/KnowledgeView.tsx
+++ b/src/components/app/KnowledgeView.tsx
@@ -8,6 +8,7 @@ import {
   LayoutList, LayoutGrid, RefreshCw, SquareMousePointer,
 } from 'lucide-react'
 import { FileTreeSkeleton, KnowledgeListSkeleton } from '@/components/ui/Skeleton'
+import posthog from 'posthog-js'
 import { FileViewerPanel, getFileType, isEditableType } from './FileViewer'
 import OutputsView from './OutputsView'
 
@@ -495,7 +496,13 @@ export default function KnowledgeView({ userId: _userId }: { userId: string }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, type: dialog.type, parentId: dialog.parentId }),
       })
-      if (res.ok) { setDialogName(''); setDialog(null); await loadFiles() }
+      if (res.ok) {
+        posthog.capture('knowledge_file_created', { file_name: name, type: dialog.type })
+        if (dialog.type === 'folder') {
+          posthog.capture('knowledge_folder_created', { folder_name: name })
+        }
+        setDialogName(''); setDialog(null); await loadFiles()
+      }
     } finally { setIsCreating(false) }
   }
 
@@ -506,7 +513,11 @@ export default function KnowledgeView({ userId: _userId }: { userId: string }) {
 
   async function handleDeleteNode(id: string, e: React.MouseEvent) {
     e.stopPropagation()
-    await fetch(`/api/app/files?fileId=${id}`, { method: 'DELETE' })
+    const node = files.find((f) => f._id === id)
+    const res = await fetch(`/api/app/files?fileId=${id}`, { method: 'DELETE' })
+    if (res.ok && node) {
+      posthog.capture('knowledge_file_deleted', { file_name: node.name, type: node.type })
+    }
     if (selectedFile?._id === id) {
       setSelectedFile(null)
       setFileContent('')

--- a/src/components/app/VoiceRecorder.tsx
+++ b/src/components/app/VoiceRecorder.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useCallback } from 'react'
 import { Mic, Square, Copy, MessageSquare, BookOpen, Loader2 } from 'lucide-react'
+import posthog from 'posthog-js'
 
 type OutputMode = 'clipboard' | 'chat' | 'note'
 
@@ -35,6 +36,7 @@ export default function VoiceRecorder({ userId: _userId }: { userId: string }) {
       mediaRecorder.start()
       setIsRecording(true)
       setStatus('Recording...')
+      posthog.capture('voice_recording_started', { output_mode: outputMode })
     } catch (err) {
       setStatus('Microphone access denied. Please allow microphone access.')
       console.error('[VoiceRecorder] Start error:', err)
@@ -69,6 +71,10 @@ export default function VoiceRecorder({ userId: _userId }: { userId: string }) {
       }
       const text = data.text || ''
       setTranscript(text)
+      posthog.capture('voice_transcription_completed', {
+        output_mode: outputMode,
+        transcript_length: text.length,
+      })
 
       if (outputMode === 'clipboard') {
         await navigator.clipboard.writeText(text)
@@ -79,6 +85,10 @@ export default function VoiceRecorder({ userId: _userId }: { userId: string }) {
         setStatus('Transcription ready. Send to chat below.')
       }
     } catch (err) {
+      posthog.capture('voice_transcription_error', {
+        output_mode: outputMode,
+        error: err instanceof Error ? err.message : 'unknown',
+      })
       setStatus(err instanceof Error ? err.message : 'Transcription failed. Please try again.')
       console.error('[VoiceRecorder] Transcribe error:', err)
     } finally {
@@ -98,6 +108,7 @@ export default function VoiceRecorder({ userId: _userId }: { userId: string }) {
         }),
       })
       if (res.ok) {
+        posthog.capture('voice_saved_as_note', { transcript_length: text.length })
         setStatus('Saved as note.')
       }
     } catch {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
+import posthog from 'posthog-js'
 
 export interface AuthUser {
   id: string
@@ -50,7 +51,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const signOut = useCallback(async () => {
     try {
+      posthog.capture('user_signed_out')
       await fetch('/api/auth/sign-out', { method: 'POST' })
+      posthog.reset()
       setUser(null)
       window.location.href = '/'
     } catch (error) {

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,9 +1,23 @@
 import * as Sentry from '@sentry/nextjs'
+import posthog from 'posthog-js'
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   sendDefaultPii: false,
   tracesSampleRate: process.env.NODE_ENV === 'development' ? 1 : 0.1,
 })
+
+const posthogToken = process.env.NEXT_PUBLIC_POSTHOG_TOKEN?.trim()
+const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST?.trim()
+if (posthogToken && posthogHost) {
+  posthog.init(posthogToken, {
+    api_host: posthogHost,
+    defaults: '2026-01-30',
+    autocapture: false,
+    capture_pageview: false,
+    capture_pageleave: true,
+    persistence: 'localStorage',
+  })
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/src/lib/mobile-auth-client.ts
+++ b/src/lib/mobile-auth-client.ts
@@ -1,0 +1,37 @@
+const STORAGE_KEY = 'overlay_mobile_pkce_challenge'
+
+export function persistMobilePkceChallengeFromUrl(searchParams: Pick<URLSearchParams, 'get'> | null): void {
+  if (typeof window === 'undefined' || !searchParams) return
+  const c = searchParams.get('codeChallenge')?.trim()
+  if (!c) return
+  try {
+    sessionStorage.setItem(STORAGE_KEY, c)
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+export function getStoredMobilePkceChallenge(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return sessionStorage.getItem(STORAGE_KEY)?.trim() || null
+  } catch {
+    return null
+  }
+}
+
+export function clearStoredMobilePkceChallenge(): void {
+  if (typeof window === 'undefined') return
+  try {
+    sessionStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/** PKCE challenge for SSO: prefer current URL (app-opened tab), else session fallback across in-site navigation. */
+export function resolveCodeChallengeForSso(searchParams: Pick<URLSearchParams, 'get'> | null): string | null {
+  const fromUrl = searchParams?.get('codeChallenge')?.trim()
+  if (fromUrl) return fromUrl
+  return getStoredMobilePkceChallenge()
+}

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -1,0 +1,18 @@
+import { PostHog } from 'posthog-node'
+
+let posthogClient: PostHog | null = null
+
+export function getPostHogClient(): PostHog | null {
+  const token = process.env.NEXT_PUBLIC_POSTHOG_TOKEN?.trim()
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST?.trim()
+  if (!token || !host) return null
+
+  if (!posthogClient) {
+    posthogClient = new PostHog(token, {
+      host,
+      flushAt: 1,
+      flushInterval: 0,
+    })
+  }
+  return posthogClient
+}

--- a/src/lib/server-provider-keys.ts
+++ b/src/lib/server-provider-keys.ts
@@ -7,7 +7,6 @@ const PROVIDER_VAULT_NAMES: Record<string, string> = {
   minimax: 'MINIMAX_API_KEY',
   composio: 'COMPOSIO_API_KEY',
   ai_gateway: 'AI_GATEWAY_API_KEY',
-  mixpanel: 'MIXPANEL_TOKEN',
 }
 
 const CACHE_TTL_MS = 5 * 60 * 1000

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -62,6 +62,7 @@ function uniqueSources(values: Array<string | null | undefined>): string[] {
 function buildConnectSrc(): string[] {
   return uniqueSources([
     "'self'",
+    parseOrigin(process.env.NEXT_PUBLIC_POSTHOG_HOST),
     parseOrigin(process.env.NEXT_PUBLIC_SENTRY_DSN),
     parseOrigin(process.env.SENTRY_DSN),
     parseOrigin(process.env.NEXT_PUBLIC_CONVEX_URL),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -62,10 +62,6 @@ function uniqueSources(values: Array<string | null | undefined>): string[] {
 function buildConnectSrc(): string[] {
   return uniqueSources([
     "'self'",
-    'https://api-js.mixpanel.com',
-    'https://api.mixpanel.com',
-    'https://mixpanel.com',
-    parseOrigin(process.env.NEXT_PUBLIC_MIXPANEL_API_HOST),
     parseOrigin(process.env.NEXT_PUBLIC_SENTRY_DSN),
     parseOrigin(process.env.SENTRY_DSN),
     parseOrigin(process.env.NEXT_PUBLIC_CONVEX_URL),


### PR DESCRIPTION
### Motivation

- Replace a shared `TopUpPreferenceControl` component with an inline, more opinionated UX for quick-pick top-ups, custom amounts, and auto-recharge controls on the Account and Pricing pages.
- Surface one-tap plan presets on the Pricing page to simplify plan selection and drive consistent quick-pick amounts across pages.

### Description

- Removed `TopUpPreferenceControl` imports and usage from `src/app/account/page.tsx` and `src/app/pricing/page.tsx` and implemented custom UI blocks for quick-pick presets, a "Custom" slider, and auto-recharge toggle on the Account page.
- Added `planQuickPicks` / `topUpQuickPicks` preset arrays (`[800, 2400, 9400]`) and new state to track preset mode (`'8' | '24' | '94' | 'custom'`) and selection on both pages, plus logic to resolve the preset from fetched subscription/settings data.
- Updated Account page behavior to initialize `topUpAmountDraftCents` and `topUpAmountMode` from `/api/subscription/settings` and to render purchase, save, and auto-recharge controls with new copy and layout.
- Updated Pricing page to show preset buttons instead of the previous slider by default, added a custom slider only when the `custom` preset is chosen, changed the default selected plan to `$24` (2_400 cents), removed the `topup-settings` loading state and the inline `handleSaveTopUpPreference` handler and replaced the manage action with a link/button to the Account page for top-up/auto-recharge management.

### Testing

- Ran a full TypeScript check and production build with `yarn build` and the build completed without errors.
- Ran linting with `yarn lint` and fixed style issues; lint passed.
- Executed the test suite with `yarn test` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12b638f208331a34902ef3dc01c4c)