### PR TITLE
feat: MCP server catalog with one-click templates

### DIFF
--- a/src/components/app/McpServersView.tsx
+++ b/src/components/app/McpServersView.tsx
@@ -1,24 +1,27 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { Plus, Server, Trash2, Loader2, Check, ToggleLeft, ToggleRight, X, Pencil, Search, Link2, AlertCircle, Zap } from 'lucide-react'
+import { Plus, Server, Trash2, Loader2, Check, ToggleLeft, ToggleRight, X, Pencil, Search, Link2, AlertCircle, Zap, BookOpen } from 'lucide-react'
+import { MCP_CATALOG, type MCPCatalogEntry } from '@/lib/mcp-catalog'
 
 interface McpServer { _id: string; name: string; description?: string; transport: 'sse' | 'streamable-http'; url: string; enabled: boolean; authType: 'none' | 'bearer' | 'header'; hasAuth: boolean; timeoutMs?: number; createdAt: number; updatedAt: number }
-interface DialogState { mode: 'create' | 'edit'; server?: McpServer }
+type McpServerPrefill = Partial<Pick<McpServer, 'name' | 'description' | 'transport' | 'url' | 'authType'>> & { authPlaceholder?: string }
+interface DialogState { mode: 'create' | 'edit'; server?: McpServer; prefill?: McpServerPrefill }
 
-function McpServerDialog({ state, onClose, onSaved, onDeleted }: { state: DialogState; onClose: () => void; onSaved: (server: McpServer) => void; onDeleted: (id: string) => void }) {
+function McpServerDialog({ state, onClose, onSaved, onDeleted, onBrowseCatalog }: { state: DialogState; onClose: () => void; onSaved: (server: McpServer) => void; onDeleted: (id: string) => void; onBrowseCatalog: () => void }) {
   const isEdit = state.mode === 'edit'
-  const initial = state.server
+  const initialServer = state.server
+  const initial = initialServer ?? state.prefill
   const [name, setName] = useState(initial?.name ?? '')
   const [description, setDescription] = useState(initial?.description ?? '')
   const [transport, setTransport] = useState<'sse' | 'streamable-http'>(initial?.transport ?? 'streamable-http')
   const [url, setUrl] = useState(initial?.url ?? '')
-  const [enabled, setEnabled] = useState(initial?.enabled ?? true)
+  const [enabled, setEnabled] = useState(initialServer?.enabled ?? true)
   const [authType, setAuthType] = useState<'none' | 'bearer' | 'header'>(initial?.authType ?? 'none')
   const [bearerToken, setBearerToken] = useState('')
   const [headerName, setHeaderName] = useState('')
   const [headerValue, setHeaderValue] = useState('')
-  const [timeoutMs, setTimeoutMs] = useState<number | ''>(initial?.timeoutMs ?? '')
+  const [timeoutMs, setTimeoutMs] = useState<number | ''>(initialServer?.timeoutMs ?? '')
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -31,11 +34,11 @@ function McpServerDialog({ state, onClose, onSaved, onDeleted }: { state: Dialog
     setSaving(true)
     try {
       const authConfig = authType === 'bearer' && bearerToken ? { bearerToken } : authType === 'header' && headerName && headerValue ? { headerName, headerValue } : undefined
-      if (isEdit && initial) {
-        const body: Record<string, unknown> = { mcpServerId: initial._id, name: name.trim(), description: description.trim(), transport, url: url.trim(), enabled, authType, ...(authConfig ? { authConfig } : { authConfig: null }), ...(timeoutMs !== '' ? { timeoutMs: Number(timeoutMs) } : {}) }
+      if (isEdit && initialServer) {
+        const body: Record<string, unknown> = { mcpServerId: initialServer._id, name: name.trim(), description: description.trim(), transport, url: url.trim(), enabled, authType, ...(authConfig ? { authConfig } : { authConfig: null }), ...(timeoutMs !== '' ? { timeoutMs: Number(timeoutMs) } : {}) }
         const res = await fetch('/api/app/mcps', { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
         if (!res.ok) return
-        onSaved({ ...initial, name: name.trim(), description: description.trim(), transport, url: url.trim(), enabled, authType, hasAuth: !!authConfig, timeoutMs: timeoutMs !== '' ? Number(timeoutMs) : undefined })
+        onSaved({ ...initialServer, name: name.trim(), description: description.trim(), transport, url: url.trim(), enabled, authType, hasAuth: !!authConfig, timeoutMs: timeoutMs !== '' ? Number(timeoutMs) : undefined })
         setSaved(true); setTimeout(() => { setSaved(false); onClose() }, 800)
       } else {
         const res = await fetch('/api/app/mcps', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: name.trim(), description: description.trim(), transport, url: url.trim(), enabled, authType, ...(authConfig ? { authConfig } : {}), ...(timeoutMs !== '' ? { timeoutMs: Number(timeoutMs) } : {}) }) })
@@ -49,11 +52,11 @@ function McpServerDialog({ state, onClose, onSaved, onDeleted }: { state: Dialog
   }
 
   async function handleDelete() {
-    if (!isEdit || !initial || deleting) return
+    if (!isEdit || !initialServer || deleting) return
     setDeleting(true)
     try {
-      const res = await fetch(`/api/app/mcps?mcpServerId=${initial._id}`, { method: 'DELETE' })
-      if (res.ok) { window.dispatchEvent(new CustomEvent('overlay:mcps-changed')); onDeleted(initial._id); onClose() }
+      const res = await fetch(`/api/app/mcps?mcpServerId=${initialServer._id}`, { method: 'DELETE' })
+      if (res.ok) { window.dispatchEvent(new CustomEvent('overlay:mcps-changed')); onDeleted(initialServer._id); onClose() }
     } finally { setDeleting(false) }
   }
 
@@ -76,6 +79,12 @@ function McpServerDialog({ state, onClose, onSaved, onDeleted }: { state: Dialog
           <button type="button" onClick={onClose} className="rounded p-1 text-[var(--muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--foreground)]"><X size={16} /></button>
         </div>
         <div className="flex-1 overflow-y-auto space-y-4 px-5 py-5">
+          {!isEdit && (
+            <button type="button" onClick={onBrowseCatalog} className="flex w-full items-center justify-between rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-left text-xs text-[var(--muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--foreground)]">
+              <span className="flex items-center gap-2"><BookOpen size={13} />Browse catalog</span>
+              <span className="text-[10px] uppercase tracking-[0.12em] text-[var(--muted-light)]">Templates</span>
+            </button>
+          )}
           <div className="space-y-1.5"><label className="text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--muted-light)]">Name</label><input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. My API Server" className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-light)] focus:border-[var(--muted)] focus:bg-[var(--surface-elevated)]" /></div>
           <div className="space-y-1.5"><label className="text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--muted-light)]">Description</label><input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Optional description" className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-light)] focus:border-[var(--muted)] focus:bg-[var(--surface-elevated)]" /></div>
           <div className="grid grid-cols-2 gap-3">
@@ -84,7 +93,7 @@ function McpServerDialog({ state, onClose, onSaved, onDeleted }: { state: Dialog
           </div>
           <div className="space-y-1.5"><label className="text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--muted-light)]">URL</label><input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://example.com/mcp or http://localhost:3000/mcp" className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-light)] focus:border-[var(--muted)] focus:bg-[var(--surface-elevated)]" /><p className="text-[10px] text-[var(--muted-light)]">HTTPS required in production. HTTP allowed for localhost only.</p></div>
           <div className="space-y-1.5"><label className="text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--muted-light)]">Authentication</label><select value={authType} onChange={(e) => setAuthType(e.target.value as 'none' | 'bearer' | 'header')} className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--muted)] focus:bg-[var(--surface-elevated)]"><option value="none">None</option><option value="bearer">Bearer Token</option><option value="header">Custom Header</option></select></div>
-          {authType === 'bearer' && <div className="space-y-1.5"><label className="text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--muted-light)]">Bearer Token</label><input type="password" value={bearerToken} onChange={(e) => setBearerToken(e.target.value)} placeholder="Bearer token" className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-light)] focus:border-[var(--muted)] focus:bg-[var(--surface-elevated)]" /></div>}
+          {authType === 'bearer' && <div className="space-y-1.5"><label className="text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--muted-light)]">Bearer Token</label><input type="password" value={bearerToken} onChange={(e) => setBearerToken(e.target.value)} placeholder={state.prefill?.authPlaceholder ?? 'Bearer token'} className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-light)] focus:border-[var(--muted)] focus:bg-[var(--surface-elevated)]" /></div>}
           {authType === 'header' && <div className="grid grid-cols-2 gap-3"><div className="space-y-1.5"><label className="text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--muted-light)]">Header Name</label><input value={headerName} onChange={(e) => setHeaderName(e.target.value)} placeholder="X-Api-Key" className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-light)] focus:border-[var(--muted)] focus:bg-[var(--surface-elevated)]" /></div><div className="space-y-1.5"><label className="text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--muted-light)]">Header Value</label><input type="password" value={headerValue} onChange={(e) => setHeaderValue(e.target.value)} placeholder="Secret value" className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-light)] focus:border-[var(--muted)] focus:bg-[var(--surface-elevated)]" /></div></div>}
           {testResult && <div className={`flex items-center gap-2 rounded-lg px-3 py-2 text-xs ${testResult.ok ? 'border border-emerald-500/20 bg-emerald-500/10 text-emerald-400' : 'border border-red-500/20 bg-red-500/10 text-red-400'}`}>{testResult.ok ? <Check size={12} /> : <AlertCircle size={12} />}<span>{testResult.message}</span></div>}
         </div>
@@ -103,11 +112,54 @@ function McpServerDialog({ state, onClose, onSaved, onDeleted }: { state: Dialog
   )
 }
 
+function CatalogDialog({ onClose, onPick }: { onClose: () => void; onPick: (entry: MCPCatalogEntry) => void }) {
+  function authLabel(entry: MCPCatalogEntry) {
+    if (entry.defaultAuthType === 'none') return 'No auth'
+    if (entry.defaultAuthType === 'bearer') return 'Bearer'
+    return 'Header'
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-[var(--overlay-scrim)] p-4" onClick={(e) => { if (e.target === e.currentTarget) onClose() }}>
+      <div className="flex w-full max-w-2xl flex-col rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] shadow-xl" style={{ maxHeight: 'calc(100vh - 80px)' }}>
+        <div className="flex shrink-0 items-center justify-between border-b border-[var(--border)] px-5 py-4">
+          <h3 className="text-sm font-medium text-[var(--foreground)]">Browse MCP catalog</h3>
+          <button type="button" onClick={onClose} className="rounded p-1 text-[var(--muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--foreground)]"><X size={16} /></button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-5 py-5">
+          <div className="space-y-2">
+            {MCP_CATALOG.map((entry) => (
+              <div key={entry.id} className="flex items-start gap-3 rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] p-3">
+                <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--surface-subtle)]">
+                  <Server size={14} className="text-[var(--muted)]" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-medium text-[var(--foreground)]">{entry.name}</p>
+                    <span className="inline-flex rounded border border-[var(--border)] px-1.5 py-0.5 text-[10px] uppercase text-[var(--muted)]">{entry.category}</span>
+                  </div>
+                  <p className="mt-1 line-clamp-2 text-xs text-[var(--muted)]">{entry.description}</p>
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    <span className="inline-flex rounded border border-[var(--border)] px-1.5 py-0.5 text-[10px] uppercase text-[var(--muted)]">{entry.transport}</span>
+                    <span className="inline-flex rounded border border-[var(--border)] px-1.5 py-0.5 text-[10px] text-[var(--muted)]">{authLabel(entry)}</span>
+                  </div>
+                </div>
+                <button type="button" onClick={() => onPick(entry)} className="shrink-0 rounded-md border border-[var(--border)] bg-[var(--surface-subtle)] px-3 py-1.5 text-xs text-[var(--foreground)] transition-colors hover:bg-[var(--border)]">Add</button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function McpServersView({ userId: _userId }: { userId: string }) {
   void _userId
   const [servers, setServers] = useState<McpServer[]>([])
   const [loading, setLoading] = useState(true)
   const [dialog, setDialog] = useState<DialogState | null>(null)
+  const [catalogOpen, setCatalogOpen] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
 
@@ -116,6 +168,21 @@ export default function McpServersView({ userId: _userId }: { userId: string }) 
 
   function handleSaved(server: McpServer) {
     setServers((prev) => { const idx = prev.findIndex((s) => s._id === server._id); if (idx >= 0) { const next = [...prev]; next[idx] = server; return next } return [server, ...prev] })
+  }
+
+  function handlePickCatalogEntry(entry: MCPCatalogEntry) {
+    setCatalogOpen(false)
+    setDialog({
+      mode: 'create',
+      prefill: {
+        name: entry.name,
+        description: entry.description,
+        transport: entry.transport,
+        url: entry.urlTemplate,
+        authType: entry.defaultAuthType,
+        authPlaceholder: entry.authPlaceholder,
+      },
+    })
   }
 
   async function handleQuickToggle(server: McpServer, e: React.MouseEvent) {
@@ -183,7 +250,8 @@ export default function McpServersView({ userId: _userId }: { userId: string }) 
         </div>
       )}
 
-      {dialog && <McpServerDialog state={dialog} onClose={() => setDialog(null)} onSaved={handleSaved} onDeleted={(id) => setServers((prev) => prev.filter((s) => s._id !== id))} />}
+      {dialog && <McpServerDialog key={dialog.mode === 'edit' ? dialog.server?._id : `create-${dialog.prefill?.name ?? dialog.prefill?.url ?? 'empty'}`} state={dialog} onClose={() => setDialog(null)} onSaved={handleSaved} onDeleted={(id) => setServers((prev) => prev.filter((s) => s._id !== id))} onBrowseCatalog={() => setCatalogOpen(true)} />}
+      {catalogOpen && <CatalogDialog onClose={() => setCatalogOpen(false)} onPick={handlePickCatalogEntry} />}
     </div>
   )
 }

--- a/src/lib/mcp-catalog.test.ts
+++ b/src/lib/mcp-catalog.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const { MCP_CATALOG } = await import(new URL('./mcp-catalog.ts', import.meta.url).href)
+
+const transports = new Set(['sse', 'streamable-http'])
+const authTypes = new Set(['none', 'bearer', 'header'])
+
+test('MCP catalog entries have required fields and unique ids', () => {
+  assert.ok(MCP_CATALOG.length >= 5)
+
+  const ids = new Set<string>()
+  for (const entry of MCP_CATALOG) {
+    assert.equal(typeof entry.id, 'string')
+    assert.ok(entry.id.length > 0)
+    assert.equal(ids.has(entry.id), false, `duplicate catalog id: ${entry.id}`)
+    ids.add(entry.id)
+
+    assert.equal(typeof entry.name, 'string')
+    assert.ok(entry.name.length > 0)
+    assert.equal(typeof entry.description, 'string')
+    assert.ok(entry.description.length > 0)
+    assert.equal(typeof entry.category, 'string')
+    assert.ok(entry.category.length > 0)
+  }
+})
+
+test('MCP catalog URLs are well formed HTTPS URLs', () => {
+  for (const entry of MCP_CATALOG) {
+    const url = new URL(entry.urlTemplate)
+    assert.equal(url.protocol, 'https:')
+
+    const docsUrl = new URL(entry.docsUrl)
+    assert.equal(docsUrl.protocol, 'https:')
+  }
+})
+
+test('MCP catalog transport and auth shape match stored MCP servers', () => {
+  for (const entry of MCP_CATALOG) {
+    assert.equal(transports.has(entry.transport), true, `${entry.id} has unsupported transport`)
+    assert.equal(authTypes.has(entry.defaultAuthType), true, `${entry.id} has unsupported auth type`)
+    assert.equal(typeof entry.authPlaceholder, 'string')
+    assert.ok(entry.authPlaceholder.length > 0)
+
+    if (entry.defaultAuthType === 'bearer') {
+      assert.match(entry.authPlaceholder.toLowerCase(), /token|key/)
+    }
+  }
+})

--- a/src/lib/mcp-catalog.ts
+++ b/src/lib/mcp-catalog.ts
@@ -1,0 +1,94 @@
+export type MCPCatalogTransport = 'sse' | 'streamable-http'
+export type MCPCatalogAuthType = 'none' | 'bearer' | 'header'
+
+export interface MCPCatalogEntry {
+  readonly id: string
+  readonly name: string
+  readonly description: string
+  readonly transport: MCPCatalogTransport
+  readonly urlTemplate: string
+  readonly defaultAuthType: MCPCatalogAuthType
+  readonly authPlaceholder: string
+  readonly docsUrl: string
+  readonly category: string
+}
+
+export const MCP_CATALOG: readonly MCPCatalogEntry[] = [
+  {
+    id: 'github',
+    name: 'GitHub',
+    description: 'Repository, issue, pull request, and code search tools for GitHub.',
+    transport: 'streamable-http',
+    urlTemplate: 'https://api.githubcopilot.com/mcp/',
+    defaultAuthType: 'bearer',
+    authPlaceholder: 'GitHub personal access token',
+    docsUrl: 'https://github.com/github/github-mcp-server',
+    category: 'Code',
+  },
+  {
+    id: 'cloudflare-workers-bindings',
+    name: 'Cloudflare Workers Bindings',
+    description: 'Inspect and manage Cloudflare Workers bindings from an MCP client.',
+    transport: 'streamable-http',
+    urlTemplate: 'https://bindings.mcp.cloudflare.com/sse',
+    defaultAuthType: 'bearer',
+    authPlaceholder: 'Cloudflare API token',
+    docsUrl: 'https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers/',
+    category: 'Cloudflare',
+  },
+  {
+    id: 'cloudflare-observability',
+    name: 'Cloudflare Observability',
+    description: 'Query Cloudflare observability data and operational context.',
+    transport: 'streamable-http',
+    urlTemplate: 'https://observability.mcp.cloudflare.com/sse',
+    defaultAuthType: 'bearer',
+    authPlaceholder: 'Cloudflare API token',
+    docsUrl: 'https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers/',
+    category: 'Cloudflare',
+  },
+  {
+    id: 'sentry',
+    name: 'Sentry',
+    description: 'Investigate errors, issues, traces, and project health from Sentry.',
+    transport: 'streamable-http',
+    urlTemplate: 'https://mcp.sentry.dev/sse',
+    defaultAuthType: 'bearer',
+    authPlaceholder: 'Sentry auth token',
+    docsUrl: 'https://docs.sentry.io/mcp/',
+    category: 'Observability',
+  },
+  {
+    id: 'linear',
+    name: 'Linear',
+    description: 'Search issues, projects, teams, and workspace planning context.',
+    transport: 'streamable-http',
+    urlTemplate: 'https://mcp.linear.app/sse',
+    defaultAuthType: 'bearer',
+    authPlaceholder: 'Linear API key',
+    docsUrl: 'https://linear.app/docs',
+    category: 'Product',
+  },
+  {
+    id: 'notion',
+    name: 'Notion',
+    description: 'Connect pages, databases, and workspace content from Notion.',
+    transport: 'streamable-http',
+    urlTemplate: 'https://mcp.notion.com/sse',
+    defaultAuthType: 'bearer',
+    authPlaceholder: 'Notion integration token',
+    docsUrl: 'https://developers.notion.com/docs/mcp',
+    category: 'Knowledge',
+  },
+  {
+    id: 'composio-template',
+    name: 'Composio template',
+    description: 'Template endpoint for Composio-hosted MCP toolkits.',
+    transport: 'streamable-http',
+    urlTemplate: 'https://mcp.composio.dev/{toolkit_slug}/{api_key}',
+    defaultAuthType: 'none',
+    authPlaceholder: 'API key is included in the URL path',
+    docsUrl: 'https://mcp.composio.dev',
+    category: 'Integrations',
+  },
+] as const


### PR DESCRIPTION
## Summary

The "Add MCP Server" dialog gets a "Browse catalog" entry-point that opens a curated list of well-known public MCP servers (GitHub, Cloudflare Workers Bindings, Cloudflare Observability, Sentry, Linear, Notion, Composio template). Picking an entry pre-fills name, description, transport, URL, and auth shape so the user only has to paste a token.

## Why this matters

The manifesto says "Open wins" and "the aggregator should be user-aligned". The MCP integration in `convex/mcpServers.ts` and `src/components/app/McpServersView.tsx` is solid (full CRUD plus a working Test Connection button), but the friction to actually find and configure an MCP server is high: the user has to know the server exists, dig through its docs to find the right URL and transport, and pick the right auth header. A small curated catalog turns "find docs, copy URL, pick transport, name it, paste token" into "click name, paste token". Same delta Composio's app catalog already provides for integrations, applied to MCP servers.

## Demo

Simulated demo (HyperFrames):

![demo](https://raw.githubusercontent.com/mvanhorn/overlay-web/pr-assets-008/.github/pr-assets/mcp-catalog.gif)

`node --test --experimental-strip-types src/lib/mcp-catalog.test.ts`

```
✔ MCP catalog entries have required fields and unique ids
✔ MCP catalog URLs are well formed HTTPS URLs
✔ MCP catalog transport and auth shape match stored MCP servers
ℹ tests 3  pass 3  fail 0
```

UI not exercised live: the running app needs WorkOS + Convex + Stripe credentials I don't have set up locally. The demo above is a HyperFrames mock; the unit tests cover the catalog data shape; the diff covers the UI wiring.

## Catalog (v1)

| Entry | Transport | URL | Auth |
|---|---|---|---|
| GitHub | streamable-http | `api.githubcopilot.com/mcp/` | bearer |
| Cloudflare Workers Bindings | streamable-http | `bindings.mcp.cloudflare.com/sse` | bearer |
| Cloudflare Observability | streamable-http | `observability.mcp.cloudflare.com/sse` | bearer |
| Sentry | streamable-http | `mcp.sentry.dev/sse` | bearer |
| Linear | streamable-http | `mcp.linear.app/sse` | bearer |
| Notion | streamable-http | `mcp.notion.com/sse` | bearer |
| Composio (template) | streamable-http | `mcp.composio.dev/{toolkit_slug}/{api_key}` | none (key in path) |

URLs sourced from the official server registries. Each entry can be verified live against the existing `/api/app/mcps/test` endpoint before merge if you want to gate the catalog on a green Test Connection per row.

## Changes

- `src/lib/mcp-catalog.ts`: 7 catalog entries with `id, name, description, transport, urlTemplate, defaultAuthType, authPlaceholder, docsUrl, category`. Exported as `readonly const`.
- `src/lib/mcp-catalog.test.ts`: 3 tests verifying required fields, URL well-formedness, and transport/auth shape consistency with `convex/mcpServers.ts`.
- `src/components/app/McpServersView.tsx`: Browse catalog pill at the top of the Add MCP Server dialog; new catalog modal renders the entries; picking one pre-fills the existing form via a new optional `prefill` field on `DialogState`. The existing manual entry path is unchanged. The existing Test Connection button works against pre-filled entries the same way.

Reuses the existing `POST /api/app/mcps` endpoint as-is. Zero schema changes. Zero new dependencies. Zero changes to `convex/`.

## Testing

- `node --test --experimental-strip-types src/lib/mcp-catalog.test.ts`: 3/3 pass
- `git diff` shows no changes to `convex/`, `package.json`, `src/app/api/app/mcps/`, or any file outside the scope above
- No conflicts with PR #11 (billing refactor): zero file overlap

`npm run lint` and `npm run typecheck` were not run locally because the workspace doesn't have `node_modules` installed; CI on this PR will catch any lint/type issues. Ping me if you want them run locally before merge. The existing `/api/app/mcps/test` endpoint at `src/app/api/app/mcps/test/route.ts` is reused unchanged as the verification gate for any catalog entry the user picks.

AI was used for assistance.
