### PR TITLE
Fix Mintlify production proxy paths

### DIFF
--- a/docs/deploy-operate/docs-hosting.mdx
+++ b/docs/deploy-operate/docs-hosting.mdx
@@ -19,8 +19,8 @@ When `MINTLIFY_DOCS_URL` is set, the app adds these routes:
 
 | Public URL | Upstream |
 | --- | --- |
-| `https://getoverlay.io/docs` | `${MINTLIFY_DOCS_URL}/docs` |
-| `https://getoverlay.io/docs/*` | `${MINTLIFY_DOCS_URL}/docs/*` |
+| `https://getoverlay.io/docs` | `${MINTLIFY_DOCS_URL}` |
+| `https://getoverlay.io/docs/*` | `${MINTLIFY_DOCS_URL}/*` |
 | `https://getoverlay.io/_mintlify/*` | `${MINTLIFY_DOCS_URL}/_mintlify/*` |
 | `https://getoverlay.io/api/request` | `${MINTLIFY_DOCS_URL}/_mintlify/api/request` |
 | `https://getoverlay.io/docs/llms.txt` | `${MINTLIFY_DOCS_URL}/llms.txt` |

--- a/next.config.ts
+++ b/next.config.ts
@@ -84,11 +84,11 @@ const nextConfig: NextConfig = {
         },
         {
           source: "/docs",
-          destination: `${mintlifyDocsOrigin}/docs`,
+          destination: mintlifyDocsOrigin,
         },
         {
           source: "/docs/:match*",
-          destination: `${mintlifyDocsOrigin}/docs/:match*`,
+          destination: `${mintlifyDocsOrigin}/:match*`,
         },
         {
           source: "/mintlify-assets/:path*",


### PR DESCRIPTION
## Summary
- proxy public `/docs` routes to the root-hosted Mintlify origin
- align the docs-hosting runbook with the actual Mintlify path model

## Verification
- `npm run docs:health`
- confirmed `https://layernorminc.mintlify.app/deploy-operate/docker-ec2` returns the EC2 guide
- reproduced the broken production mapping adding an extra `/docs` prefix

The full local typecheck was not representative because this disposable worktree reused an older shared `node_modules`; the release CI installs from the current lockfile.