### PR TITLE
DOCS: fix Mintlify step formatting

### DIFF
--- a/docs/deploy-operate/aws.mdx
+++ b/docs/deploy-operate/aws.mdx
@@ -111,160 +111,160 @@ value, build log, document, ticket, email, or chat.
 ## Deployment procedure
 
 <Steps>
-  <Step title="Prepare the customer repository">
-    Create a customer-controlled private repository. Import the approved Overlay
-    release and retain `layernorm/overlay-web` as the upstream remote.
+<Step title="Prepare the customer repository">
+Create a customer-controlled private repository. Import the approved Overlay
+release and retain `layernorm/overlay-web` as the upstream remote.
 
-    ```bash
-    git remote add upstream https://github.com/layernorm/overlay-web.git
-    git fetch upstream --tags
-    git checkout -b release/overlay-<VERSION>-customer.1 <APPROVED_TAG>
-    git push -u origin release/overlay-<VERSION>-customer.1
-    ```
+```bash
+git remote add upstream https://github.com/layernorm/overlay-web.git
+git fetch upstream --tags
+git checkout -b release/overlay-<VERSION>-customer.1 <APPROVED_TAG>
+git push -u origin release/overlay-<VERSION>-customer.1
+```
 
-    Merge only through a reviewed pull request with required checks.
-  </Step>
+Merge only through a reviewed pull request with required checks.
+</Step>
 
-  <Step title="Establish customer-controlled CI access">
-    Configure GitHub Actions OIDC or CodeBuild. Restrict the deployment role to
-    the exact repository, branch/environment, ECR repository, ECS services,
-    task roles, log groups, and approved infrastructure stacks. Restrict
-    `iam:PassRole` to the named ECS execution and task roles.
-  </Step>
+<Step title="Establish customer-controlled CI access">
+Configure GitHub Actions OIDC or CodeBuild. Restrict the deployment role to
+the exact repository, branch/environment, ECR repository, ECS services,
+task roles, log groups, and approved infrastructure stacks. Restrict
+`iam:PassRole` to the named ECS execution and task roles.
+</Step>
 
-  <Step title="Provision infrastructure as code">
-    Use the customer's approved Terraform, CloudFormation, CDK, or platform
-    catalog. Keep environment values outside application source. Review the
-    generated plan or change set before applying it.
+<Step title="Provision infrastructure as code">
+Use the customer's approved Terraform, CloudFormation, CDK, or platform
+catalog. Keep environment values outside application source. Review the
+generated plan or change set before applying it.
 
-    Required network flows are:
+Required network flows are:
 
-    ```text
-    Internet/edge -> ALB: HTTPS only
-    ALB -> web tasks: application port only
-    app/worker/scheduler/migration -> RDS: 5432 by security-group reference
-    app/worker/scheduler -> Redis: TLS port by security-group reference
-    runtime -> S3/Secrets/ECR/CloudWatch: VPC endpoints or approved egress
-    runtime -> OIDC/model/customer APIs: explicit approved HTTPS destinations
-    ```
-  </Step>
+```text
+Internet/edge -> ALB: HTTPS only
+ALB -> web tasks: application port only
+app/worker/scheduler/migration -> RDS: 5432 by security-group reference
+app/worker/scheduler -> Redis: TLS port by security-group reference
+runtime -> S3/Secrets/ECR/CloudWatch: VPC endpoints or approved egress
+runtime -> OIDC/model/customer APIs: explicit approved HTTPS destinations
+```
+</Step>
 
-  <Step title="Build and push one immutable image">
-    Build from the reviewed commit in CI, not on a production host:
+<Step title="Build and push one immutable image">
+Build from the reviewed commit in CI, not on a production host:
 
-    ```bash
-    export AWS_REGION=<REGION>
-    export AWS_ACCOUNT_ID=<ACCOUNT_ID>
-    export ECR_REPOSITORY=overlay-web
-    export GIT_SHA="$(git rev-parse HEAD)"
-    export IMAGE="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY:$GIT_SHA"
+```bash
+export AWS_REGION=<REGION>
+export AWS_ACCOUNT_ID=<ACCOUNT_ID>
+export ECR_REPOSITORY=overlay-web
+export GIT_SHA="$(git rev-parse HEAD)"
+export IMAGE="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY:$GIT_SHA"
 
-    aws ecr get-login-password --region "$AWS_REGION" | \
-      docker login --username AWS --password-stdin \
-      "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
+aws ecr get-login-password --region "$AWS_REGION" | \
+  docker login --username AWS --password-stdin \
+  "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
 
-    docker buildx build \
-      --platform linux/amd64 \
-      --file Dockerfile.enterprise-runtime \
-      --tag "$IMAGE" \
-      --push .
+docker buildx build \
+  --platform linux/amd64 \
+  --file Dockerfile.enterprise-runtime \
+  --tag "$IMAGE" \
+  --push .
 
-    export IMAGE_DIGEST="$(aws ecr describe-images \
-      --repository-name "$ECR_REPOSITORY" \
-      --image-ids imageTag="$GIT_SHA" \
-      --query 'imageDetails[0].imageDigest' \
-      --output text)"
+export IMAGE_DIGEST="$(aws ecr describe-images \
+  --repository-name "$ECR_REPOSITORY" \
+  --image-ids imageTag="$GIT_SHA" \
+  --query 'imageDetails[0].imageDigest' \
+  --output text)"
 
-    test -n "$IMAGE_DIGEST" && test "$IMAGE_DIGEST" != None
-    printf 'Release %s -> %s@%s\n' "$GIT_SHA" "$ECR_REPOSITORY" "$IMAGE_DIGEST"
-    ```
+test -n "$IMAGE_DIGEST" && test "$IMAGE_DIGEST" != None
+printf 'Release %s -> %s@%s\n' "$GIT_SHA" "$ECR_REPOSITORY" "$IMAGE_DIGEST"
+```
 
-    Record the digest and use `repository@sha256:...` in every task definition.
-    Do not rebuild the image between staging and production.
-  </Step>
+Record the digest and use `repository@sha256:...` in every task definition.
+Do not rebuild the image between staging and production.
+</Step>
 
-  <Step title="Define the four ECS roles">
-    All task definitions use the same image digest and configuration family:
+<Step title="Define the four ECS roles">
+All task definitions use the same image digest and configuration family:
 
-    | Role | Command | Scaling |
-    | --- | --- | --- |
-    | Web | `node server.js` | At least two tasks behind the ALB. |
-    | Worker | `node dist/app-data-worker.cjs --mode=worker` | At least two tasks. |
-    | Scheduler | `node dist/app-data-worker.cjs --mode=scheduler` | One task initially. Test two before pilot qualification. |
-    | Migration | See the command below | One-off task only; never an ECS service. |
+| Role | Command | Scaling |
+| --- | --- | --- |
+| Web | `node server.js` | At least two tasks behind the ALB. |
+| Worker | `node dist/app-data-worker.cjs --mode=worker` | At least two tasks. |
+| Scheduler | `node dist/app-data-worker.cjs --mode=scheduler` | One task initially. Test two before pilot qualification. |
+| Migration | See the command below | One-off task only; never an ECS service. |
 
-    Migration command:
+Migration command:
 
-    ```bash
-    NODE_OPTIONS=--conditions=react-server node_modules/.bin/tsx scripts/app-data-migrate.ts && \
-    NODE_OPTIONS=--conditions=react-server node_modules/.bin/tsx scripts/better-auth-migrate.ts
-    ```
+```bash
+NODE_OPTIONS=--conditions=react-server node_modules/.bin/tsx scripts/app-data-migrate.ts && \
+NODE_OPTIONS=--conditions=react-server node_modules/.bin/tsx scripts/better-auth-migrate.ts
+```
 
-    Configure health checks, log groups, CPU/memory, graceful stop time, read-only
-    filesystem exceptions, database pool budgets, and secret ARN references per role.
-  </Step>
+Configure health checks, log groups, CPU/memory, graceful stop time, read-only
+filesystem exceptions, database pool budgets, and secret ARN references per role.
+</Step>
 
-  <Step title="Snapshot and run migrations once">
-    Record the current image digest, task-definition revisions, schema version,
-    and a pre-deploy RDS snapshot. Quiesce background services when the release
-    notes require it.
+<Step title="Snapshot and run migrations once">
+Record the current image digest, task-definition revisions, schema version,
+and a pre-deploy RDS snapshot. Quiesce background services when the release
+notes require it.
 
-    Run the migration task in the private ECS subnets with the direct RDS writer
-    endpoint and `OVERLAY_DATABASE_SSL_MODE=verify-full`. Wait for the task to
-    stop, inspect its exit code, and retain its redacted logs. Do not deploy the
-    services when the migration exit code is nonzero or schema compatibility fails.
-  </Step>
+Run the migration task in the private ECS subnets with the direct RDS writer
+endpoint and `OVERLAY_DATABASE_SSL_MODE=verify-full`. Wait for the task to
+stop, inspect its exit code, and retain its redacted logs. Do not deploy the
+services when the migration exit code is nonzero or schema compatibility fails.
+</Step>
 
-  <Step title="Deploy the same digest to every service">
-    Register new task-definition revisions containing the recorded digest, then
-    update scheduler, worker, and web services. For web rolling deployments use:
+<Step title="Deploy the same digest to every service">
+Register new task-definition revisions containing the recorded digest, then
+update scheduler, worker, and web services. For web rolling deployments use:
 
-    ```text
-    desiredCount: 2 or more
-    minimumHealthyPercent: 100
-    maximumPercent: 200
-    ALB stickiness: disabled
-    ALB idle timeout: at least 60 seconds
-    ```
+```text
+desiredCount: 2 or more
+minimumHealthyPercent: 100
+maximumPercent: 200
+ALB stickiness: disabled
+ALB idle timeout: at least 60 seconds
+```
 
-    Wait for every ECS service to become stable and every ALB target to become
-    healthy. A service must not silently fall back to Convex when a Postgres
-    dependency is unavailable.
-  </Step>
+Wait for every ECS service to become stable and every ALB target to become
+healthy. A service must not silently fall back to Convex when a Postgres
+dependency is unavailable.
+</Step>
 
-  <Step title="Configure DNS, TLS, and OIDC">
-    Point the approved hostname to the ALB or approved edge. Register the exact
-    production values with the OIDC owner:
+<Step title="Configure DNS, TLS, and OIDC">
+Point the approved hostname to the ALB or approved edge. Register the exact
+production values with the OIDC owner:
 
-    ```text
-    Callback: https://<OVERLAY_HOST>/api/better-auth/sso/callback/<PROVIDER_ID>
-    Logout:   https://<OVERLAY_HOST>
-    Origin:   https://<OVERLAY_HOST>
-    ```
+```text
+Callback: https://<OVERLAY_HOST>/api/better-auth/sso/callback/<PROVIDER_ID>
+Logout:   https://<OVERLAY_HOST>
+Origin:   https://<OVERLAY_HOST>
+```
 
-    Set `BETTER_AUTH_URL`, trusted origins, JWT issuer/audience, and JWKS URL to
-    that same HTTPS origin. Store only the public client ID in plaintext config;
-    the client secret remains in Secrets Manager.
-  </Step>
+Set `BETTER_AUTH_URL`, trusted origins, JWT issuer/audience, and JWKS URL to
+that same HTTPS origin. Store only the public client ID in plaintext config;
+the client secret remains in Secrets Manager.
+</Step>
 
-  <Step title="Qualify staging">
-    At minimum verify:
+<Step title="Qualify staging">
+At minimum verify:
 
-    1. `/api/v1/capabilities`, `/api/auth/session`, and the ALB health path.
-    2. OIDC sign-in, refresh, new tab, sign-out, and account deletion.
-    3. Chat create, stream, stop, refresh recovery, rename, and delete across two web tasks.
-    4. Files, notes, projects, memory, knowledge, and citations when enabled.
-    5. Worker lease recovery and scheduler deduplication after task replacement.
-    6. Redis fail-closed behavior and recovery.
-    7. RDS failover and automatic web/worker/scheduler recovery.
-    8. S3 signed URL expiry, ownership checks, deletion, and reconciliation.
-    9. Backup restore to a new database and application connection to the restore.
-    10. CloudWatch alarms and delivery to the named operator.
-    11. No Convex environment variables, browser traffic, server calls, or DNS traffic.
+1. `/api/v1/capabilities`, `/api/auth/session`, and the ALB health path.
+2. OIDC sign-in, refresh, new tab, sign-out, and account deletion.
+3. Chat create, stream, stop, refresh recovery, rename, and delete across two web tasks.
+4. Files, notes, projects, memory, knowledge, and citations when enabled.
+5. Worker lease recovery and scheduler deduplication after task replacement.
+6. Redis fail-closed behavior and recovery.
+7. RDS failover and automatic web/worker/scheduler recovery.
+8. S3 signed URL expiry, ownership checks, deletion, and reconciliation.
+9. Backup restore to a new database and application connection to the restore.
+10. CloudWatch alarms and delivery to the named operator.
+11. No Convex environment variables, browser traffic, server calls, or DNS traffic.
 
-    Keep the test accounts and data disposable. Run destructive contracts only
-    against a separate contract-test database.
-  </Step>
+Keep the test accounts and data disposable. Run destructive contracts only
+against a separate contract-test database.
+</Step>
 </Steps>
 
 ## Rollback

--- a/docs/deploy-operate/docker-ec2.mdx
+++ b/docs/deploy-operate/docker-ec2.mdx
@@ -56,229 +56,229 @@ Use security-group references, not public database endpoints:
 ## Install
 
 <Steps>
-  <Step title="Connect to the EC2 instance">
-    Connect through Session Manager when available. Otherwise use the temporary,
-    IP-restricted SSH rule:
+<Step title="Connect to the EC2 instance">
+Connect through Session Manager when available. Otherwise use the temporary,
+IP-restricted SSH rule:
 
-    ```bash
-    ssh ubuntu@<EC2_PUBLIC_DNS>
-    ```
-  </Step>
+```bash
+ssh ubuntu@<EC2_PUBLIC_DNS>
+```
+</Step>
 
-  <Step title="Install Docker, Git, and PostgreSQL tools">
-    Review the Docker installation script before running it if customer policy
-    requires source inspection.
+<Step title="Install Docker, Git, and PostgreSQL tools">
+Review the Docker installation script before running it if customer policy
+requires source inspection.
 
-    ```bash
-    sudo apt-get update
-    sudo apt-get install -y ca-certificates curl git jq postgresql-client
-    curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
-    less /tmp/get-docker.sh
-    sudo sh /tmp/get-docker.sh
-    sudo usermod -aG docker "$USER"
-    newgrp docker
-    docker version
-    docker compose version
-    ```
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl git jq postgresql-client
+curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+less /tmp/get-docker.sh
+sudo sh /tmp/get-docker.sh
+sudo usermod -aG docker "$USER"
+newgrp docker
+docker version
+docker compose version
+```
 
-    Install the AWS RDS CA bundle for administrative `psql` commands:
+Install the AWS RDS CA bundle for administrative `psql` commands:
 
-    ```bash
-    mkdir -p "$HOME/.postgresql"
-    curl -fsSL \
-      https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
-      -o "$HOME/.postgresql/root.crt"
-    chmod 600 "$HOME/.postgresql/root.crt"
-    ```
-  </Step>
+```bash
+mkdir -p "$HOME/.postgresql"
+curl -fsSL \
+  https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+  -o "$HOME/.postgresql/root.crt"
+chmod 600 "$HOME/.postgresql/root.crt"
+```
+</Step>
 
-  <Step title="Create the two databases with the RDS administrator">
-    Run this once with a temporary administrative connection. The application
-    and Better Auth roles must be separate and must not retain administrative
-    membership. Replace all angle-bracket values before running it.
+<Step title="Create the two databases with the RDS administrator">
+Run this once with a temporary administrative connection. The application
+and Better Auth roles must be separate and must not retain administrative
+membership. Replace all angle-bracket values before running it.
 
-    ```bash
-    export PGHOST='<writer>.rds.amazonaws.com'
-    export PGPORT=5432
-    export PGUSER='<rds-admin-role>'
-    export PGSSLMODE=verify-full
-    export PGSSLROOTCERT="$HOME/.postgresql/root.crt"
-    read -rsp 'RDS admin password: ' PGPASSWORD; echo; export PGPASSWORD
-    read -rsp 'Overlay app password: ' OVERLAY_APP_DB_PASSWORD; echo
-    read -rsp 'Better Auth password: ' OVERLAY_AUTH_DB_PASSWORD; echo
+```bash
+export PGHOST='<writer>.rds.amazonaws.com'
+export PGPORT=5432
+export PGUSER='<rds-admin-role>'
+export PGSSLMODE=verify-full
+export PGSSLROOTCERT="$HOME/.postgresql/root.crt"
+read -rsp 'RDS admin password: ' PGPASSWORD; echo; export PGPASSWORD
+read -rsp 'Overlay app password: ' OVERLAY_APP_DB_PASSWORD; echo
+read -rsp 'Better Auth password: ' OVERLAY_AUTH_DB_PASSWORD; echo
 
-    psql --dbname=postgres -v ON_ERROR_STOP=1 \
-      -v admin_role="$PGUSER" \
-      -v app_password="$OVERLAY_APP_DB_PASSWORD" \
-      -v auth_password="$OVERLAY_AUTH_DB_PASSWORD" <<'SQL'
-    CREATE ROLE overlay_app LOGIN PASSWORD :'app_password';
-    CREATE ROLE overlay_auth LOGIN PASSWORD :'auth_password';
-    GRANT overlay_app TO :"admin_role";
-    GRANT overlay_auth TO :"admin_role";
-    SQL
+psql --dbname=postgres -v ON_ERROR_STOP=1 \
+  -v admin_role="$PGUSER" \
+  -v app_password="$OVERLAY_APP_DB_PASSWORD" \
+  -v auth_password="$OVERLAY_AUTH_DB_PASSWORD" <<'SQL'
+CREATE ROLE overlay_app LOGIN PASSWORD :'app_password';
+CREATE ROLE overlay_auth LOGIN PASSWORD :'auth_password';
+GRANT overlay_app TO :"admin_role";
+GRANT overlay_auth TO :"admin_role";
+SQL
 
-    psql --dbname=postgres -v ON_ERROR_STOP=1 \
-      -c 'CREATE DATABASE overlay_app OWNER overlay_app;'
-    psql --dbname=postgres -v ON_ERROR_STOP=1 \
-      -c 'CREATE DATABASE overlay_auth OWNER overlay_auth;'
+psql --dbname=postgres -v ON_ERROR_STOP=1 \
+  -c 'CREATE DATABASE overlay_app OWNER overlay_app;'
+psql --dbname=postgres -v ON_ERROR_STOP=1 \
+  -c 'CREATE DATABASE overlay_auth OWNER overlay_auth;'
 
-    psql --dbname=overlay_app -v ON_ERROR_STOP=1 \
-      -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+psql --dbname=overlay_app -v ON_ERROR_STOP=1 \
+  -c 'CREATE EXTENSION IF NOT EXISTS vector;'
 
-    psql --dbname=postgres -v ON_ERROR_STOP=1 -v admin_role="$PGUSER" <<'SQL'
-    REVOKE overlay_app FROM :"admin_role";
-    REVOKE overlay_auth FROM :"admin_role";
-    SQL
-    unset PGPASSWORD OVERLAY_APP_DB_PASSWORD OVERLAY_AUTH_DB_PASSWORD
-    ```
+psql --dbname=postgres -v ON_ERROR_STOP=1 -v admin_role="$PGUSER" <<'SQL'
+REVOKE overlay_app FROM :"admin_role";
+REVOKE overlay_auth FROM :"admin_role";
+SQL
+unset PGPASSWORD OVERLAY_APP_DB_PASSWORD OVERLAY_AUTH_DB_PASSWORD
+```
 
-    RDS requires its administrative role to install `pgvector`, even when the
-    narrow sanity profile keeps vector search disabled. The normal migration
-    and runtime commands must use the restricted `overlay_app` role afterward.
-    If roles or databases already exist, inspect them instead of blindly
-    rerunning the creation statements.
-  </Step>
+RDS requires its administrative role to install `pgvector`, even when the
+narrow sanity profile keeps vector search disabled. The normal migration
+and runtime commands must use the restricted `overlay_app` role afterward.
+If roles or databases already exist, inspect them instead of blindly
+rerunning the creation statements.
+</Step>
 
-  <Step title="Clone the approved release">
-    Use the customer-controlled repository when one exists.
+<Step title="Clone the approved release">
+Use the customer-controlled repository when one exists.
 
-    ```bash
-    git clone <CUSTOMER_REPOSITORY_URL> overlay-web
-    cd overlay-web
-    git fetch --tags
-    git checkout --detach <APPROVED_RELEASE_TAG_OR_SHA>
-    git status --short --branch
-    ```
+```bash
+git clone <CUSTOMER_REPOSITORY_URL> overlay-web
+cd overlay-web
+git fetch --tags
+git checkout --detach <APPROVED_RELEASE_TAG_OR_SHA>
+git status --short --branch
+```
 
-    Record the exact commit:
+Record the exact commit:
 
-    ```bash
-    git rev-parse HEAD
-    ```
-  </Step>
+```bash
+git rev-parse HEAD
+```
+</Step>
 
-  <Step title="Create the runtime files">
-    The real environment file is ignored by Git.
+<Step title="Create the runtime files">
+The real environment file is ignored by Git.
 
-    ```bash
-    cp deploy/ec2/.env.example deploy/ec2/.env
-    cp docs/config/ec2-sanity.example.json deploy/ec2/overlay.config.json
-    chmod 600 deploy/ec2/.env
-    ```
+```bash
+cp deploy/ec2/.env.example deploy/ec2/.env
+cp docs/config/ec2-sanity.example.json deploy/ec2/overlay.config.json
+chmod 600 deploy/ec2/.env
+```
 
-    Edit `deploy/ec2/.env` and replace every `replace_me` or `replace-me`
-    value. Generate every Overlay-owned secret independently:
+Edit `deploy/ec2/.env` and replace every `replace_me` or `replace-me`
+value. Generate every Overlay-owned secret independently:
 
-    ```bash
-    openssl rand -hex 32
-    ```
+```bash
+openssl rand -hex 32
+```
 
-    Do not reuse a generated value. Do not paste secret values into chat,
-    tickets, logs, screenshots, Git, or the coding agent's final report.
+Do not reuse a generated value. Do not paste secret values into chat,
+tickets, logs, screenshots, Git, or the coding agent's final report.
 
-    Database passwords containing reserved URL characters must be URL-encoded
-    in `OVERLAY_DATABASE_URL` and `BETTER_AUTH_DATABASE_URL`.
-  </Step>
+Database passwords containing reserved URL characters must be URL-encoded
+in `OVERLAY_DATABASE_URL` and `BETTER_AUTH_DATABASE_URL`.
+</Step>
 
-  <Step title="Configure Google Workspace login">
-    In a customer-controlled Google Cloud project, configure Google Auth Platform
-    with an **Internal** audience and create a **Web application** OAuth client.
-    Register these exact values:
+<Step title="Configure Google Workspace login">
+In a customer-controlled Google Cloud project, configure Google Auth Platform
+with an **Internal** audience and create a **Web application** OAuth client.
+Register these exact values:
 
-    ```text
-    Callback URL:
-    http://localhost:3000/api/better-auth/sso/callback/workspace
+```text
+Callback URL:
+http://localhost:3000/api/better-auth/sso/callback/workspace
 
-    Web origin:
-    http://localhost:3000
-    ```
+Web origin:
+http://localhost:3000
+```
 
-    In `deploy/ec2/.env`, replace `example.edu` with the Workspace domain and
-    set `BETTER_AUTH_CONNECTION_CLIENT_ID` and
-    `BETTER_AUTH_CONNECTION_CLIENT_SECRET`. Keep the connection ID as
-    `workspace` so it matches the callback path.
+In `deploy/ec2/.env`, replace `example.edu` with the Workspace domain and
+set `BETTER_AUTH_CONNECTION_CLIENT_ID` and
+`BETTER_AUTH_CONNECTION_CLIENT_SECRET`. Keep the connection ID as
+`workspace` so it matches the callback path.
 
-    Follow [Google Workspace](/configure/authentication/recipes/google-workspace)
-    for the complete console flow. If Auth0 is the approved broker instead,
-    follow [Auth0](/configure/authentication/recipes/auth0) and use connection ID
-    `auth0`. Cognito, Okta, and Keycloak use [Generic OIDC](/configure/authentication/recipes/generic-oidc).
-  </Step>
+Follow [Google Workspace](/configure/authentication/recipes/google-workspace)
+for the complete console flow. If Auth0 is the approved broker instead,
+follow [Auth0](/configure/authentication/recipes/auth0) and use connection ID
+`auth0`. Cognito, Okta, and Keycloak use [Generic OIDC](/configure/authentication/recipes/generic-oidc).
+</Step>
 
-  <Step title="Validate and pull the release image">
-    Define a short helper for the remaining commands:
+<Step title="Validate and pull the release image">
+Define a short helper for the remaining commands:
 
-    ```bash
-    compose() {
-      docker compose \
-        --env-file deploy/ec2/.env \
-        -f deploy/ec2/docker-compose.yml \
-        "$@"
-    }
+```bash
+compose() {
+  docker compose \
+    --env-file deploy/ec2/.env \
+    -f deploy/ec2/docker-compose.yml \
+    "$@"
+}
 
-    OVERLAY_ENV_FILE=.env \
-    OVERLAY_CONFIG_PATH=./overlay.config.json \
-    compose config --quiet
-    compose pull web worker scheduler migrate
-    ```
+OVERLAY_ENV_FILE=.env \
+OVERLAY_CONFIG_PATH=./overlay.config.json \
+compose config --quiet
+compose pull web worker scheduler migrate
+```
 
-    `OVERLAY_WEB_IMAGE` must name the approved versioned release, such as
-    `ghcr.io/layernorm/overlay-web:0.1.0-rc.1`. Do not use `latest` for a
-    customer qualification run. The web, worker, scheduler, and migration roles
-    all use the same immutable image.
+`OVERLAY_WEB_IMAGE` must name the approved versioned release, such as
+`ghcr.io/layernorm/overlay-web:0.1.0-rc.1`. Do not use `latest` for a
+customer qualification run. The web, worker, scheduler, and migration roles
+all use the same immutable image.
 
-    To build inspected or customized source instead, use the build override:
+To build inspected or customized source instead, use the build override:
 
-    ```bash
-    compose_source() {
-      docker compose \
-        --env-file deploy/ec2/.env \
-        -f deploy/ec2/docker-compose.yml \
-        -f deploy/ec2/docker-compose.build.yml \
-        "$@"
-    }
+```bash
+compose_source() {
+  docker compose \
+    --env-file deploy/ec2/.env \
+    -f deploy/ec2/docker-compose.yml \
+    -f deploy/ec2/docker-compose.build.yml \
+    "$@"
+}
 
-    compose_source build web
-    ```
+compose_source build web
+```
 
-    Continue with `compose_source` instead of `compose` for the remaining steps
-    when using a source build. The override builds the tested enterprise runtime,
-    including the web server, worker, scheduler, and migration tooling.
-  </Step>
+Continue with `compose_source` instead of `compose` for the remaining steps
+when using a source build. The override builds the tested enterprise runtime,
+including the web server, worker, scheduler, and migration tooling.
+</Step>
 
-  <Step title="Run migrations once">
-    Migrations must complete before any long-running service starts:
+<Step title="Run migrations once">
+Migrations must complete before any long-running service starts:
 
-    ```bash
-    compose --profile tools run --rm migrate
-    ```
+```bash
+compose --profile tools run --rm migrate
+```
 
-    The command must exit with status `0` and report that both app-data and
-    Better Auth migrations are current. Do not run migrations from every web,
-    worker, or scheduler container.
-  </Step>
+The command must exit with status `0` and report that both app-data and
+Better Auth migrations are current. Do not run migrations from every web,
+worker, or scheduler container.
+</Step>
 
-  <Step title="Start web, worker, and scheduler">
-    ```bash
-    compose up -d web worker scheduler
-    compose ps
-    compose logs --tail=100 web worker scheduler
-    ```
+<Step title="Start web, worker, and scheduler">
+```bash
+compose up -d web worker scheduler
+compose ps
+compose logs --tail=100 web worker scheduler
+```
 
-    Wait for `web` to become healthy. Worker and scheduler logs should show a
-    successful schema check and regular runtime activity without restart loops.
-  </Step>
+Wait for `web` to become healthy. Worker and scheduler logs should show a
+successful schema check and regular runtime activity without restart loops.
+</Step>
 
-  <Step title="Open the SSH tunnel">
-    From the operator's computer, open a second terminal:
+<Step title="Open the SSH tunnel">
+From the operator's computer, open a second terminal:
 
-    ```bash
-    ssh -N -L 3000:127.0.0.1:3000 ubuntu@<EC2_PUBLIC_DNS>
-    ```
+```bash
+ssh -N -L 3000:127.0.0.1:3000 ubuntu@<EC2_PUBLIC_DNS>
+```
 
-    Keep that terminal open and visit
-    [http://localhost:3000](http://localhost:3000). The browser and IdP see a
-    localhost origin while the application runs inside the customer VPC.
-  </Step>
+Keep that terminal open and visit
+[http://localhost:3000](http://localhost:3000). The browser and IdP see a
+localhost origin while the application runs inside the customer VPC.
+</Step>
 </Steps>
 
 ## Verify the sanity check


### PR DESCRIPTION
## Summary
- normalize Markdown inside Mintlify Steps components
- render fenced commands correctly in the EC2 sanity-check guide
- apply the same correction to the full AWS deployment guide

## Verification
- npm run docs:health
- Mintlify build validation
- Mintlify broken-links --check-anchors