### PR TITLE
FIX: preserve Mintlify CSP on docs host

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,8 +22,11 @@ const PUBLIC_ROUTES = [
   '/api/checkout/verify',
 ]
 
-function isDocsProxyRoute(pathname: string): boolean {
+function isDocsProxyRequest(request: NextRequest): boolean {
+  const { hostname, pathname } = request.nextUrl
+
   return (
+    hostname.toLowerCase() === 'docs.getoverlay.io' ||
     pathname === '/docs' ||
     pathname.startsWith('/docs/') ||
     pathname.startsWith('/_mintlify/') ||
@@ -183,7 +186,7 @@ function applyBrowserSecurityHeaders(
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  if (isDocsProxyRoute(pathname)) {
+  if (isDocsProxyRequest(request)) {
     return NextResponse.next()
   }
 


### PR DESCRIPTION
## Root cause
Overlay middleware applied the app CSP to host-based Mintlify rewrites on docs.getoverlay.io. Mintlify uses client-side evaluation for MDX hydration, so the page rendered initially and then crashed because unsafe-eval was blocked.

## Fix
- recognize docs.getoverlay.io as a docs proxy request
- bypass Overlay browser CSP for that host
- preserve Mintlify's upstream CSP, matching the existing /docs proxy behavior

## Verification
- targeted ESLint passes
- live preview will be checked for CSP headers and post-hydration stability