### PR TITLE
FIX: redirect docs host through CSP-safe proxy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -45,6 +45,38 @@ const nextConfig: NextConfig = {
   distDir: process.env.NEXT_DIST_DIR?.trim() || ".next",
   output: process.env.NEXT_OUTPUT_MODE?.trim() === "standalone" ? "standalone" : undefined,
   transpilePackages: ["@overlay/app-core"],
+  async redirects() {
+    if (!mintlifyDocsOrigin) return [];
+
+    const docsHost = [{ type: "host" as const, value: "docs.getoverlay.io" }];
+
+    return [
+      {
+        source: "/mintlify-assets/:path*",
+        has: docsHost,
+        destination: "https://www.getoverlay.io/mintlify-assets/:path*",
+        permanent: false,
+      },
+      {
+        source: "/_mintlify/:path*",
+        has: docsHost,
+        destination: "https://www.getoverlay.io/_mintlify/:path*",
+        permanent: false,
+      },
+      {
+        source: "/api/request",
+        has: docsHost,
+        destination: "https://www.getoverlay.io/api/request",
+        permanent: false,
+      },
+      {
+        source: "/:match*",
+        has: docsHost,
+        destination: "https://www.getoverlay.io/docs/:match*",
+        permanent: false,
+      },
+    ];
+  },
   async rewrites() {
     const rewrites: Array<{
       source: string;
@@ -93,16 +125,6 @@ const nextConfig: NextConfig = {
         {
           source: "/mintlify-assets/:path*",
           destination: `${mintlifyDocsOrigin}/mintlify-assets/:path*`,
-        },
-        {
-          source: "/",
-          has: [{ type: "host", value: "docs.getoverlay.io" }],
-          destination: mintlifyDocsOrigin,
-        },
-        {
-          source: "/:match*",
-          has: [{ type: "host", value: "docs.getoverlay.io" }],
-          destination: `${mintlifyDocsOrigin}/:match*`,
         },
       );
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,11 +22,8 @@ const PUBLIC_ROUTES = [
   '/api/checkout/verify',
 ]
 
-function isDocsProxyRequest(request: NextRequest): boolean {
-  const { hostname, pathname } = request.nextUrl
-
+function isDocsProxyRoute(pathname: string): boolean {
   return (
-    hostname.toLowerCase() === 'docs.getoverlay.io' ||
     pathname === '/docs' ||
     pathname.startsWith('/docs/') ||
     pathname.startsWith('/_mintlify/') ||
@@ -186,7 +183,7 @@ function applyBrowserSecurityHeaders(
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  if (isDocsProxyRequest(request)) {
+  if (isDocsProxyRoute(pathname)) {
     return NextResponse.next()
   }
 


### PR DESCRIPTION
## Root cause
Vercel normalizes the custom hostname before Next middleware, so middleware could not reliably exempt docs.getoverlay.io from Overlay's CSP. Mintlify hydrated with unsafe-eval blocked and replaced the rendered page with Error 500.

## Fix
- redirect docs.getoverlay.io pages to the working www.getoverlay.io/docs proxy at the Next routing layer
- preserve dedicated redirects for Mintlify assets and request endpoints
- remove the ineffective middleware hostname check and host rewrites

## Verification
- targeted ESLint passed
- full local typecheck was attempted but the shared node_modules checkout lacks current on-prem dependencies; CI/Vercel performs the authoritative clean install and build
- after merge, verify redirect, CSP, and post-hydration browser state