### PR TITLE
Fix Mintlify docs subpath proxy

### DIFF
--- a/docs/deploy-operate/docs-hosting.mdx
+++ b/docs/deploy-operate/docs-hosting.mdx
@@ -10,26 +10,20 @@ Overlay docs are authored in `docs/` and hosted by Mintlify. The production web 
 `next.config.ts` reads this build-time environment variable:
 
 ```bash
-MINTLIFY_DOCS_URL=https://your-subdomain.mintlify.site
+MINTLIFY_DOCS_URL=https://your-subdomain.mintlify.dev
 ```
 
-Do not include a trailing slash. If the value ends in `/docs`, the app normalizes it to the origin.
+Do not include a trailing slash or `/docs`; the app adds the required `/docs`
+upstream path.
 
 When `MINTLIFY_DOCS_URL` is set, the app adds these routes:
 
 | Public URL | Upstream |
 | --- | --- |
-| `https://getoverlay.io/docs` | `${MINTLIFY_DOCS_URL}` |
-| `https://getoverlay.io/docs/*` | `${MINTLIFY_DOCS_URL}/*` |
-| `https://getoverlay.io/_mintlify/*` | `${MINTLIFY_DOCS_URL}/_mintlify/*` |
-| `https://getoverlay.io/api/request` | `${MINTLIFY_DOCS_URL}/_mintlify/api/request` |
-| `https://getoverlay.io/docs/llms.txt` | `${MINTLIFY_DOCS_URL}/llms.txt` |
-| `https://getoverlay.io/docs/llms-full.txt` | `${MINTLIFY_DOCS_URL}/llms-full.txt` |
-| `https://getoverlay.io/docs/sitemap.xml` | `${MINTLIFY_DOCS_URL}/sitemap.xml` |
-| `https://getoverlay.io/docs/robots.txt` | `${MINTLIFY_DOCS_URL}/robots.txt` |
-| `https://getoverlay.io/docs/mcp` | `${MINTLIFY_DOCS_URL}/mcp` |
-| `https://getoverlay.io/mintlify-assets/*` | `${MINTLIFY_DOCS_URL}/mintlify-assets/*` |
-| `https://docs.getoverlay.io/*` | `${MINTLIFY_DOCS_URL}/*` |
+| `https://getoverlay.io/docs` | `${MINTLIFY_DOCS_URL}/docs` |
+| `https://getoverlay.io/docs/*` | `${MINTLIFY_DOCS_URL}/docs/*` |
+| `https://getoverlay.io/.well-known/vercel/*` | `${MINTLIFY_DOCS_URL}/.well-known/vercel/*` |
+| `https://docs.getoverlay.io/*` | Redirect to `https://www.getoverlay.io/docs/*` |
 
 ## Mintlify Setup
 
@@ -37,8 +31,11 @@ In Mintlify:
 
 1. Connect the Git repository.
 2. Set the docs content directory to `docs/`.
-3. Configure the docs project for `/docs` subpath hosting on `getoverlay.io`.
-4. Keep the public docs source in `docs/`; internal reports and design assets stay in `internal-docs/`.
+3. Enable **Host at `/docs`** in Mintlify for `getoverlay.io`.
+4. Use the project's `*.mintlify.dev` URL for `MINTLIFY_DOCS_URL`. The
+   `*.mintlify.app` URL is for root/custom-subpath proxies and will generate
+   incorrect root-relative navigation links in this setup.
+5. Keep the public docs source in `docs/`; internal reports and design assets stay in `internal-docs/`.
 
 ## Vercel Setup
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,7 +11,7 @@ const hasSentryUploadConfig = Boolean(
   process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT,
 );
 
-const mintlifyDocsOrigin = process.env.MINTLIFY_DOCS_URL?.trim().replace(/\/+$/, "").replace(/\/docs$/, "");
+const mintlifyDocsOrigin = process.env.MINTLIFY_DOCS_URL?.trim().replace(/\/+$/, "");
 
 const staticSecurityHeaders = [
   {
@@ -52,27 +52,21 @@ const nextConfig: NextConfig = {
 
     return [
       {
-        source: "/mintlify-assets/:path*",
+        source: "/docs",
         has: docsHost,
-        destination: "https://www.getoverlay.io/mintlify-assets/:path*",
+        destination: "https://www.getoverlay.io/docs",
         permanent: false,
       },
       {
-        source: "/_mintlify/:path*",
+        source: "/docs/:path*",
         has: docsHost,
-        destination: "https://www.getoverlay.io/_mintlify/:path*",
+        destination: "https://www.getoverlay.io/docs/:path*",
         permanent: false,
       },
       {
-        source: "/api/request",
+        source: "/:path*",
         has: docsHost,
-        destination: "https://www.getoverlay.io/api/request",
-        permanent: false,
-      },
-      {
-        source: "/:match*",
-        has: docsHost,
-        destination: "https://www.getoverlay.io/docs/:match*",
+        destination: "https://www.getoverlay.io/docs/:path*",
         permanent: false,
       },
     ];
@@ -87,44 +81,16 @@ const nextConfig: NextConfig = {
     if (mintlifyDocsOrigin) {
       rewrites.push(
         {
-          source: "/_mintlify/:path*",
-          destination: `${mintlifyDocsOrigin}/_mintlify/:path*`,
-        },
-        {
-          source: "/api/request",
-          destination: `${mintlifyDocsOrigin}/_mintlify/api/request`,
-        },
-        {
-          source: "/docs/llms.txt",
-          destination: `${mintlifyDocsOrigin}/llms.txt`,
-        },
-        {
-          source: "/docs/llms-full.txt",
-          destination: `${mintlifyDocsOrigin}/llms-full.txt`,
-        },
-        {
-          source: "/docs/sitemap.xml",
-          destination: `${mintlifyDocsOrigin}/sitemap.xml`,
-        },
-        {
-          source: "/docs/robots.txt",
-          destination: `${mintlifyDocsOrigin}/robots.txt`,
-        },
-        {
-          source: "/docs/mcp",
-          destination: `${mintlifyDocsOrigin}/mcp`,
+          source: "/.well-known/vercel/:path*",
+          destination: `${mintlifyDocsOrigin}/.well-known/vercel/:path*`,
         },
         {
           source: "/docs",
-          destination: mintlifyDocsOrigin,
+          destination: `${mintlifyDocsOrigin}/docs`,
         },
         {
           source: "/docs/:match*",
-          destination: `${mintlifyDocsOrigin}/:match*`,
-        },
-        {
-          source: "/mintlify-assets/:path*",
-          destination: `${mintlifyDocsOrigin}/mintlify-assets/:path*`,
+          destination: `${mintlifyDocsOrigin}/docs/:match*`,
         },
       );
     }


### PR DESCRIPTION
## Summary
- Proxy the docs path to the Mintlify dev upstream required by Host at docs.
- Make getoverlay.io/docs canonical and redirect the legacy docs subdomain.
- Update operator documentation for the correct Mintlify configuration.

## Verification
- npm run docs:health
- Inspected generated rewrite and redirect configuration.
- Verified the upstream emits docs-prefixed navigation and asset URLs.