### PR TITLE
docs: audit public setup and deployment guides

### DIFF
--- a/docs/configure/environment.mdx
+++ b/docs/configure/environment.mdx
@@ -13,7 +13,7 @@ Environment variables override `overlay.config.json`. Put secrets in the runtime
 | `NEXT_PUBLIC_CONVEX_URL` | App talks to Convex | Public Convex deployment URL for the selected environment. |
 | `DEV_NEXT_PUBLIC_CONVEX_URL` | Local dev with separate dev backend | Preferred for local work against the development Convex deployment. |
 | `OVERLAY_CONFIG_FILE` | JSON runtime config | Absolute or repo-relative path, usually `overlay.config.json`; Docker mounts it at `/app/overlay.config.json`. |
-| `INTERNAL_API_SECRET` | Always | Shared app-to-Convex secret. The matching Convex deployment must have the same value. |
+| `INTERNAL_API_SECRET` | Convex app-data provider | Shared app-to-Convex secret. It is not required by a Postgres-only deployment. |
 | `INTERNAL_SERVICE_AUTH_SECRET` | App runtime only | Internal service auth secret. Do not put this in Convex. |
 | `SESSION_SECRET` | Cookie sessions | Long, random, environment-specific app secret. |
 | `SESSION_TRANSFER_KEY` | Native/session transfer flows | App runtime only. |
@@ -25,7 +25,7 @@ Environment variables override `overlay.config.json`. Put secrets in the runtime
 | Provider family | Variables |
 | --- | --- |
 | WorkOS auth | `WORKOS_CLIENT_ID`, `WORKOS_API_KEY`; dev fallback uses `DEV_WORKOS_CLIENT_ID`, `DEV_WORKOS_API_KEY`. |
-| Better Auth | `BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_DATABASE_URL`, optional `BETTER_AUTH_DEFAULT_SSO_*`, `BETTER_AUTH_OIDC_*`, `BETTER_AUTH_JWT_*`, and `BETTER_AUTH_JWKS_URL`. |
+| Better Auth | `BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_DATABASE_URL`, `BETTER_AUTH_JWT_ISSUER`, `BETTER_AUTH_JWT_AUDIENCE`, `BETTER_AUTH_JWKS_URL`, and one connection registry using `BETTER_AUTH_CONNECTION_ID`, `BETTER_AUTH_CONNECTION_PRESET`, `BETTER_AUTH_CONNECTION_LABEL`, `BETTER_AUTH_CONNECTION_DOMAINS`, and the applicable connection client/issuer variables. See [Authentication](/configure/authentication/index). Legacy `BETTER_AUTH_DEFAULT_SSO_*` and `BETTER_AUTH_OIDC_*` variables exist for migration compatibility but must not be mixed with the connection registry. |
 | OIDC auth | `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_AUDIENCE`. Use these variables for Keycloak-compatible realm issuers too. |
 | Stripe billing | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PAID_UNIT_PRICE_ID`, `STRIPE_TOPUP_UNIT_PRICE_ID`, `STRIPE_PORTAL_CONFIGURATION_ID`; dev fallback uses `DEV_STRIPE_SECRET_KEY`, `DEV_STRIPE_WEBHOOK_SECRET`. |
 | R2 storage | `R2_ACCOUNT_ID`, `R2_BUCKET_NAME`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `S3_API`. |
@@ -57,9 +57,10 @@ OVERLAY_PROVIDER_ANALYTICS=none
 OVERLAY_PROVIDER_ERROR_REPORTING=none
 ```
 
-## Convex Placement
+## Backend-specific placement
 
-Convex needs only the secrets used by Convex functions. For the normal web path, configure:
+When the app-data provider is Convex, Convex needs only the secrets used by
+Convex functions. Configure:
 
 - `INTERNAL_API_SECRET`, matching the app runtime.
 
@@ -77,3 +78,9 @@ npm run convex:push:all
 ```
 
 Do not pass `.env.local` to production Convex deploy commands; use the package scripts so production and development deployments receive the right environment.
+
+When the app-data provider is Postgres, omit `NEXT_PUBLIC_CONVEX_URL`,
+`DEV_NEXT_PUBLIC_CONVEX_URL`, `CONVEX_DEPLOYMENT`, and `INTERNAL_API_SECRET`.
+Use `OVERLAY_DATABASE_URL` for application data and
+`BETTER_AUTH_DATABASE_URL` for Better Auth. They must use separate databases,
+roles, and migration lifecycles.

--- a/docs/configure/providers.mdx
+++ b/docs/configure/providers.mdx
@@ -11,7 +11,7 @@ Use `none` plus the matching feature flag when a provider family must be disable
 
 | Purpose | Values | Current support |
 | --- | --- | --- |
-| Auth | `workos`, `better-auth`, `oidc`, `none` | `workos` is the hosted default. `better-auth` owns the web session, supports SSO through Better Auth, and issues JWKS-verifiable service JWTs for Convex. `oidc` remains a low-level bearer/access-token verifier for deployment-specific browser wiring. |
+| Auth | `workos`, `better-auth`, `oidc`, `none` | `workos` is the hosted default. `better-auth` owns the web session and supports provider-driven enterprise SSO independently of the selected app-data backend. Postgres mode does not require Convex. `oidc` remains a low-level bearer/access-token verifier for deployment-specific browser wiring. |
 | Billing | `stripe`, `none` | `stripe` supports subscriptions, top-ups, portal sessions, and webhooks. Use `none` for private deployments. |
 | Object storage | `r2`, `s3`, `none` | `r2` is the hosted default. `s3` covers AWS S3 and compatible enterprise object stores. Keep compatible stores under `s3`; set `storage.s3.forcePathStyle=true` only when required. |
 | Models | `openrouter`, `ai-gateway`, `openai`, `anthropic`, `groq`, `none` | All listed model providers have active routing paths except `none`, which intentionally disables generation. |

--- a/docs/deploy-operate/aws.mdx
+++ b/docs/deploy-operate/aws.mdx
@@ -112,14 +112,22 @@ value, build log, document, ticket, email, or chat.
 
 <Steps>
 <Step title="Prepare the customer repository">
-Create a customer-controlled private repository. Import the approved Overlay
-release and retain `layernorm/overlay-web` as the upstream remote.
+Fork or mirror the public
+[LayerNorm/overlay-web](https://github.com/LayerNorm/overlay-web) repository into
+the customer's GitHub organization. Clone that customer-controlled repository,
+retain the public repository as `upstream`, and branch from an approved
+published release. The example defaults to the tested `v0.1.0-rc.1` release.
 
 ```bash
+export CUSTOMER_REPOSITORY_URL="https://github.com/<CUSTOMER_ORGANIZATION>/<CUSTOMER_REPOSITORY>.git"
+export OVERLAY_RELEASE="${OVERLAY_RELEASE:-v0.1.0-rc.1}"
+
+git clone "$CUSTOMER_REPOSITORY_URL" overlay-web
+cd overlay-web
 git remote add upstream https://github.com/layernorm/overlay-web.git
-git fetch upstream --tags
-git checkout -b release/overlay-<VERSION>-customer.1 <APPROVED_TAG>
-git push -u origin release/overlay-<VERSION>-customer.1
+git fetch upstream --tags --force
+git checkout -b "release/${OVERLAY_RELEASE#v}-customer.1" "$OVERLAY_RELEASE"
+git push -u origin "release/${OVERLAY_RELEASE#v}-customer.1"
 ```
 
 Merge only through a reviewed pull request with required checks.

--- a/docs/deploy-operate/docker-ec2.mdx
+++ b/docs/deploy-operate/docker-ec2.mdx
@@ -140,21 +140,32 @@ rerunning the creation statements.
 </Step>
 
 <Step title="Clone the approved release">
-Use the customer-controlled repository when one exists.
+Clone the public repository for the initial sanity check. If your organization
+maintains an approved private mirror, set `OVERLAY_REPOSITORY_URL` to that
+mirror instead. The commands below default to the tested `v0.1.0-rc.1`
+release; change `OVERLAY_RELEASE` only when you have approved another published
+release.
 
 ```bash
-git clone <CUSTOMER_REPOSITORY_URL> overlay-web
+export OVERLAY_REPOSITORY_URL="${OVERLAY_REPOSITORY_URL:-https://github.com/LayerNorm/overlay-web.git}"
+export OVERLAY_RELEASE="${OVERLAY_RELEASE:-v0.1.0-rc.1}"
+
+git clone "$OVERLAY_REPOSITORY_URL" overlay-web
 cd overlay-web
-git fetch --tags
-git checkout --detach <APPROVED_RELEASE_TAG_OR_SHA>
+git fetch --tags --force
+git checkout --detach "$OVERLAY_RELEASE"
 git status --short --branch
 ```
 
-Record the exact commit:
+Record the exact commit and tag:
 
 ```bash
 git rev-parse HEAD
+git tag --points-at HEAD
 ```
+
+Published releases are listed at
+[github.com/LayerNorm/overlay-web/releases](https://github.com/LayerNorm/overlay-web/releases).
 </Step>
 
 <Step title="Create the runtime files">

--- a/docs/deploy-operate/enterprise-admin-onboarding.mdx
+++ b/docs/deploy-operate/enterprise-admin-onboarding.mdx
@@ -10,10 +10,17 @@ This guide is for the first administrator of an enterprise or managed-cloud Over
 The first admin is normally granted by the deployment operator or by the [One-Command Install](./one-command-install) bootstrap script. If you need to grant it manually, use the admin helper:
 
 ```bash
-npx tsx scripts/app-db-admin.ts grant --userId=user_123 --role=admin --reason="Initial enterprise admin"
+OVERLAY_DATABASE_URL='postgresql://overlay_app:password@database.example.com:5432/overlay_app' \
+OVERLAY_DATABASE_SSL_MODE=verify-full \
+npm run app-db:admin -- grant \
+  --user-id user_123 \
+  --role admin \
+  --reason "Initial enterprise admin"
 ```
 
 This creates an `administrative_principal` record and records the grant in the audit log.
+Run the command from the checked-out release with the application database
+role. Do not use the Better Auth database URL or an RDS administrator role.
 
 ## Grant and revoke principals
 

--- a/docs/deploy-operate/enterprise-source-install.mdx
+++ b/docs/deploy-operate/enterprise-source-install.mdx
@@ -12,7 +12,9 @@ For the fastest pilot path without source checkout, use [One-Command Install](/d
 - Git.
 - Docker with the Compose v2 plugin.
 - Access to the Overlay source repository or customer fork.
-- A Convex deployment URL and matching `INTERNAL_API_SECRET` for the selected environment.
+- A supported app-data backend: Postgres for self-hosted deployments, or Convex
+  only when it is explicitly selected.
+- A separate Postgres database for Better Auth when Better Auth is selected.
 - Enterprise provider credentials for the providers you enable, such as OIDC, S3-compatible storage, and a model provider.
 
 ## Install From Source
@@ -33,7 +35,16 @@ docker compose ps
 docker compose logs -f overlay-web
 ```
 
-By default, `docker compose up -d` pulls `ghcr.io/layernorm/overlay-web:latest`. This keeps first boot fast and avoids compiling the app on the customer's server.
+By default, `docker compose up -d` pulls `ghcr.io/layernorm/overlay-web:latest`.
+Use that moving tag only for exploration. For qualification or production, set
+an immutable release in `.env`, for example:
+
+```bash
+OVERLAY_WEB_IMAGE=ghcr.io/layernorm/overlay-web:0.1.0-rc.1
+```
+
+For the current end-to-end Postgres and Better Auth procedure, use
+[Docker on EC2](/deploy-operate/docker-ec2).
 
 ## What The Repo Provides
 
@@ -127,4 +138,4 @@ docker compose up -d
 | Port `3000` is already in use | Change `OVERLAY_HTTP_PORT` in `.env`, then run `docker compose up -d`. |
 | Config edits do not appear | Confirm `overlay.config.json` exists at the repo root and restart with `docker compose up -d`. |
 | Source build fills disk | Run the default image path unless code was edited; source builds create dependency, Next.js, and Docker cache layers. |
-| App starts but cannot load data | Check `NEXT_PUBLIC_CONVEX_URL` and ensure the same `INTERNAL_API_SECRET` is configured in the app env and Convex deployment. |
+| App starts but cannot load data | Check `/api/v1/capabilities`, then verify the selected database provider and its credentials. In Postgres mode, check `OVERLAY_DATABASE_URL`, schema migrations, TLS, and database reachability. In Convex mode, check `NEXT_PUBLIC_CONVEX_URL` and the matching `INTERNAL_API_SECRET`. |

--- a/docs/deploy-operate/self-hosting.mdx
+++ b/docs/deploy-operate/self-hosting.mdx
@@ -56,7 +56,7 @@ Minimum app runtime variables:
 | `OVERLAY_CONFIG_FILE` | Using a JSON runtime config | Absolute or repo-relative path, for example `overlay.config.json`. |
 | `NEXT_PUBLIC_APP_URL` | Always in deployed environments | Public browser URL for the web app. |
 | `NEXT_PUBLIC_CONVEX_URL` | Browser or server talks to Convex | Public Convex deployment URL for the selected environment. Use `DEV_NEXT_PUBLIC_CONVEX_URL` for local dev against a separate dev deployment. |
-| `INTERNAL_API_SECRET` | Always | Shared server-to-Convex secret. The same value must be configured in the matching Convex deployment. |
+| `INTERNAL_API_SECRET` | `database.provider="convex"` | Shared server-to-Convex secret. It is not required by a Postgres-only deployment. |
 | `INTERNAL_SERVICE_AUTH_SECRET` | App runtime only | Used for internal app service auth. Do not put this in Convex. |
 | `SESSION_SECRET` | Cookie sessions | App runtime only. Must be long, random, and environment-specific. |
 | `SESSION_TRANSFER_KEY` | Native/session transfer flows | App runtime only. |
@@ -67,9 +67,9 @@ Provider-specific variables:
 
 | Variable | Provider | Notes |
 | --- | --- | --- |
-| `WORKOS_CLIENT_ID`, `WORKOS_API_KEY` | `auth.provider="workos"` | Use production WorkOS values only with production app and Convex deployments. |
+| `WORKOS_CLIENT_ID`, `WORKOS_API_KEY` | `auth.provider="workos"` | Use production WorkOS values only with the production app-data deployment. |
 | `DEV_WORKOS_CLIENT_ID`, `DEV_WORKOS_API_KEY` | Local or staging WorkOS fallback | Only use when `auth.allowDevFallbacks=true` in non-production. |
-| `BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_DATABASE_URL`, `BETTER_AUTH_DEFAULT_SSO_*`, `BETTER_AUTH_OIDC_*`, `BETTER_AUTH_JWT_*`, `BETTER_AUTH_JWKS_URL` | `auth.provider="better-auth"` | Better Auth owns the web session in Overlay and issues short-lived JWTs for Convex verification through its JWKS endpoint. Keep this database auth-scoped; it does not replace Convex app data. |
+| `BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_DATABASE_URL`, `BETTER_AUTH_CONNECTION_*`, `BETTER_AUTH_JWT_*`, `BETTER_AUTH_JWKS_URL` | `auth.provider="better-auth"` | Better Auth owns the web session and provider-driven SSO. Keep its database auth-scoped and separate from the selected app-data backend. See [Authentication](/configure/authentication/index). |
 | `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_AUDIENCE` | `auth.provider="oidc"` | Verifies RS256 bearer/access tokens against OIDC discovery JWKS and maps standard profile claims. Use these variables for Keycloak-compatible realm issuers too. Browser sign-in/callback wiring is still deployment-specific. |
 | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` | `billing.provider="stripe"` | Required only when billing is enabled. |
 | `DEV_STRIPE_SECRET_KEY`, `DEV_STRIPE_WEBHOOK_SECRET` | Staging Stripe | Preferred for non-production. |
@@ -123,7 +123,7 @@ The normalized shape is:
 | `billing` | Stripe or disabled billing. |
 | `storage` | R2, S3-compatible storage, or no-op object store. |
 | `llm` | Gateway provider, provider key source, default model, and allowlist. |
-| `database` | Convex URL/deployment and internal server secrets. |
+| `database` | Convex or Postgres app-data selection and backend-specific connection settings. |
 | `capabilities` | Feature booleans consumed by browser UI and server route guards. |
 
 Enterprise config v2 adds these top-level sections while keeping all keys above backward compatible:
@@ -174,7 +174,7 @@ Auth providers:
 | Provider | Config | Current status |
 | --- | --- | --- |
 | `workos` | `auth.workos` | Default SaaS path. Production-ready path for current hosted app. |
-| `better-auth` | `auth.betterAuth` | Better Auth web sessions plus SSO and JWKS-backed service JWTs for Convex. Requires an auth-scoped Postgres database and Better Auth migrations before production use. |
+| `better-auth` | `auth.betterAuth` | Better Auth web sessions plus provider-driven SSO and JWKS-backed service JWTs. Requires a separate auth-scoped Postgres database and Better Auth migrations before production use. |
 | `oidc` | `auth.oidc` | Runtime-config OIDC bearer/access-token verification, including Keycloak-compatible realm issuers. Verify browser sign-in/callback wiring for your IdP before production. |
 | `none` | none | Local/on-prem no-op auth. Pair with `capabilities.sso=false`. |
 
@@ -396,7 +396,9 @@ UI hiding is not an authorization boundary. Server routes also check capabilitie
 
 ## Build and Deploy Without Vercel
 
-Overlay is a Next.js app plus Convex. You can run the web process anywhere that can run Node and reach your Convex and object storage endpoints.
+Overlay is a Next.js application with selectable app-data, auth, storage, and
+model providers. You can run the web process anywhere that can run Node.js 22
+and reach the providers selected in `overlay.config.json`.
 
 Basic Node deployment:
 
@@ -406,7 +408,11 @@ npm run build
 OVERLAY_CONFIG_FILE=overlay.config.json npm run start
 ```
 
-Set `NEXT_PUBLIC_APP_URL` and `NEXT_PUBLIC_CONVEX_URL` in the app runtime. If your host injects env vars at runtime, prefer env vars for secrets and keep non-secret provider shape in `overlay.config.json`.
+Set `NEXT_PUBLIC_APP_URL` in the app runtime. Set `NEXT_PUBLIC_CONVEX_URL` only
+when Convex is the selected app-data provider; Postgres mode instead requires
+`OVERLAY_DATABASE_URL`. If your host injects environment variables at runtime,
+use them for secrets and keep non-secret provider shape in
+`overlay.config.json`.
 
 Without Stripe:
 
@@ -449,7 +455,9 @@ With OIDC instead of WorkOS:
 
 Use this path when an enterprise operator wants a source checkout with a plain Compose install. The default Compose file pulls a prebuilt `ghcr.io/layernorm/overlay-web` image; local source builds are opt-in through `docker-compose.build.yml`.
 
-This is a minimal on-prem shape for the app container. It assumes the customer already has S3-compatible object storage and does not include Convex because Convex remains a hosted deployment in the current architecture.
+This is a minimal on-prem shape for the app container. It assumes the customer
+already operates the selected database, auth database, object storage, Redis,
+and other enabled providers. Postgres mode does not include or contact Convex.
 
 Quick start:
 
@@ -503,7 +511,7 @@ App runtime only:
 - R2/S3 access key secrets
 - LLM provider API keys
 
-Convex:
+Convex deployments only:
 
 - `INTERNAL_API_SECRET` must be set in Convex and must match the app runtime value for that deployment.
 - If you intentionally run direct Convex auth/debug paths or Convex Stripe sync actions, also configure the corresponding WorkOS or Stripe variables in that Convex deployment. The BFF-first web path should not require session cookie secrets in Convex.
@@ -511,8 +519,7 @@ Convex:
 Public and safe to expose:
 
 - `NEXT_PUBLIC_APP_URL`
-- `NEXT_PUBLIC_CONVEX_URL`
-- `DEV_NEXT_PUBLIC_CONVEX_URL`
+- `NEXT_PUBLIC_CONVEX_URL` and `DEV_NEXT_PUBLIC_CONVEX_URL` only when Convex is selected
 - `NEXT_PUBLIC_POSTHOG_TOKEN`
 - `NEXT_PUBLIC_POSTHOG_HOST`
 - Public CSP origins in `app.cspConnectSrc`
@@ -535,7 +542,10 @@ Values that must differ between staging and production:
 
 Do not copy production secrets into staging to "make it work". The config schema rejects several mixed staging/production combinations, but secret separation is still an operator responsibility.
 
-## Convex Notes
+## Convex notes
+
+This section applies only when `database.provider="convex"`. Skip it for a
+Postgres-only deployment.
 
 Push Convex schema/function changes to the matching deployment:
 

--- a/docs/help/automations.mdx
+++ b/docs/help/automations.mdx
@@ -26,5 +26,3 @@ Before enabling the schedule, click **Run once** to test the automation. The res
 - View past runs in the automation detail view.
 - Click a run to see outputs and errors.
 - Disable a schedule if the automation is not needed.
-
-[TODO: screenshot of automation editor and run history]

--- a/docs/help/chat.mdx
+++ b/docs/help/chat.mdx
@@ -30,5 +30,3 @@ Drag a file into the input or click the attachment icon. Files are stored in you
 ## Generated UI
 
 Some replies include cards, tables, or action buttons. These are generated from the model and can be run directly.
-
-[TODO: screenshot of chat UI with model selector and attachment icon]

--- a/docs/help/files.mdx
+++ b/docs/help/files.mdx
@@ -23,5 +23,3 @@ description: "How to upload, search, share, and download files in Overlay."
 
 - Click a file to preview or download.
 - Generated images and videos appear in the **Outputs** panel.
-
-[TODO: screenshot of file upload and search]

--- a/docs/help/memory.mdx
+++ b/docs/help/memory.mdx
@@ -29,5 +29,3 @@ Find the section on refund policy in my files.
 ## Privacy
 
 Memories and knowledge are scoped to your account. They are not shared across users unless you explicitly share a project or file.
-
-[TODO: screenshot of memory panel]

--- a/docs/help/projects.mdx
+++ b/docs/help/projects.mdx
@@ -26,5 +26,3 @@ Projects help you group related chats, notes, files, and outputs.
 ## Switch projects
 
 Use the project selector in the sidebar or the project list to switch between projects. Your personal workspace is separate from projects.
-
-[TODO: screenshot of project selector and project view]

--- a/docs/help/settings.mdx
+++ b/docs/help/settings.mdx
@@ -29,5 +29,3 @@ description: "How to manage account, billing, integrations, and preferences in O
 ## SSO
 
 If your workspace uses SSO, sign in through your organization. Contact your admin for access issues.
-
-[TODO: screenshot of settings panel]

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -7,6 +7,15 @@ Overlay Web is the Next.js application that powers the browser experience for Ov
 
 These docs are for developers and self-hosters working with the web app. They cover local setup, runtime configuration, provider wiring, deployment, operational checks, and the stable `/api/v1` web API surface.
 
+<CardGroup cols={2}>
+  <Card title="Source repository" icon="github" href="https://github.com/LayerNorm/overlay-web">
+    Browse, fork, or clone the public Overlay Web repository.
+  </Card>
+  <Card title="Published releases" icon="tag" href="https://github.com/LayerNorm/overlay-web/releases">
+    Use a versioned release for deployment instead of an unpinned branch.
+  </Card>
+</CardGroup>
+
 ## Scope
 
 Included:
@@ -15,7 +24,7 @@ Included:
 - Web route orchestration under `src/server/app-api`.
 - Browser-safe contracts under `src/shared`.
 - Feature containers under `src/features`.
-- Convex workflow where it affects the web app.
+- Convex and Postgres workflows where they affect the web app.
 - Public `/api/v1` request, query, and form schemas.
 
 Excluded:

--- a/docs/start/quickstart.mdx
+++ b/docs/start/quickstart.mdx
@@ -1,12 +1,13 @@
 ---
 title: "Quickstart"
-description: "Run Overlay Web locally against the development Convex backend."
+description: "Clone Overlay Web and run the hosted-development profile locally."
 ---
 
 ## Prerequisites
 
-- Node.js 20 or newer.
-- npm.
+- Git.
+- Node.js 22 or newer.
+- npm 11 or newer.
 - Access to the development Convex deployment.
 - WorkOS credentials for sign-in flows.
 - Stripe test credentials when testing billing.
@@ -18,9 +19,17 @@ The local web app starts the Next.js browser shell, `/api/v1` route wrappers, se
 ## Install
 
 ```bash
-npm install
+git clone https://github.com/LayerNorm/overlay-web.git
+cd overlay-web
+npm ci
 cp .env.example .env.local
 ```
+
+This quickstart follows the current development branch and the hosted Convex
+profile. For a reproducible self-hosted deployment, use a versioned
+[GitHub release](https://github.com/LayerNorm/overlay-web/releases) and follow
+[Docker on EC2](/deploy-operate/docker-ec2) or the
+[full AWS guide](/deploy-operate/aws).
 
 Fill in the required web environment variables before starting the app. For local web work against the development backend, prefer:
 

--- a/scripts/check-docs-health.ts
+++ b/scripts/check-docs-health.ts
@@ -30,6 +30,8 @@ const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
 const docsDir = path.join(root, 'docs')
 const configExamplesDir = path.join(docsDir, 'config')
 const openApiFile = path.join(docsDir, 'openapi/overlay-web.openapi.json')
+const packageJsonFile = path.join(root, 'package.json')
+const publicRepositoryUrl = 'https://github.com/LayerNorm/overlay-web'
 
 const allowedDocsEntries = new Set([
   'README.md',
@@ -87,6 +89,8 @@ async function main() {
   await checkMdxOrphans(navPages, failures)
   await checkLocalLinks(failures)
   await checkStalePublicTerms(failures)
+  await checkPublicationReadiness(failures)
+  await checkDocumentedCommands(failures)
   await checkConfigExamples(failures)
   await checkOpenApiOutput(failures)
   await checkProviderDocs(failures)
@@ -244,6 +248,81 @@ async function checkStalePublicTerms(failures: string[]) {
     const text = await readFile(file, 'utf8')
     for (const { label, pattern } of stalePublicPatterns) {
       if (pattern.test(text)) failures.push(`${relative(file)} contains ${label}`)
+    }
+  }
+}
+
+async function checkPublicationReadiness(failures: string[]) {
+  const markdownFiles = (await listFiles(docsDir)).filter(
+    (file) => file.endsWith('.mdx') || file.endsWith('.md'),
+  )
+
+  for (const file of markdownFiles) {
+    const text = await readFile(file, 'utf8')
+    if (/\[(?:TODO|TBD):|\bTODO:\s/i.test(text)) {
+      failures.push(`${relative(file)} contains an unfinished TODO/TBD marker`)
+    }
+  }
+
+  const requiredSourcePages = [
+    'introduction.mdx',
+    'start/quickstart.mdx',
+    'deploy-operate/docker-ec2.mdx',
+    'deploy-operate/aws.mdx',
+  ]
+  for (const page of requiredSourcePages) {
+    const file = path.join(docsDir, page)
+    const text = await readFile(file, 'utf8')
+    if (!text.toLowerCase().includes(publicRepositoryUrl.toLowerCase())) {
+      failures.push(`docs/${page} does not identify the public source repository ${publicRepositoryUrl}`)
+    }
+  }
+
+  const quickstart = await readFile(path.join(docsDir, 'start/quickstart.mdx'), 'utf8')
+  if (!/Node\.js 22 or newer/i.test(quickstart)) {
+    failures.push('docs/start/quickstart.mdx must require Node.js 22 or newer')
+  }
+  if (!/npm 11 or newer/i.test(quickstart)) {
+    failures.push('docs/start/quickstart.mdx must require npm 11 or newer')
+  }
+
+  const forbiddenCommandFragments = [
+    'scripts/app-db-admin.ts',
+    '--userId=',
+    'git clone <CUSTOMER_REPOSITORY_URL>',
+  ]
+  const combined = await Promise.all(markdownFiles.map((file) => readFile(file, 'utf8')))
+  const publicDocs = combined.join('\n')
+  for (const fragment of forbiddenCommandFragments) {
+    if (publicDocs.includes(fragment)) {
+      failures.push(`public docs contain obsolete command fragment ${JSON.stringify(fragment)}`)
+    }
+  }
+}
+
+async function checkDocumentedCommands(failures: string[]) {
+  const packageJson = JSON.parse(await readFile(packageJsonFile, 'utf8')) as {
+    scripts?: Record<string, string>
+  }
+  const packageScripts = new Set(Object.keys(packageJson.scripts ?? {}))
+  const markdownFiles = (await listFiles(docsDir)).filter(
+    (file) => file.endsWith('.mdx') || file.endsWith('.md'),
+  )
+
+  for (const file of markdownFiles) {
+    const text = await readFile(file, 'utf8')
+    for (const match of text.matchAll(/\bnpm run ([A-Za-z0-9:_-]+)/g)) {
+      const script = match[1]
+      if (script && !packageScripts.has(script)) {
+        failures.push(`${relative(file)} references missing package script npm run ${script}`)
+      }
+    }
+
+    for (const match of text.matchAll(/\bscripts\/[A-Za-z0-9._/-]+\.(?:ts|mjs|js)\b/g)) {
+      const scriptPath = match[0]
+      if (!(await fileExists(path.join(root, scriptPath)))) {
+        failures.push(`${relative(file)} references missing repository script ${scriptPath}`)
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add the public GitHub repository and tested release to setup/deployment entry points
- correct Node/npm prerequisites, enterprise admin command, and Postgres/Convex provider guidance
- remove unfinished screenshot TODOs from published help pages
- make docs health validate public source links, documented commands, script paths, and unfinished markers

## Verification
- npm run docs:health
- npm run docs:check
- npx eslint scripts/check-docs-health.ts
- git diff --check