### PR TITLE
docs: Desktop Mintlify + fail-closed /download

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 # Overlay Docs
 
-`docs/` is the Mintlify site root and contains only publishable developer,
-self-hosting, operator, API, and legal documentation.
+`docs/` is the Mintlify site root and contains publishable documentation for
+Overlay across **web**, **desktop**, self-hosting, operator, API, and legal
+topics.
 
 ## Edit Model
 
@@ -15,6 +16,7 @@ self-hosting, operator, API, and legal documentation.
 ## Structure
 
 - `introduction.mdx` - docs home.
+- `desktop/` - Overlay Desktop (macOS) install, permissions, security, troubleshooting.
 - `start/` - quickstart and repository map.
 - `configure/` - environment variables, runtime config, provider matrix, and feature gates.
 - `develop/` - architecture, Convex workflow, customization, modules, and API source of truth.

--- a/docs/desktop/browser-security.mdx
+++ b/docs/desktop/browser-security.mdx
@@ -1,0 +1,13 @@
+---
+title: "Browser-agent security"
+description: "How agent browsing is isolated from the interactive browser."
+---
+
+Overlay separates:
+
+- **Interactive browser** — the user’s browsing panel / profile.
+- **Agent browser** — tool-driven sessions used by chat agents.
+
+Agent browser traffic is subject to destination policy that blocks private,
+loopback, link-local, metadata, and other restricted targets. This is defense
+in depth. It does not make arbitrary host execution safe under Full access.

--- a/docs/desktop/build-from-source.mdx
+++ b/docs/desktop/build-from-source.mdx
@@ -1,0 +1,30 @@
+---
+title: "Building from source"
+description: "Clone and run Overlay Desktop on Apple Silicon."
+---
+
+```bash
+git clone https://github.com/LayerNorm/overlay-desktop.git
+cd overlay-desktop
+cp .env.example .env.local
+npm ci
+npm run dev
+```
+
+Checks:
+
+```bash
+npm run typecheck
+npm test
+npm run build
+```
+
+Local package (typically unsigned in CI dry-runs):
+
+```bash
+npm run build:mac:ci
+```
+
+See the repository [README](https://github.com/LayerNorm/overlay-desktop#build-from-source)
+and [RELEASE_PROCESS](https://github.com/LayerNorm/overlay-desktop/blob/main/guides/RELEASE_PROCESS.md)
+for signed release requirements.

--- a/docs/desktop/changelog.mdx
+++ b/docs/desktop/changelog.mdx
@@ -1,0 +1,10 @@
+---
+title: "Desktop changelog"
+description: "Release notes for Overlay Desktop."
+---
+
+User-facing desktop changes are tracked in the repository
+[CHANGELOG.md](https://github.com/LayerNorm/overlay-desktop/blob/main/CHANGELOG.md).
+
+After Gate B, GitHub Release notes for each signed version are the canonical
+binary release notes. Keep this docs page linked to that changelog.

--- a/docs/desktop/chat-permissions.mdx
+++ b/docs/desktop/chat-permissions.mdx
@@ -1,0 +1,25 @@
+---
+title: "Chat operation permissions"
+description: "Ask for approval vs Full access on desktop chat."
+---
+
+Desktop chat host tools use a main-process permission mode:
+
+## Ask for approval (default)
+
+Every eligible direct host operation requires a fresh native approval bound to
+the exact action. Cancel is always available.
+
+## Full access
+
+After an explicit native warning from Settings, eligible desktop chat tools may
+run without per-action prompts. This is **unsandboxed** access to the user’s Mac.
+
+Full access:
+
+- Does **not** bypass server auth, billing, model policy, or usage accounting.
+- Applies only to the desktop chat surface (not browser/voice/notebook agents).
+- Should remain visibly marked as unsandboxed in product UI.
+
+See the repository threat model and Phase 3 exception notes in the desktop repo
+for residual risk and review expiry.

--- a/docs/desktop/download-install.mdx
+++ b/docs/desktop/download-install.mdx
@@ -1,0 +1,26 @@
+---
+title: "Download and installation"
+description: "Install Overlay Desktop on Apple Silicon Macs."
+---
+
+## Official builds
+
+Signed, notarized builds will ship from GitHub Releases on
+[LayerNorm/overlay-desktop](https://github.com/LayerNorm/overlay-desktop) and
+from [getoverlay.io/download](https://getoverlay.io/download) after **Gate B**.
+
+Until Gate B is approved, the website download APIs return **503** and do not
+advertise a DMG.
+
+### After Gate B
+
+1. Open [getoverlay.io/download](https://getoverlay.io/download).
+2. Confirm **macOS, Apple Silicon**.
+3. Download the DMG via the site (routes through `/api/latest-release/download`).
+4. Open the DMG and drag Overlay to Applications.
+5. Launch Overlay and complete sign-in in your browser.
+
+## From source
+
+See [Building from source](/desktop/build-from-source). From-source builds are
+unsigned unless you configure your own Developer ID credentials.

--- a/docs/desktop/local-vs-cloud.mdx
+++ b/docs/desktop/local-vs-cloud.mdx
@@ -1,0 +1,17 @@
+---
+title: "Local versus cloud data"
+description: "What stays on the Mac vs what needs Overlay Server."
+---
+
+| Capability | Local | Overlay Server |
+| --- | --- | --- |
+| Notes / notebook files | Yes | Optional sync |
+| Local transcription helpers | Yes | No |
+| Workspace / file tools | Yes (permissioned) | No |
+| User-owned API keys | Keychain on device | No |
+| Sign-in / account | — | Yes |
+| Hosted models & policy | — | Yes |
+| Billing / entitlements | — | Yes |
+| Cloud sync & integrations | — | Yes |
+
+The desktop app is not a standalone offline backend.

--- a/docs/desktop/macos-permissions.mdx
+++ b/docs/desktop/macos-permissions.mdx
@@ -1,0 +1,16 @@
+---
+title: "macOS permissions"
+description: "Why Overlay requests system permissions."
+---
+
+| Permission | Why Overlay may ask |
+| --- | --- |
+| Microphone | Voice input / transcription |
+| Accessibility | Approved UI automation tools |
+| Apple Events / Automation | Control other apps when an approved tool needs it |
+| Files / folders | Read/write user-selected or approved paths |
+| Network / browser | Interactive browsing and policy-restricted agent browsing |
+| Keychain | Persist auth and user-owned API keys via OS secure storage |
+
+Deny any permission you do not want to grant. Related features fail closed.
+After changing **System Settings → Privacy & Security**, quit and relaunch Overlay.

--- a/docs/desktop/overview.mdx
+++ b/docs/desktop/overview.mdx
@@ -1,0 +1,30 @@
+---
+title: "Desktop overview"
+description: "Architecture and scope of Overlay Desktop on macOS."
+---
+
+Overlay Desktop is the Electron macOS client for Overlay. It provides voice input, chat, notes, files, and permissioned agent operations on Apple Silicon.
+
+## Surfaces
+
+| Surface | Role |
+| --- | --- |
+| Main / overlay windows | App shell, settings, launcher |
+| Chat | Permissioned host tools + hosted models |
+| Notebook | Local notes with optional cloud sync |
+| Browser | Interactive browsing; agent browser is isolated |
+| Transcription | Local and/or cloud speech-to-text |
+
+## Processes
+
+- **Main** — trusted host capabilities, IPC, Keychain-backed secrets, policy.
+- **Preload** — narrow typed bridge (`window.bridge` only).
+- **Renderer** — React UI; no Node privileged APIs.
+
+## Source
+
+- Public repository: [LayerNorm/overlay-desktop](https://github.com/LayerNorm/overlay-desktop)
+- Website: [getoverlay.io](https://getoverlay.io)
+- Download (after Gate B): [getoverlay.io/download](https://getoverlay.io/download)
+
+Hosted authentication, model policy, entitlements, billing, and usage accounting remain server-authoritative on Overlay Server.

--- a/docs/desktop/privacy-diagnostics.mdx
+++ b/docs/desktop/privacy-diagnostics.mdx
@@ -1,0 +1,11 @@
+---
+title: "Privacy and diagnostics"
+description: "What Overlay Desktop collects by default."
+---
+
+Optional diagnostics are **off by default**. When enabled, data should follow
+the desktop [privacy policy](https://github.com/LayerNorm/overlay-desktop/blob/main/privacy-policy.md)
+with redaction and bounded retention.
+
+Hosted product analytics on Overlay Server are separate from local desktop
+diagnostics and are governed by the website privacy policy at getoverlay.io.

--- a/docs/desktop/release-verification.mdx
+++ b/docs/desktop/release-verification.mdx
@@ -1,0 +1,17 @@
+---
+title: "Release verification"
+description: "How to verify a signed Overlay Desktop release."
+---
+
+For each official release, verify:
+
+| Check | What to confirm |
+| --- | --- |
+| Signature | Developer ID Application signature on the app / DMG |
+| Notarization | Stapled ticket; Gatekeeper accepts on a clean Mac |
+| Checksum | SHA-256 matches the published checksums / manifest |
+| Provenance | GitHub attestations bind the artifact to the source SHA |
+| SBOM | Published SBOM matches the release set |
+| Updater | Website latest version equals updater metadata version |
+
+See Gate B and `guides/RELEASE_PROCESS.md` in the desktop repository.

--- a/docs/desktop/security-reporting.mdx
+++ b/docs/desktop/security-reporting.mdx
@@ -1,0 +1,12 @@
+---
+title: "Security reporting"
+description: "How to report Overlay Desktop vulnerabilities."
+---
+
+Report vulnerabilities privately using the process in
+[SECURITY.md](https://github.com/LayerNorm/overlay-desktop/blob/main/SECURITY.md)
+on the desktop repository (and the corresponding policy on Overlay Web for
+server issues).
+
+Do **not** open public issues with exploit details, private audit reports, or
+proofs of concept.

--- a/docs/desktop/self-hosted-server.mdx
+++ b/docs/desktop/self-hosted-server.mdx
@@ -1,0 +1,22 @@
+---
+title: "Self-hosted Overlay Server"
+description: "Point Overlay Desktop at your own Overlay Server."
+---
+
+Set the server origin before launch:
+
+```bash
+APP_SERVER_URL=https://your-overlay-server.example.com
+```
+
+Rules:
+
+- Use **HTTPS** in production.
+- `http://localhost:3000` is acceptable for local development only.
+- The server must implement Overlay discovery and `/api/v1` contracts compatible
+  with this desktop version.
+- Never place owner-funded provider keys or signing secrets in the desktop app
+  environment.
+
+Self-hosting the **server** is separate from installing the desktop client.
+Docker/Compose applies to Overlay Server — not to the Electron GUI.

--- a/docs/desktop/sign-in.mdx
+++ b/docs/desktop/sign-in.mdx
@@ -1,0 +1,18 @@
+---
+title: "Sign-in and hosted server"
+description: "How Overlay Desktop authenticates against Overlay Server."
+---
+
+Official builds authenticate against the hosted Overlay Server at
+`https://getoverlay.io`.
+
+Flow:
+
+1. Desktop opens the system browser to the server sign-in page.
+2. After success, the browser returns via an `overlay://` callback.
+3. Main process validates the handoff and stores session material using OS
+   secure storage / Keychain-backed APIs.
+
+Hosted mode still requires Overlay Server for account features, hosted models,
+entitlements, and billing. Local notes and some tools can work on-device after
+sign-in depending on configuration.

--- a/docs/desktop/system-requirements.mdx
+++ b/docs/desktop/system-requirements.mdx
@@ -1,0 +1,15 @@
+---
+title: "System requirements"
+description: "Supported Macs and runtime requirements."
+---
+
+| Requirement | Supported |
+| --- | --- |
+| Chip | Apple Silicon (`arm64`) only |
+| OS | Recent macOS versions supported by current Electron |
+| Disk | Enough space for the app + optional local models/helpers |
+| Network | Required for sign-in, hosted models, sync, billing |
+| Node.js | 22+ when building from source |
+
+**Not supported:** Intel Macs, Windows, Linux desktop UI, running the Electron
+app inside Docker.

--- a/docs/desktop/transcription.mdx
+++ b/docs/desktop/transcription.mdx
@@ -1,0 +1,14 @@
+---
+title: "Transcription"
+description: "Local and cloud speech-to-text on desktop."
+---
+
+Overlay Desktop can use:
+
+- **Local helpers** (for example bundled arm64 transcription binaries) when
+  present and permitted.
+- **Cloud / hosted** enhancement or models when configured through Overlay
+  Server and the user’s entitlements.
+
+Microphone permission is required for capture. Local helpers are Apple Silicon
+only and ship as pinned native artifacts in official builds.

--- a/docs/desktop/troubleshooting.mdx
+++ b/docs/desktop/troubleshooting.mdx
@@ -1,0 +1,26 @@
+---
+title: "Desktop troubleshooting"
+description: "Common Overlay Desktop setup and runtime issues."
+---
+
+## Authentication
+
+- Confirm the Overlay Server URL is reachable (`APP_SERVER_URL` or hosted default).
+- Complete browser sign-in; ensure `overlay://` callbacks reach this app.
+- After server-side session revocation, sign in again.
+
+## Keychain
+
+- Deny Keychain access → auth/API keys will not persist.
+- After Keychain reset or new Mac, sign in again and re-enter user-owned keys.
+
+## Permissions
+
+- Grant Microphone / Accessibility / Automation / Files in System Settings as needed.
+- Relaunch Overlay after TCC changes.
+
+## Native helpers / models
+
+- Confirm Apple Silicon.
+- Official builds include pinned arm64 helpers; stripped copies will fail.
+- From-source packages need a successful native artifact layout.

--- a/docs/desktop/uninstall.mdx
+++ b/docs/desktop/uninstall.mdx
@@ -1,0 +1,18 @@
+---
+title: "Uninstall and local data"
+description: "Remove Overlay Desktop and optional local files."
+---
+
+1. Quit Overlay.
+2. Delete `Overlay.app` (Applications or your build output).
+3. Optional — remove local application data:
+
+```bash
+rm -rf ~/Library/Application\ Support/Overlay
+# Dev Electron builds may use Application Support/Electron instead.
+```
+
+4. Optional — remove Keychain items labeled for Overlay.
+
+Uninstalling the desktop app does **not** delete your cloud account or
+server-side data on Overlay Server.

--- a/docs/desktop/updates.mdx
+++ b/docs/desktop/updates.mdx
@@ -1,0 +1,14 @@
+---
+title: "Updates and channels"
+description: "How Overlay Desktop updates after Gate B."
+---
+
+After official releases begin:
+
+- Updates are delivered from the same GitHub Releases channel used by
+  getoverlay.io/download.
+- Downgrades and prereleases are rejected by the desktop updater policy.
+- Website download metadata and auto-update metadata must resolve to the same
+  version for a given release.
+
+Until Gate B, no public update channel should be advertised.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
-  "name": "Overlay Web",
-  "description": "Developer and self-hosting documentation for the Overlay web app.",
+  "name": "Overlay",
+  "description": "Documentation for Overlay across web, desktop, and self-hosted deployments.",
   "colors": {
     "primary": "#111827"
   },
@@ -30,6 +30,29 @@
       {
         "group": "Start",
         "pages": ["introduction", "start/quickstart", "start/repository-map"]
+      },
+      {
+        "group": "Desktop",
+        "pages": [
+          "desktop/overview",
+          "desktop/download-install",
+          "desktop/system-requirements",
+          "desktop/sign-in",
+          "desktop/self-hosted-server",
+          "desktop/build-from-source",
+          "desktop/local-vs-cloud",
+          "desktop/chat-permissions",
+          "desktop/macos-permissions",
+          "desktop/browser-security",
+          "desktop/transcription",
+          "desktop/updates",
+          "desktop/uninstall",
+          "desktop/privacy-diagnostics",
+          "desktop/security-reporting",
+          "desktop/troubleshooting",
+          "desktop/release-verification",
+          "desktop/changelog"
+        ]
       },
       {
         "group": "Configure",

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,49 +1,48 @@
 ---
-title: "Overlay Web"
-description: "Developer and self-hosting documentation for the Overlay web app."
+title: "Overlay"
+description: "Documentation for Overlay across web, desktop, and self-hosted deployments."
 ---
 
-Overlay Web is the Next.js application that powers the browser experience for Overlay. It owns the public web routes, the browser app shell, API route wrappers, server-side orchestration, provider adapters, and the shared contracts used by the app.
-
-These docs are for developers and self-hosters working with the web app. They cover local setup, runtime configuration, provider wiring, deployment, operational checks, and the stable `/api/v1` web API surface.
+Overlay is a private workspace for models, knowledge, tools, and agents. These
+docs cover the **web app / Overlay Server**, **Overlay Desktop** on macOS, and
+self-hosting.
 
 <CardGroup cols={2}>
-  <Card title="Source repository" icon="github" href="https://github.com/LayerNorm/overlay-web">
-    Browse, fork, or clone the public Overlay Web repository.
+  <Card title="Web / server source" icon="github" href="https://github.com/LayerNorm/overlay-web">
+    Next.js app, APIs, and self-hosting surface.
   </Card>
-  <Card title="Published releases" icon="tag" href="https://github.com/LayerNorm/overlay-web/releases">
-    Use a versioned release for deployment instead of an unpinned branch.
+  <Card title="Overlay Desktop source" icon="laptop" href="https://github.com/LayerNorm/overlay-desktop">
+    macOS Apple Silicon client (public source; signed downloads after Gate B).
+  </Card>
+  <Card title="Desktop download" icon="download" href="https://getoverlay.io/download">
+    Official macOS builds when Gate B is open.
+  </Card>
+  <Card title="Desktop docs" icon="book-open" href="/desktop/overview">
+    Install, permissions, security model, and troubleshooting.
   </Card>
 </CardGroup>
 
 ## Scope
 
-Included:
+**Web / server**
 
-- The Next.js web app under `src/app`.
-- Web route orchestration under `src/server/app-api`.
-- Browser-safe contracts under `src/shared`.
-- Feature containers under `src/features`.
-- Convex and Postgres workflows where they affect the web app.
-- Public `/api/v1` request, query, and form schemas.
+- Next.js app under `src/app`
+- `/api/v1` contracts and server orchestration
+- Convex / Postgres workflows that affect the product
+- Self-hosting and operations
 
-Excluded:
+**Desktop**
 
-- Mobile, desktop, and Chrome extension implementation details.
-- Internal audit reports and design exploration assets.
-- Private security notes.
+- Electron macOS client (Apple Silicon)
+- Local vs cloud data flows and chat permissions
+- Build-from-source and (after Gate B) signed releases
+
+**Excluded**
+
+- Mobile and Chrome extension deep internals
+- Internal audit reports and private security notes
 
 ## Source of truth
 
-The API reference is generated from `src/shared/schemas/api-boundary.ts`. Prose pages explain workflows, deployment, and maintenance expectations that cannot be captured cleanly in OpenAPI.
-
-Run this before publishing docs changes:
-
-```bash
-npm run docs:check
-```
-
-## Audience
-
-- **Developers and operators** — this documentation covers setup, runtime config, deployment, and the API reference.
-- **End users** — see the [Help Center](./help/index) for chat, memory, files, projects, automations, settings, and FAQ.
+The web API reference is generated from `src/shared/schemas/api-boundary.ts`.
+Desktop release notes live in the desktop repository changelog and GitHub Releases.

--- a/docs/openapi/overlay-web.openapi.json
+++ b/docs/openapi/overlay-web.openapi.json
@@ -35,6 +35,9 @@
       "name": "Conversations"
     },
     {
+      "name": "Discovery"
+    },
+    {
       "name": "Files"
     },
     {
@@ -3004,6 +3007,66 @@
             }
           }
         }
+      }
+    },
+    "/api/v1/discovery": {
+      "get": {
+        "operationId": "getDiscovery",
+        "summary": "Public Overlay Server discovery metadata",
+        "tags": [
+          "Discovery"
+        ],
+        "security": [
+          {
+            "browserSession": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response. Stable response schemas are documented in workflow guides when available.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Response shape is route-specific and may be backed by @overlay/app-core contracts."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authentication.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Unauthenticated desktop/server discovery: API versions, capabilities, native auth paths, and minimum desktop version. No secrets."
       }
     },
     "/api/v1/files": {
@@ -8095,6 +8158,12 @@
                   "autoTopUpEnabled": {
                     "type": "boolean"
                   },
+                  "confirmation": {
+                    "type": "string",
+                    "enum": [
+                      "UPDATE_BILLING_SETTINGS"
+                    ]
+                  },
                   "grantOffSessionConsent": {
                     "type": "boolean"
                   },
@@ -8106,7 +8175,8 @@
                   }
                 },
                 "required": [
-                  "autoTopUpEnabled"
+                  "autoTopUpEnabled",
+                  "confirmation"
                 ],
                 "additionalProperties": true
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3239,7 +3239,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3262,7 +3261,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3282,7 +3280,6 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
       "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3305,7 +3302,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3322,7 +3318,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3339,7 +3334,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3356,7 +3350,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3373,7 +3366,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3390,7 +3382,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3407,7 +3398,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3424,7 +3414,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3441,7 +3430,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3458,7 +3446,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3475,7 +3462,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3498,7 +3484,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3521,7 +3506,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3544,7 +3528,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3567,7 +3550,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3590,7 +3572,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3613,7 +3594,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3636,7 +3616,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3656,7 +3635,6 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
       "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3673,7 +3651,6 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
       "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3687,7 +3664,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -3707,7 +3683,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3727,7 +3702,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3747,7 +3721,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/scripts/check-docs-health.ts
+++ b/scripts/check-docs-health.ts
@@ -40,6 +40,7 @@ const allowedDocsEntries = new Set([
   'config',
   'configure',
   'deploy-operate',
+  'desktop',
   'develop',
   'docs.json',
   'help',
@@ -310,6 +311,9 @@ async function checkDocumentedCommands(failures: string[]) {
   )
 
   for (const file of markdownFiles) {
+    // Desktop pages document LayerNorm/overlay-desktop scripts, not this package.
+    if (relative(file).startsWith('docs/desktop/')) continue
+
     const text = await readFile(file, 'utf8')
     for (const match of text.matchAll(/\bnpm run ([A-Za-z0-9:_-]+)/g)) {
       const script = match[1]

--- a/src/app/app/account/page.tsx
+++ b/src/app/app/account/page.tsx
@@ -392,6 +392,13 @@ function AccountPageContent() {
                         )}
                       </button>
                       <Link
+                        href="/download"
+                        className="inline-flex items-center justify-center gap-2 rounded-lg border border-[var(--button-secondary-border)] bg-[var(--button-secondary-bg)] px-4 py-2 text-sm font-medium text-[var(--button-secondary-text)] transition-colors hover:bg-[var(--surface-muted)]"
+                      >
+                        Download for macOS
+                        <ArrowRight className="h-4 w-4" />
+                      </Link>
+                      <Link
                         href="/app/chat"
                         className="inline-flex items-center justify-center gap-2 rounded-lg bg-[var(--button-primary-bg)] px-4 py-2 text-sm font-medium text-[var(--button-primary-text)] transition-opacity hover:opacity-90"
                       >

--- a/src/app/download/page.tsx
+++ b/src/app/download/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next'
+import { DesktopDownloadPage } from '@/features/marketing/pages/DesktopDownloadPage'
+import { areOfficialDesktopDownloadsEnabled } from '@/server/releases/desktop-download-policy'
+import {
+  fetchLatestReleaseInfo,
+  type LatestReleaseInfo,
+} from '@/shared/web/latest-release'
+
+export const metadata: Metadata = {
+  title: 'Download Overlay for macOS',
+  description:
+    'Download Overlay Desktop for macOS Apple Silicon, or build from the public source repository.',
+}
+
+export const dynamic = 'force-dynamic'
+
+export default async function DownloadRoutePage() {
+  const downloadsEnabled = areOfficialDesktopDownloadsEnabled()
+
+  let release: LatestReleaseInfo | null = null
+  let releaseError: string | null = null
+
+  if (downloadsEnabled) {
+    try {
+      release = await fetchLatestReleaseInfo()
+    } catch (error) {
+      releaseError = error instanceof Error ? error.message : 'unknown error'
+    }
+  }
+
+  return (
+    <DesktopDownloadPage
+      downloadsEnabled={downloadsEnabled}
+      release={release}
+      releaseError={releaseError}
+    />
+  )
+}

--- a/src/features/marketing/components/MarketingNavbar.tsx
+++ b/src/features/marketing/components/MarketingNavbar.tsx
@@ -47,6 +47,7 @@ const PRIMARY_LINKS_AFTER: Array<{
     label: "Open Source",
     match: (p) => p === "/home",
   },
+  { href: "/download", label: "Download", match: (p) => p === "/download" },
   { href: "/pricing", label: "Pricing", match: (p) => p === "/pricing" },
 ];
 

--- a/src/features/marketing/pages/DesktopDownloadPage.tsx
+++ b/src/features/marketing/pages/DesktopDownloadPage.tsx
@@ -1,0 +1,188 @@
+import Link from 'next/link'
+import { MarketingButton } from '@/features/marketing/components/MarketingButton'
+import { MarketingFooter } from '@/features/marketing/components/MarketingFooter'
+import { StaticMarketingShell } from '@/features/marketing/components/StaticMarketingShell'
+import {
+  minimalBody,
+  minimalDisplay,
+  minimalLabel,
+  minimalSection,
+  minimalSerif,
+  minimalTextLink,
+} from '@/features/marketing/lib/minimalLayout'
+import type { LatestReleaseInfo } from '@/shared/web/latest-release'
+import { LATEST_RELEASE_DOWNLOAD_PATH } from '@/shared/web/latest-release'
+
+export type DesktopDownloadPageProps = {
+  downloadsEnabled: boolean
+  release: LatestReleaseInfo | null
+  releaseError: string | null
+}
+
+function formatPublishedAt(iso: string | undefined): string | null {
+  if (!iso) return null
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export function DesktopDownloadPage({
+  downloadsEnabled,
+  release,
+  releaseError,
+}: DesktopDownloadPageProps) {
+  const published = formatPublishedAt(release?.publishedAt ?? undefined)
+  const canDownload = downloadsEnabled && Boolean(release)
+
+  return (
+    <StaticMarketingShell>
+      <main className="flex-1">
+        <section className={minimalSection()}>
+          <div className="mx-auto max-w-2xl">
+            <p className={minimalLabel()}>Desktop</p>
+            <h1 className={`mt-4 ${minimalDisplay()}`} style={minimalSerif()}>
+              Download Overlay for macOS
+            </h1>
+            <p className={`mt-6 ${minimalBody()}`}>
+              Official builds are for <strong>macOS on Apple Silicon</strong> only.
+              Hosted cloud features require Overlay Server (default:{' '}
+              <a className="underline underline-offset-4" href="https://getoverlay.io">
+                getoverlay.io
+              </a>
+              ).
+            </p>
+
+            <div className="mt-10 space-y-4 rounded-xl border border-[var(--border)] bg-[var(--surface-subtle)] p-6">
+              {!downloadsEnabled ? (
+                <>
+                  <p className={minimalBody()}>
+                    Signed public downloads are not open yet. Source is available now;
+                    the official beta DMG ships after Gate B (signing, notarization, and
+                    release review).
+                  </p>
+                  <div className="flex flex-wrap gap-3 pt-2">
+                    <MarketingButton
+                      href="https://github.com/LayerNorm/overlay-desktop"
+                      external
+                      variant="primary"
+                      arrow="up-right"
+                    >
+                      View source
+                    </MarketingButton>
+                    <MarketingButton
+                      href="https://getoverlay.io/docs/desktop/overview"
+                      external
+                      variant="secondary"
+                      arrow="up-right"
+                    >
+                      Desktop docs
+                    </MarketingButton>
+                  </div>
+                </>
+              ) : releaseError || !release ? (
+                <>
+                  <p className={minimalBody()}>
+                    A signed build could not be loaded right now
+                    {releaseError ? ` (${releaseError})` : ''}. Try again later, or
+                    install from source.
+                  </p>
+                  <div className="flex flex-wrap gap-3 pt-2">
+                    <MarketingButton
+                      href="https://github.com/LayerNorm/overlay-desktop/releases"
+                      external
+                      variant="primary"
+                      arrow="up-right"
+                    >
+                      GitHub Releases
+                    </MarketingButton>
+                    <MarketingButton
+                      href="https://github.com/LayerNorm/overlay-desktop"
+                      external
+                      variant="secondary"
+                      arrow="up-right"
+                    >
+                      Build from source
+                    </MarketingButton>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <p className="text-sm text-[var(--muted)]">
+                    Version {release.version}
+                    {published ? ` · ${published}` : null}
+                    {release.releaseName ? ` · ${release.releaseName}` : null}
+                  </p>
+                  <p className={`mt-2 ${minimalBody()}`}>
+                    Platform: <strong>macOS, Apple Silicon</strong>
+                  </p>
+                  <div className="flex flex-wrap gap-3 pt-4">
+                    <MarketingButton
+                      href={LATEST_RELEASE_DOWNLOAD_PATH}
+                      variant="primary"
+                      arrow="right"
+                    >
+                      Download for macOS
+                    </MarketingButton>
+                    <MarketingButton
+                      href="https://github.com/LayerNorm/overlay-desktop/releases/latest"
+                      external
+                      variant="secondary"
+                      arrow="up-right"
+                    >
+                      Release notes
+                    </MarketingButton>
+                  </div>
+                </>
+              )}
+            </div>
+
+            <ul className={`mt-10 space-y-3 ${minimalBody()}`}>
+              <li>
+                <a
+                  className={minimalTextLink()}
+                  href="https://getoverlay.io/docs/desktop/system-requirements"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  System requirements
+                </a>
+              </li>
+              <li>
+                <Link className={minimalTextLink()} href="/privacy">
+                  Privacy policy
+                </Link>
+              </li>
+              <li>
+                <a
+                  className={minimalTextLink()}
+                  href="https://github.com/LayerNorm/overlay-desktop"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Source repository
+                </a>
+              </li>
+              {canDownload ? (
+                <li>
+                  <a
+                    className={minimalTextLink()}
+                    href="https://github.com/LayerNorm/overlay-desktop/releases/latest"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Checksums & provenance (GitHub Release assets)
+                  </a>
+                </li>
+              ) : null}
+            </ul>
+          </div>
+        </section>
+      </main>
+      <MarketingFooter />
+    </StaticMarketingShell>
+  )
+}

--- a/src/features/marketing/pages/MarketingOverviewPage.tsx
+++ b/src/features/marketing/pages/MarketingOverviewPage.tsx
@@ -60,10 +60,13 @@ function HomeLandingContent() {
                 >
                   Try Overlay
                 </MarketingButton>
+                <MarketingButton href="/download" variant="secondary" arrow="right">
+                  Download for macOS
+                </MarketingButton>
                 <MarketingButton
                   href={MARKETING_DEPLOY_URL}
                   external
-                  variant="secondary"
+                  variant="ghost"
                   arrow="up-right"
                 >
                   Deploy privately

--- a/src/shared/schemas/api-boundary.ts
+++ b/src/shared/schemas/api-boundary.ts
@@ -184,6 +184,15 @@ export const webApiBoundaryDefinitions = [
   },
   {
     method: 'GET',
+    path: '/api/v1/discovery',
+    schema: { query: EmptyQuery, response: UnknownResponse },
+    summary: 'Public Overlay Server discovery metadata',
+    description:
+      'Unauthenticated desktop/server discovery: API versions, capabilities, native auth paths, and minimum desktop version. No secrets.',
+    tag: 'Discovery',
+  },
+  {
+    method: 'GET',
     path: '/api/v1/conversations',
     schema: { query: ConversationListQuery },
     summary: 'List or read conversations',


### PR DESCRIPTION
## Summary
- Mintlify: rename site to **Overlay**; add full **Desktop** nav group (`docs/desktop/*`)
- Website: `/download` page + navbar/homepage/account “Download for macOS” CTAs
- Downloads remain fail-closed until `OVERLAY_DESKTOP_DOWNLOADS_ENABLED=1` (Gate B)
- Bump `overlay-desktop` submodule to current LayerNorm `main` (`105cdae`)

Companion desktop docs PR: https://github.com/LayerNorm/overlay-desktop/pull/19

## Test plan
- [ ] `npm run docs:check` (or Mintlify preview) — Desktop group renders
- [ ] Visit `/download` with flag unset → “not open yet” + source/docs links (no DMG CTA)
- [ ] Confirm `/api/latest-release/download` still 503 when flag unset
- [ ] Homepage + account show Download for macOS → `/download`


Made with [Cursor](https://cursor.com)