### PR TITLE
security: add Gate A hostile-client evidence harness

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout v4
 
+      - name: Check out public desktop boundary source
+        run: git submodule update --init --depth 1 overlay-desktop
+
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node v4
         with:

--- a/docs/develop/desktop-hostile-client-testing.mdx
+++ b/docs/develop/desktop-hostile-client-testing.mdx
@@ -1,0 +1,90 @@
+---
+title: Desktop hostile-client testing
+description: Run and document Gate A server-authority tests from a modified desktop client.
+---
+
+This is a blank evidence procedure, not a completed security review. Store
+filled reports, tokens, provider screenshots, raw logs, and reservation
+identifiers in the private security evidence system. Do not commit completed
+reports.
+
+## Scope
+
+Record the server and desktop source SHAs, test window, operator, independent
+reviewer, dedicated deployment URLs, backends, and enabled providers. Production
+must remain excluded unless the owner explicitly authorizes a production drill.
+
+## Preconditions
+
+- Dedicated, non-production deployments use production-equivalent policy.
+- Test users have the lowest applicable entitlements.
+- Provider credentials are dedicated and have hard spending caps.
+- Provider dashboards and Overlay security/billing logs are observable.
+- The matrix contains every enabled owner-funded provider path.
+- Output paths are private and outside the public repository.
+
+## Run control checks
+
+Control-only checks do not intentionally invoke a provider:
+
+```sh
+npm run test:desktop-security:hostile-matrix -- \
+  --config=scripts/fixtures/desktop-hostile-client-matrix.example.json \
+  --output=/private/evidence/gate-a-hostile-control.json
+```
+
+## Run provider checks
+
+Cost-bearing concurrency, disconnect, and replay checks require two explicit
+acknowledgements:
+
+```sh
+OVERLAY_HOSTILE_CLIENT_EXECUTE_PROVIDER=1 \
+OVERLAY_HOSTILE_CLIENT_ACK=I_UNDERSTAND_THIS_MAY_INCUR_PROVIDER_COSTS \
+npm run test:desktop-security:hostile-matrix -- \
+  --config=/private/evidence/gate-a-hostile-matrix.json \
+  --output=/private/evidence/gate-a-hostile-provider.json
+```
+
+The runner rejects `getoverlay.io` by default. A production drill additionally
+requires `OVERLAY_HOSTILE_CLIENT_ALLOW_PRODUCTION=1` and explicit owner approval.
+
+## Evidence matrix
+
+Complete one row for every backend/provider target in the private report.
+
+| Backend | Provider | Control report | Provider report | Provider calls | Charged operations | Overlay reservations | Result |
+| --- | --- | --- | --- | ---: | ---: | ---: | --- |
+| Convex | unset | unset | unset | unset | unset | unset | PENDING |
+| Postgres | unset | unset | unset | unset | unset | unset | PENDING |
+
+For each target, attach private evidence that:
+
+- Missing, invalid, and identity-substituted authentication was rejected.
+- Missing idempotency keys were rejected before provider work.
+- Server-denied models or capabilities could not be substituted by the client.
+- Concurrent identical requests caused exactly one provider operation.
+- Disconnect and retry did not start a second provider operation.
+- Provider usage, Overlay reservation, finalization/release, and user accounting reconcile.
+- No provider credential, internal service credential, raw token, or another
+  user’s data appeared in responses or logs.
+
+## Required negative cases
+
+- Credential and key retrieval attempts
+- Identity substitution
+- Model and capability substitution
+- Missing and malformed idempotency keys
+- Concurrent identical requests
+- Disconnect followed by retry
+- Same key with a different request body
+- Free or expired entitlement attempting a paid operation
+- Rate-limit and budget exhaustion
+- Kill switch enabled
+- Provider timeout and provider 4xx/5xx
+
+## Reviewer decision
+
+The private result records unresolved Critical and High findings, accepted
+exceptions and expiry dates, reviewer identity, date, and an
+`APPROVED`/`REJECTED` decision.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,7 +86,7 @@
       },
       {
         "group": "Develop",
-        "pages": ["develop/architecture", "develop/convex-workflow", "develop/local-integrations", "develop/customization", "develop/feature-modules", "develop/api-source-of-truth"]
+        "pages": ["develop/architecture", "develop/convex-workflow", "develop/local-integrations", "develop/customization", "develop/feature-modules", "develop/api-source-of-truth", "develop/desktop-hostile-client-testing"]
       },
       {
         "group": "Deploy & Operate",

--- a/internal-docs/reports/web-app-complexity-baseline.json
+++ b/internal-docs/reports/web-app-complexity-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-16T06:31:06.157Z",
+  "generatedAt": "2026-07-27T00:24:02.433Z",
   "budgets": {
     "maxProductionFileLoc": 500,
     "maxFunctionComplexity": 25,
@@ -30,22 +30,21 @@
   ],
   "largeProductionFiles": [
     "packages/overlay-app-core/src/extensions.ts",
+    "packages/overlay-app-core/src/knowledge-surface.ts",
     "packages/overlay-billing/src/adapters/stripe-billing-provider.ts",
     "packages/overlay-chat-core/src/messages.ts",
     "packages/overlay-chat-react/src/components/ChatExperienceHeader.tsx",
-    "packages/overlay-chat-react/src/components/ExchangeBlock.tsx",
     "packages/overlay-chat-react/src/components/GeneratedUiCard.tsx",
+    "packages/overlay-chat-react/src/styles/chat-surface.css",
+    "packages/overlay-modules-react/src/knowledge/surface.tsx",
     "packages/overlay-modules-react/src/knowledge/view-header.tsx",
-    "src/app/globals.css",
+    "packages/overlay-modules-react/src/notes/editor.tsx",
+    "packages/overlay-modules-react/src/notes/inline-diff-extension.ts",
     "src/app/pricing/PricingClient.tsx",
     "src/components/layout/AppSidebar.tsx",
     "src/features/account/components/OnboardingTour.tsx",
     "src/features/chat/components/ChatExperience.tsx",
     "src/features/chat/components/chat/useChatModelSelectionController.ts",
-    "src/features/knowledge/components/KnowledgeView.tsx",
-    "src/features/marketing/components/MarketingShowcase.tsx",
-    "src/features/notebook/components/InlineDiffExtension.ts",
-    "src/features/notebook/components/NotebookEditor.tsx",
     "src/features/projects/components/ProjectsView.tsx",
     "src/server/ai/gateway/gateway-search-tools.ts",
     "src/server/ai/sandbox/daytona.ts",
@@ -67,11 +66,11 @@
   ],
   "complexFunctionCounts": {
     "src/shared/config/overlayConfigSchema.ts#callback": 1,
+    "src/components/layout/AppSidebar.tsx#AppSidebar": 1,
+    "src/features/chat/components/ChatExperience.tsx#ChatExperience": 1,
     "src/server/app-api/v1/settings/route.ts#PATCH": 1,
     "src/components/providers/AppSettingsProvider.tsx#isAppSettingsPayload": 1,
     "src/features/chat/components/ChatMessage.tsx#TextChatMessage": 1,
-    "src/components/layout/AppSidebar.tsx#AppSidebar": 1,
-    "src/features/chat/components/ChatExperience.tsx#ChatExperience": 1,
     "src/server/app-api/v1/generate-video/route.ts#start": 1,
     "src/shared/tools/output-types.ts#classifyOutputType": 1,
     "packages/overlay-chat-core/src/visual-sequence.ts#buildAssistantVisualSequence": 1,
@@ -83,36 +82,38 @@
     "src/server/app-api/v1/generate-image/route.ts#POST": 1,
     "src/shared/chat/persist-assistant-turn.ts#buildAssistantPersistenceFromSteps": 1,
     "packages/overlay-chat-react/src/components/ChatExperienceHeader.tsx#ChatExperienceHeader": 1,
-    "src/features/notebook/components/InlineDiffExtension.ts#parseMarkdownLine": 1,
+    "packages/overlay-modules-react/src/knowledge/surface.tsx#SharedKnowledgeSurface": 1,
+    "packages/overlay-modules-react/src/notes/inline-diff-extension.ts#parseMarkdownLine": 1,
     "src/server/account/PostgresAccountDataDeletionRepository.ts#countUserRows": 1,
     "src/components/layout/AppSidebar.tsx#callback": 1,
     "src/shared/tools/tool-result-summary.ts#summarizeToolResultForTranscript": 1,
-    "packages/overlay-chat-react/src/components/ExchangeBlock.tsx#ExchangeBlock": 1,
-    "src/features/notebook/components/InlineDiffExtension.ts#parseMarkdownLines": 1,
+    "packages/overlay-modules-react/src/notes/inline-diff-extension.ts#parseMarkdownLines": 1,
+    "src/server/app-api/v1/browser-task/route.ts#POST": 1,
     "src/server/files/PostgresFileRepository.ts#callback": 1,
     "src/features/files/lib/export/markdown.ts#walk": 1,
-    "src/features/knowledge/components/KnowledgeView.tsx#KnowledgeView": 1,
-    "src/server/app-api/v1/browser-task/route.ts#POST": 1,
+    "packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx#ChatExchange": 1,
     "src/server/tools/tools/build.ts#buildOverlayToolSet": 1,
-    "packages/overlay-chat-react/src/components/ExchangeBlock.tsx#callback": 1,
+    "packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx#callback": 1,
     "src/features/chat/components/chat/chat-send-text.ts#sendTextTurn": 1,
+    "src/features/chat/components/chat/toChatTranscriptView.ts#callback": 1,
     "src/server/files/PostgresFileRepository.ts#normalizeFile": 1,
     "src/server/ai/sandbox/PostgresDaytonaReconciliationService.ts#reconcile": 1,
+    "src/server/app-api/v1/conversations/act/route.ts#POST": 1,
     "src/server/automations/AutomationService.ts#buildAutomationUpdateNote": 1,
     "src/server/knowledge/mention-resolver.ts#resolveOne": 1,
     "packages/overlay-billing/src/adapters/stripe-billing-provider.ts#verifyPaidPlanCheckoutSession": 1,
     "packages/overlay-chat-react/src/components/MediaSlotOutput.tsx#MediaSlotOutput": 1,
-    "src/server/app-api/v1/conversations/act/route.ts#POST": 1,
-    "packages/overlay-chat-react/src/components/tools/BrowserSessionToolBlock.tsx#BrowserSessionToolBlock": 1,
+    "src/app/api/v1/_utils/bff.ts#handleBffRoute": 1,
     "src/server/database/convex.ts#callConvex": 1,
     "packages/overlay-chat-core/src/tool-labels.ts#describeComposioIntegrationTool": 1,
+    "packages/overlay-modules-react/src/notes/editor.tsx#CanonicalNotebookEditor": 1,
     "src/features/chat/components/chat/chat-send-media.ts#sendMediaTurn": 1,
     "src/features/chat/components/ChatExperience.tsx#handleBranchConversationAtTurn": 1,
-    "packages/overlay-chat-react/src/lib/web-tool-sources.ts#collectSourceCandidatesFromUnknown": 1,
-    "src/features/files/components/FileViewer.tsx#FileViewer": 1,
-    "src/server/app-api/v1/conversations/act/extension-plan/route.ts#POST": 1
+    "src/server/app-api/v1/conversations/act/extension-plan/route.ts#POST": 1,
+    "packages/overlay-chat-react/src/lib/web-tool-sources.ts#collectSourceCandidatesFromUnknown": 1
   },
   "routeHandlersOverBudget": [
+    "src/server/app-api/v1/chat-suggestions/route.ts",
     "src/server/app-api/v1/conversations/act/extension-plan/route.ts",
     "src/server/app-api/v1/conversations/act/route.ts",
     "src/server/app-api/v1/conversations/route.ts",
@@ -186,16 +187,30 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
-      "file": "src/app/account/page.tsx",
+      "file": "src/app/%5F_fixtures/chat-parity/page.tsx",
       "layer": "src/app routes",
-      "loc": 387,
+      "loc": 23,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/%5F_fixtures/file-parity/page.tsx",
+      "layer": "src/app routes",
+      "loc": 22,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/about/page.tsx",
+      "layer": "src/app routes",
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/api/account/delete/route.ts",
       "layer": "src/app/api other",
-      "loc": 63,
+      "loc": 91,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -242,13 +257,6 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
-      "file": "src/app/api/auth/native/provider-keys/route.ts",
-      "layer": "src/app/api other",
-      "loc": 46,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
       "file": "src/app/api/auth/native/refresh/route.ts",
       "layer": "src/app/api other",
       "loc": 54,
@@ -258,7 +266,7 @@
     {
       "file": "src/app/api/auth/native/subscription/route.ts",
       "layer": "src/app/api other",
-      "loc": 90,
+      "loc": 54,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -279,7 +287,7 @@
     {
       "file": "src/app/api/auth/session/route.ts",
       "layer": "src/app/api other",
-      "loc": 51,
+      "loc": 55,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -349,14 +357,14 @@
     {
       "file": "src/app/api/latest-release/download/route.ts",
       "layer": "src/app/api other",
-      "loc": 23,
+      "loc": 34,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/api/latest-release/route.ts",
       "layer": "src/app/api other",
-      "loc": 15,
+      "loc": 26,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -732,6 +740,13 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/app/account/page.tsx",
+      "layer": "src/app routes",
+      "loc": 415,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/app/admin/page.tsx",
       "layer": "src/app routes",
       "loc": 142,
@@ -755,7 +770,7 @@
     {
       "file": "src/app/app/automations/page.tsx",
       "layer": "src/app routes",
-      "loc": 57,
+      "loc": 65,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -769,7 +784,7 @@
     {
       "file": "src/app/app/chat/page.tsx",
       "layer": "src/app routes",
-      "loc": 38,
+      "loc": 55,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -783,7 +798,14 @@
     {
       "file": "src/app/app/files/page.tsx",
       "layer": "src/app routes",
-      "loc": 47,
+      "loc": 52,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/app/home/page.tsx",
+      "layer": "src/app routes",
+      "loc": 22,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -832,7 +854,7 @@
     {
       "file": "src/app/app/layout.tsx",
       "layer": "src/app routes",
-      "loc": 64,
+      "loc": 71,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -840,6 +862,13 @@
       "file": "src/app/app/loading.tsx",
       "layer": "src/app routes",
       "loc": 4,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/app/manifesto/page.tsx",
+      "layer": "src/app routes",
+      "loc": 22,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -874,7 +903,7 @@
     {
       "file": "src/app/app/notes/page.tsx",
       "layer": "src/app routes",
-      "loc": 11,
+      "loc": 15,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -900,6 +929,13 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/app/pricing/page.tsx",
+      "layer": "src/app routes",
+      "loc": 24,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/app/projects/error.tsx",
       "layer": "src/app routes",
       "loc": 11,
@@ -916,7 +952,7 @@
     {
       "file": "src/app/app/projects/page.tsx",
       "layer": "src/app routes",
-      "loc": 35,
+      "loc": 43,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -937,7 +973,7 @@
     {
       "file": "src/app/app/settings/page.tsx",
       "layer": "src/app routes",
-      "loc": 343,
+      "loc": 346,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -951,7 +987,7 @@
     {
       "file": "src/app/app/tools/page.tsx",
       "layer": "src/app routes",
-      "loc": 13,
+      "loc": 21,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1000,7 +1036,7 @@
     {
       "file": "src/app/auth/native/callback/route.ts",
       "layer": "src/app routes",
-      "loc": 47,
+      "loc": 28,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1014,7 +1050,7 @@
     {
       "file": "src/app/auth/sign-in/page.tsx",
       "layer": "src/app routes",
-      "loc": 255,
+      "loc": 282,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1026,9 +1062,23 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/download/page.tsx",
+      "layer": "src/app routes",
+      "loc": 32,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/error.tsx",
       "layer": "src/app routes",
       "loc": 24,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/explore/[surface]/page.tsx",
+      "layer": "src/app routes",
+      "loc": 15,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1042,14 +1092,14 @@
     {
       "file": "src/app/home/page.tsx",
       "layer": "src/app routes",
-      "loc": 231,
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/layout.tsx",
       "layer": "src/app routes",
-      "loc": 79,
+      "loc": 81,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1063,21 +1113,21 @@
     {
       "file": "src/app/manifesto/page.tsx",
       "layer": "src/app routes",
-      "loc": 80,
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/page.tsx",
       "layer": "src/app routes",
-      "loc": 4,
+      "loc": 13,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/pricing/page.tsx",
       "layer": "src/app routes",
-      "loc": 6,
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1124,34 +1174,6 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
-      "file": "src/app/use-cases/business/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
-      "file": "src/app/use-cases/content/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
-      "file": "src/app/use-cases/developers/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
-      "file": "src/app/use-cases/education/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
       "file": "src/instrumentation-client.ts",
       "layer": "other",
       "loc": 43,
@@ -1168,9 +1190,23 @@
     {
       "file": "src/middleware.ts",
       "layer": "other",
-      "loc": 262,
+      "loc": 301,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "packages/overlay-chat-react/scripts/check-transcript-boundaries.mjs",
+      "layer": "packages/overlay-chat-react",
+      "loc": 169,
+      "classification": "review",
+      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
+    },
+    {
+      "file": "packages/overlay-chat-react/src/lib/web-tool-sources.ts",
+      "layer": "packages/overlay-chat-react",
+      "loc": 95,
+      "classification": "review",
+      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
     },
     {
       "file": "src/features/chat/components/chat/useEmptyChatStarters.ts",
@@ -1180,23 +1216,9 @@
       "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
     },
     {
-      "file": "src/features/knowledge/components/KnowledgeToolbarMenus.tsx",
+      "file": "src/features/notebook/lib/notebook-editor-blocks.ts",
       "layer": "src/features",
-      "loc": 5,
-      "classification": "review",
-      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
-    },
-    {
-      "file": "src/features/knowledge/components/KnowledgeViewHeader.tsx",
-      "layer": "src/features",
-      "loc": 8,
-      "classification": "review",
-      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
-    },
-    {
-      "file": "src/features/knowledge/components/KnowledgeViewHost.tsx",
-      "layer": "src/features",
-      "loc": 3,
+      "loc": 1,
       "classification": "review",
       "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
     },
@@ -1209,12 +1231,12 @@
     }
   ],
   "totals": {
-    "files": 1193,
-    "code": 133057,
-    "total": 147848,
-    "productionFiles": 1044,
-    "productionCode": 117463,
-    "testFiles": 149,
-    "testCode": 15594
+    "files": 1273,
+    "code": 143321,
+    "total": 159106,
+    "productionFiles": 1093,
+    "productionCode": 125534,
+    "testFiles": 180,
+    "testCode": 17787
   }
 }

--- a/package.json
+++ b/package.json
@@ -163,6 +163,8 @@
     "security:audit": "npm audit --omit=dev --audit-level=high",
     "check:owner-funded-boundary": "node scripts/check-owner-funded-boundary.mjs",
     "test:desktop-security:backend": "npm run check:desktop-provider-key-boundary && npm run check:owner-funded-boundary && npm run test:auth:native-validation && NODE_OPTIONS=--conditions=react-server tsx --test src/server/auth/session-transfer-crypto.test.ts src/server/billing/billing-runtime.test.ts src/server/billing/owner-funded-operations.test.ts src/server/billing/transcription-billing.test.ts src/server/security/rate-limit-specs.test.ts src/server/security/ssrf.test.ts src/server/shared/providers/convex-rate-limiter.test.ts src/server/outputs/GenerationUsagePolicy.test.ts src/server/releases/desktop-download-policy.test.ts",
+    "test:desktop-security:hostile-matrix": "node scripts/desktop-hostile-client-matrix.mjs",
+    "test:desktop-security:hostile-matrix:unit": "node --test scripts/desktop-hostile-client-matrix.test.mjs",
     "video:studio": "npx remotion studio src/remotion/index.ts",
     "video:render:launch": "mkdir -p renders && npx remotion render src/remotion/index.ts overlay-launch-video renders/overlay-launch-video.mp4",
     "test:auth:env": "node --experimental-strip-types scripts/auth-dev-env-check.ts",

--- a/scripts/desktop-hostile-client-matrix.mjs
+++ b/scripts/desktop-hostile-client-matrix.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const PROVIDER_EXECUTION_ACK = 'I_UNDERSTAND_THIS_MAY_INCUR_PROVIDER_COSTS'
+const MAX_RESPONSE_BYTES = 8_192
+const PRODUCTION_HOSTS = new Set(['getoverlay.io', 'www.getoverlay.io'])
+
+export async function runHostileClientMatrix(config, options = {}) {
+  validateConfig(config)
+  const env = options.env ?? process.env
+  const fetchImpl = options.fetchImpl ?? fetch
+  const executeProviders =
+    options.executeProviders ??
+    env.OVERLAY_HOSTILE_CLIENT_EXECUTE_PROVIDER === '1'
+
+  if (
+    executeProviders &&
+    env.OVERLAY_HOSTILE_CLIENT_ACK !== PROVIDER_EXECUTION_ACK
+  ) {
+    throw new Error(
+      `Set OVERLAY_HOSTILE_CLIENT_ACK=${PROVIDER_EXECUTION_ACK} before running cost-bearing provider cases.`,
+    )
+  }
+
+  const runId = config.runId || `hostile-${new Date().toISOString()}`
+  const report = {
+    schemaVersion: 1,
+    runId,
+    startedAt: new Date().toISOString(),
+    sourceCommit: config.sourceCommit || null,
+    executeProviders,
+    targets: [],
+    passed: false,
+  }
+
+  for (const target of config.targets) {
+    assertSafeTarget(target, env)
+    const token = env[target.tokenEnv]?.trim()
+    if (!token) throw new Error(`Missing token environment variable ${target.tokenEnv}`)
+
+    const targetReport = {
+      name: target.name,
+      backend: target.backend,
+      provider: target.provider,
+      baseUrl: new URL(target.baseUrl).origin,
+      route: target.request.path,
+      cases: [],
+      providerExecution: executeProviders ? 'requested' : 'skipped',
+      externalEvidenceRequired: [
+        'provider invocation count',
+        'provider charge or usage entry',
+        'Overlay reservation and reconciliation records',
+        'security event correlation by runId',
+      ],
+      passed: false,
+    }
+    report.targets.push(targetReport)
+
+    await recordCase(targetReport, 'discovery', async () => {
+      const response = await fetchImpl(new URL('/api/v1/discovery', target.baseUrl), {
+        headers: { 'x-overlay-security-run-id': runId },
+      })
+      expectStatus(response, target.expected?.discovery ?? [200])
+      return summarizeResponse(response)
+    })
+
+    await recordCase(targetReport, 'missing-authentication', async () => {
+      const response = await sendTargetRequest(fetchImpl, target, {
+        env,
+        runId,
+      })
+      expectStatus(response, target.expected?.unauthenticated ?? [401])
+      return summarizeResponse(response)
+    })
+
+    await recordCase(targetReport, 'invalid-bearer-token', async () => {
+      const response = await sendTargetRequest(fetchImpl, target, {
+        env,
+        runId,
+        token: 'hostile-invalid-token',
+      })
+      expectStatus(response, target.expected?.invalidToken ?? [401])
+      return summarizeResponse(response)
+    })
+
+    await recordCase(targetReport, 'identity-substitution', async () => {
+      const response = await sendTargetRequest(fetchImpl, target, {
+        claimedUserId: `forged-${runId}`,
+        env,
+        runId,
+        token,
+      })
+      expectStatus(response, target.expected?.identitySubstitution ?? [401])
+      return summarizeResponse(response)
+    })
+
+    await recordCase(targetReport, 'missing-idempotency-key', async () => {
+      const response = await sendTargetRequest(fetchImpl, target, {
+        env,
+        runId,
+        token,
+      })
+      expectStatus(response, target.expected?.missingIdempotency ?? [428])
+      return summarizeResponse(response)
+    })
+
+    if (target.deniedMutation?.bodyPatch) {
+      await recordCase(targetReport, 'server-policy-substitution', async () => {
+        const response = await sendTargetRequest(fetchImpl, target, {
+          bodyPatch: target.deniedMutation.bodyPatch,
+          env,
+          idempotencyKey: `${runId}-${target.name}-denied`,
+          runId,
+          token,
+        })
+        expectStatus(
+          response,
+          target.deniedMutation.expectedStatuses ?? [403],
+        )
+        return summarizeResponse(response)
+      })
+    }
+
+    if (executeProviders) {
+      await recordCase(targetReport, 'concurrency-disconnect-replay', async () => {
+        const idempotencyKey = `${runId}-${target.name}-provider`
+        const request = {
+          env,
+          idempotencyKey,
+          runId,
+          token,
+        }
+        const [first, second] = await Promise.all([
+          sendTargetRequest(fetchImpl, target, request),
+          sendTargetRequest(fetchImpl, target, request),
+        ])
+        const successStatuses = target.expected?.success ?? [200, 201, 202]
+        const responses = [first, second]
+        const successful = responses.filter((response) =>
+          successStatuses.includes(response.status),
+        )
+        const blocked = responses.filter((response) => response.status === 409)
+        if (successful.length !== 1 || blocked.length !== 1) {
+          throw new Error(
+            `Expected one provider request and one 409 concurrency rejection; received ${responses.map((response) => response.status).join(', ')}`,
+          )
+        }
+
+        await successful[0].body?.cancel().catch(() => undefined)
+        const retry = await sendTargetRequest(fetchImpl, target, request)
+        if (target.idempotencyKind === 'json') {
+          expectStatus(retry, successStatuses)
+          if (retry.headers.get('idempotency-replayed') !== 'true') {
+            throw new Error('Expected Idempotency-Replayed: true on JSON replay')
+          }
+        } else {
+          expectStatus(retry, [409])
+        }
+        const conflictingReplay = await sendTargetRequest(fetchImpl, target, {
+          ...request,
+          bodyPatch: { hostileReplayNonce: `${runId}-different-body` },
+        })
+        expectStatus(conflictingReplay, [409])
+        targetReport.providerExecution = 'completed'
+        return {
+          concurrentStatuses: responses.map((response) => response.status),
+          retry: await summarizeResponse(retry),
+          conflictingReplay: await summarizeResponse(conflictingReplay),
+          disconnectedSuccessfulStream: true,
+        }
+      })
+    }
+
+    targetReport.passed = targetReport.cases.every((entry) => entry.passed)
+  }
+
+  report.completedAt = new Date().toISOString()
+  report.passed = report.targets.every((target) => target.passed)
+  return report
+}
+
+async function recordCase(targetReport, name, run) {
+  const startedAt = Date.now()
+  try {
+    const evidence = await run()
+    targetReport.cases.push({
+      name,
+      passed: true,
+      durationMs: Date.now() - startedAt,
+      evidence,
+    })
+  } catch (error) {
+    targetReport.cases.push({
+      name,
+      passed: false,
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+async function sendTargetRequest(fetchImpl, target, options) {
+  const url = new URL(target.request.path, target.baseUrl)
+  for (const [name, value] of Object.entries(target.request.query ?? {})) {
+    url.searchParams.set(name, String(value))
+  }
+  const method = (target.request.method ?? 'POST').toUpperCase()
+  if (method === 'GET') {
+    for (const [name, value] of Object.entries(options.bodyPatch ?? {})) {
+      url.searchParams.set(name, String(value))
+    }
+    if (options.claimedUserId) url.searchParams.set('userId', options.claimedUserId)
+  }
+  const headers = new Headers(target.request.headers ?? {})
+  headers.set('x-overlay-security-run-id', options.runId)
+  if (options.token) headers.set('authorization', `Bearer ${options.token}`)
+  if (options.idempotencyKey) {
+    headers.set('idempotency-key', options.idempotencyKey)
+  }
+
+  let body
+  if (method === 'GET' || method === 'HEAD') {
+    body = undefined
+  } else if (target.request.bodyType === 'multipart') {
+    const form = new FormData()
+    for (const [name, value] of Object.entries(target.request.fields ?? {})) {
+      form.set(name, String(value))
+    }
+    for (const [name, value] of Object.entries(options.bodyPatch ?? {})) {
+      form.set(name, String(value))
+    }
+    if (options.claimedUserId) form.set('userId', options.claimedUserId)
+    const file = target.request.file
+    if (file) {
+      const filePath = options.env[file.pathEnv]?.trim()
+      if (!filePath) throw new Error(`Missing file path environment variable ${file.pathEnv}`)
+      const bytes = fs.readFileSync(filePath)
+      form.set(
+        file.field,
+        new Blob([bytes], { type: file.contentType || 'application/octet-stream' }),
+        file.filename || path.basename(filePath),
+      )
+    }
+    body = form
+  } else {
+    headers.set('content-type', 'application/json')
+    body = JSON.stringify({
+      ...(target.request.json ?? {}),
+      ...(options.bodyPatch ?? {}),
+      ...(options.claimedUserId ? { userId: options.claimedUserId } : {}),
+    })
+  }
+
+  return fetchImpl(url, {
+    method,
+    headers,
+    body,
+  })
+}
+
+function expectStatus(response, expected) {
+  if (!expected.includes(response.status)) {
+    throw new Error(
+      `Expected HTTP ${expected.join(' or ')}, received ${response.status}`,
+    )
+  }
+}
+
+async function summarizeResponse(response) {
+  const summary = {
+    status: response.status,
+    cacheControl: response.headers.get('cache-control'),
+    idempotencyStatus: response.headers.get('idempotency-status'),
+    idempotencyReplayed: response.headers.get('idempotency-replayed'),
+    retryAfter: response.headers.get('retry-after'),
+    requestId: response.headers.get('x-request-id'),
+  }
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.includes('json')) return summary
+
+  const text = (await response.clone().text()).slice(0, MAX_RESPONSE_BYTES)
+  try {
+    const parsed = JSON.parse(text)
+    if (parsed && typeof parsed === 'object') {
+      summary.code = stringValue(parsed.code)
+      summary.error = stringValue(parsed.error)
+    }
+  } catch {
+    summary.unparseableJson = true
+  }
+  return summary
+}
+
+function stringValue(value) {
+  return typeof value === 'string' ? value.slice(0, 256) : null
+}
+
+function validateConfig(config) {
+  if (!config || config.schemaVersion !== 1 || !Array.isArray(config.targets)) {
+    throw new Error('Hostile-client matrix config must use schemaVersion 1 and include targets[]')
+  }
+  if (config.targets.length === 0) throw new Error('At least one target is required')
+  const names = new Set()
+  for (const target of config.targets) {
+    if (!target.name || names.has(target.name)) {
+      throw new Error(`Target names must be present and unique: ${target.name || '<missing>'}`)
+    }
+    names.add(target.name)
+    if (!target.backend || !target.provider || !target.baseUrl || !target.tokenEnv) {
+      throw new Error(`Target ${target.name} is missing backend, provider, baseUrl, or tokenEnv`)
+    }
+    if (!target.request?.path?.startsWith('/api/v1/')) {
+      throw new Error(`Target ${target.name} must use an /api/v1/ route`)
+    }
+  }
+}
+
+function assertSafeTarget(target, env) {
+  const url = new URL(target.baseUrl)
+  if (url.protocol !== 'https:' && !['localhost', '127.0.0.1', '::1'].includes(url.hostname)) {
+    throw new Error(`Target ${target.name} must use HTTPS unless it is local`)
+  }
+  if (
+    PRODUCTION_HOSTS.has(url.hostname) &&
+    env.OVERLAY_HOSTILE_CLIENT_ALLOW_PRODUCTION !== '1'
+  ) {
+    throw new Error(
+      `Refusing production target ${url.hostname}; use a dedicated test deployment. Set OVERLAY_HOSTILE_CLIENT_ALLOW_PRODUCTION=1 only for an explicitly approved production drill.`,
+    )
+  }
+}
+
+async function main() {
+  const configPath = valueArg('--config')
+  if (!configPath) throw new Error('Usage: desktop-hostile-client-matrix.mjs --config=<path> [--output=<private-path>]')
+  const config = JSON.parse(fs.readFileSync(path.resolve(configPath), 'utf8'))
+  const report = await runHostileClientMatrix(config)
+  const outputPath = valueArg('--output')
+  const rendered = `${JSON.stringify(report, null, 2)}\n`
+  if (outputPath) {
+    fs.writeFileSync(path.resolve(outputPath), rendered, { mode: 0o600 })
+    console.log(`Hostile-client evidence written to ${path.resolve(outputPath)}`)
+  } else {
+    process.stdout.write(rendered)
+  }
+  if (!report.passed) process.exitCode = 1
+}
+
+function valueArg(prefix) {
+  return process.argv.find((arg) => arg.startsWith(`${prefix}=`))?.slice(prefix.length + 1)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  })
+}

--- a/scripts/desktop-hostile-client-matrix.test.mjs
+++ b/scripts/desktop-hostile-client-matrix.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { runHostileClientMatrix } from './desktop-hostile-client-matrix.mjs'
+
+const config = {
+  schemaVersion: 1,
+  runId: 'test-run',
+  targets: [
+    {
+      name: 'convex-ai-gateway',
+      backend: 'convex',
+      provider: 'ai-gateway',
+      baseUrl: 'https://preview.example.test',
+      tokenEnv: 'TEST_TOKEN',
+      request: {
+        path: '/api/v1/conversations/act',
+        json: { messages: [{ role: 'user', content: 'Return OK' }], modelId: 'test-model' },
+      },
+      deniedMutation: {
+        bodyPatch: { modelId: 'denied-model' },
+      },
+    },
+  ],
+}
+
+test('control-only matrix covers unauthenticated, forged identity, idempotency, and policy cases', async () => {
+  const fetchImpl = async (input, init = {}) => {
+    const url = new URL(input)
+    if (url.pathname === '/api/v1/discovery') return json(200, { ok: true })
+    const headers = new Headers(init.headers)
+    const authorization = headers.get('authorization')
+    if (!authorization || authorization.includes('invalid-token')) return json(401, { error: 'Unauthorized' })
+    const body = JSON.parse(String(init.body))
+    if (body.userId?.startsWith('forged-')) return json(401, { error: 'Unauthorized' })
+    if (!headers.get('idempotency-key')) return json(428, { code: 'idempotency_key_required' })
+    if (body.modelId === 'denied-model') return json(403, { error: 'model_not_allowed' })
+    return json(500, { error: 'unexpected_provider_execution' })
+  }
+
+  const report = await runHostileClientMatrix(config, {
+    env: { TEST_TOKEN: 'secret-test-token' },
+    fetchImpl,
+    executeProviders: false,
+  })
+
+  assert.equal(report.passed, true)
+  assert.equal(report.targets[0].cases.length, 6)
+  assert.equal(JSON.stringify(report).includes('secret-test-token'), false)
+})
+
+test('provider matrix requires explicit cost acknowledgement', async () => {
+  await assert.rejects(
+    runHostileClientMatrix(config, {
+      env: { TEST_TOKEN: 'secret-test-token' },
+      fetchImpl: async () => json(200, {}),
+      executeProviders: true,
+    }),
+    /I_UNDERSTAND_THIS_MAY_INCUR_PROVIDER_COSTS/,
+  )
+})
+
+test('provider matrix proves one concurrent start followed by replay rejection', async () => {
+  const started = new Set()
+  const fetchImpl = async (input, init = {}) => {
+    const url = new URL(input)
+    if (url.pathname === '/api/v1/discovery') return json(200, { ok: true })
+    const headers = new Headers(init.headers)
+    const authorization = headers.get('authorization')
+    if (!authorization || authorization.includes('invalid-token')) return json(401, { error: 'Unauthorized' })
+    const body = JSON.parse(String(init.body))
+    if (body.userId?.startsWith('forged-')) return json(401, { error: 'Unauthorized' })
+    const key = headers.get('idempotency-key')
+    if (!key) return json(428, { code: 'idempotency_key_required' })
+    if (body.modelId === 'denied-model') return json(403, { error: 'model_not_allowed' })
+    if (started.has(key)) return json(409, { code: 'stream_already_started' })
+    started.add(key)
+    return new Response('provider stream', {
+      status: 200,
+      headers: { 'content-type': 'text/plain', 'idempotency-status': 'stream-started' },
+    })
+  }
+
+  const report = await runHostileClientMatrix(config, {
+    env: {
+      TEST_TOKEN: 'secret-test-token',
+      OVERLAY_HOSTILE_CLIENT_ACK: 'I_UNDERSTAND_THIS_MAY_INCUR_PROVIDER_COSTS',
+    },
+    fetchImpl,
+    executeProviders: true,
+  })
+
+  assert.equal(report.passed, true)
+  assert.equal(report.targets[0].providerExecution, 'completed')
+  assert.deepEqual(
+    [...report.targets[0].cases.at(-1).evidence.concurrentStatuses].sort(),
+    [200, 409],
+  )
+})
+
+test('production hosts are rejected unless explicitly approved', async () => {
+  const productionConfig = structuredClone(config)
+  productionConfig.targets[0].baseUrl = 'https://www.getoverlay.io'
+  await assert.rejects(
+    runHostileClientMatrix(productionConfig, {
+      env: { TEST_TOKEN: 'secret-test-token' },
+      fetchImpl: async () => json(200, {}),
+    }),
+    /Refusing production target/,
+  )
+})
+
+function json(status, body, headers = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  })
+}

--- a/scripts/fixtures/desktop-hostile-client-matrix.example.json
+++ b/scripts/fixtures/desktop-hostile-client-matrix.example.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": 1,
+  "runId": "gate-a-YYYYMMDD",
+  "sourceCommit": "40-character-server-source-commit",
+  "targets": [
+    {
+      "name": "convex-ai-gateway",
+      "backend": "convex",
+      "provider": "ai-gateway",
+      "baseUrl": "https://dedicated-security-preview.example.com",
+      "tokenEnv": "HOSTILE_CONVEX_AI_GATEWAY_TOKEN",
+      "idempotencyKind": "stream",
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/conversations/act",
+        "json": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "Return exactly OVERLAY_HOSTILE_CLIENT_OK. Do not use tools."
+            }
+          ],
+          "modelId": "replace-with-allowed-model",
+          "mode": "chat",
+          "memoryEnabled": false
+        }
+      },
+      "deniedMutation": {
+        "bodyPatch": {
+          "modelId": "replace-with-server-denied-model"
+        },
+        "expectedStatuses": [
+          403
+        ]
+      }
+    },
+    {
+      "name": "postgres-openrouter",
+      "backend": "postgres",
+      "provider": "openrouter",
+      "baseUrl": "https://dedicated-postgres-security-preview.example.com",
+      "tokenEnv": "HOSTILE_POSTGRES_OPENROUTER_TOKEN",
+      "idempotencyKind": "stream",
+      "request": {
+        "method": "POST",
+        "path": "/api/v1/conversations/act",
+        "json": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "Return exactly OVERLAY_HOSTILE_CLIENT_OK. Do not use tools."
+            }
+          ],
+          "modelId": "replace-with-allowed-model",
+          "mode": "chat",
+          "memoryEnabled": false
+        }
+      },
+      "deniedMutation": {
+        "bodyPatch": {
+          "modelId": "replace-with-server-denied-model"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a fail-closed hostile-client matrix runner with explicit cost and production acknowledgements
- cover authentication substitution, server-policy substitution, required idempotency, concurrency, disconnect, replay, and conflicting-body cases
- add a redacted evidence procedure and example Convex/Postgres matrix
- advance the existing complexity ratchet baseline without changing its limits
- align the desktop gitlink to the Gate A candidate from LayerNorm/overlay-desktop#24

## Verification
- npm run test:desktop-security:hostile-matrix:unit
- npm run test:desktop-security:backend
- npm run check:web-complexity
- npm run typecheck
- npm run security:audit
- npm run docs:check
- targeted ESLint on the new scripts

Full local lint remains polluted by ignored local .agents skill assets; the changed scripts pass targeted ESLint. This PR depends on LayerNorm/overlay-desktop#24 being merged first. Live provider execution still requires dedicated test deployments, capped test credentials, and private evidence capture.