### PR TITLE
Fix chat suggestions 428 idempotency guard

### DIFF
--- a/scripts/check-owner-funded-boundary.mjs
+++ b/scripts/check-owner-funded-boundary.mjs
@@ -22,7 +22,10 @@ for (const [file, reservationMarker, startMarker] of rules) {
 }
 
 const bff = readFileSync('src/app/api/v1/_utils/bff.ts', 'utf8')
-if (!bff.includes('getOwnerFundedOperation') || !bff.includes('idempotency_key_required')) {
+if (
+  !bff.includes('ownerFundedOperationRequiresIdempotencyKey') ||
+  !bff.includes('idempotency_key_required')
+) {
   failures.push('BFF does not fail closed when an owner-funded mutation omits Idempotency-Key')
 }
 

--- a/src/app/api/v1/_utils/bff.ts
+++ b/src/app/api/v1/_utils/bff.ts
@@ -27,7 +27,10 @@ import {
   appDataRouteUnsupportedResponse,
   getAppDataRouteSupport,
 } from '@/server/app-data/route-support'
-import { getOwnerFundedOperation } from '@/server/billing/owner-funded-operations'
+import {
+  getOwnerFundedOperation,
+  ownerFundedOperationRequiresIdempotencyKey,
+} from '@/server/billing/owner-funded-operations'
 import { hashOperationalIdentifier } from '@/server/security/operational-key-hash'
 import { logSecurityEvent } from '@/server/observability/security-events'
 
@@ -139,7 +142,10 @@ export async function handleBffRoute(
     request.method,
     request.nextUrl.pathname,
   )
-  if (ownerFundedOperation && !request.headers.get('idempotency-key')?.trim()) {
+  if (
+    ownerFundedOperationRequiresIdempotencyKey(ownerFundedOperation) &&
+    !request.headers.get('idempotency-key')?.trim()
+  ) {
     logSecurityEvent('owner_funded_idempotency_missing', {
       authType: auth.authType,
       operation: ownerFundedOperation.id,

--- a/src/server/billing/owner-funded-operations.test.ts
+++ b/src/server/billing/owner-funded-operations.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
   getOwnerFundedOperation,
+  ownerFundedOperationRequiresIdempotencyKey,
   OWNER_FUNDED_OPERATIONS,
 } from './owner-funded-operations'
 
@@ -27,3 +28,17 @@ test('owner-funded operation registry is exact and has unique routes and ids', (
   )
 })
 
+test('idempotency keys are required for owner-funded mutations but not reads', () => {
+  assert.equal(
+    ownerFundedOperationRequiresIdempotencyKey(
+      getOwnerFundedOperation('POST', '/api/v1/conversations/act'),
+    ),
+    true,
+  )
+  assert.equal(
+    ownerFundedOperationRequiresIdempotencyKey(
+      getOwnerFundedOperation('GET', '/api/v1/chat-suggestions'),
+    ),
+    false,
+  )
+})

--- a/src/server/billing/owner-funded-operations.ts
+++ b/src/server/billing/owner-funded-operations.ts
@@ -66,6 +66,8 @@ export const OWNER_FUNDED_OPERATIONS = [
 export type OwnerFundedOperation = (typeof OWNER_FUNDED_OPERATIONS)[number]
 export type OwnerFundedOperationId = OwnerFundedOperation['id']
 
+const IDEMPOTENCY_REQUIRED_METHODS = new Set(['POST', 'PATCH', 'DELETE'])
+
 const OWNER_FUNDED_OPERATION_BY_ROUTE = new Map<string, OwnerFundedOperation>(
   OWNER_FUNDED_OPERATIONS.map((operation) => [
     `${operation.method} ${operation.path}`,
@@ -80,4 +82,10 @@ export function getOwnerFundedOperation(
   return OWNER_FUNDED_OPERATION_BY_ROUTE.get(
     `${method.toUpperCase()} ${pathname}`,
   ) ?? null
+}
+
+export function ownerFundedOperationRequiresIdempotencyKey(
+  operation: OwnerFundedOperation | null,
+): operation is OwnerFundedOperation {
+  return Boolean(operation && IDEMPOTENCY_REQUIRED_METHODS.has(operation.method))
 }


### PR DESCRIPTION
## Summary
- keep owner-funded GET helpers under the enhanced rate-limit registry
- require Idempotency-Key only for owner-funded mutation methods
- add regression coverage for chat suggestions and the Act mutation

## Verification
- `NODE_OPTIONS=--require=./scripts/register-server-only.cjs npx tsx --test src/server/billing/owner-funded-operations.test.ts`
- `npm run check:owner-funded-boundary`
- `npx eslint src/server/billing/owner-funded-operations.ts src/server/billing/owner-funded-operations.test.ts src/app/api/v1/_utils/bff.ts scripts/check-owner-funded-boundary.mjs`
- `npx tsc --noEmit --pretty false`