### PR TITLE
Fix production chat preflight config coupling

### DIFF
--- a/src/server/ai/model-policy-authority.test.ts
+++ b/src/server/ai/model-policy-authority.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveRuntimeChatAllowlist } from './model-policy-authority'
+
+test('uses the validated runtime model allowlist when configuration is available', async () => {
+  const allowlist = await resolveRuntimeChatAllowlist(async () => ({
+    llm: { modelAllowlist: ['meta/muse-spark-1.1', 'openrouter/free'] },
+  }) as never)
+
+  assert.deepEqual([...allowlist!], ['meta/muse-spark-1.1', 'openrouter/free'])
+})
+
+test('preserves the direct environment allowlist when unrelated runtime validation fails', async () => {
+  const allowlist = await resolveRuntimeChatAllowlist(
+    async () => { throw new Error('Production Stripe billing requires a live key') },
+    { LLM_MODEL_ALLOWLIST: ' meta/muse-spark-1.1, openrouter/free ' },
+  )
+
+  assert.deepEqual([...allowlist!], ['meta/muse-spark-1.1', 'openrouter/free'])
+})
+
+test('falls back to the live server catalog when no explicit allowlist exists', async () => {
+  const allowlist = await resolveRuntimeChatAllowlist(
+    async () => { throw new Error('runtime config unavailable') },
+    {},
+  )
+
+  assert.equal(allowlist, null)
+})

--- a/src/server/ai/model-policy-authority.ts
+++ b/src/server/ai/model-policy-authority.ts
@@ -12,6 +12,32 @@ import { isFreeTierChatModelId } from '@/shared/ai/gateway/model-types'
 import { isPaidPlan } from '@/server/billing/billing-runtime'
 import { logger } from '@/server/observability/logger'
 
+type RuntimeConfigLoader = typeof getOverlayRuntimeConfig
+
+export async function resolveRuntimeChatAllowlist(
+  loadRuntimeConfig: RuntimeConfigLoader = getOverlayRuntimeConfig,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): Promise<Set<string> | null> {
+  try {
+    const runtimeConfig = await loadRuntimeConfig()
+    return runtimeConfig.llm.modelAllowlist.length
+      ? new Set(runtimeConfig.llm.modelAllowlist)
+      : null
+  } catch (error) {
+    // Chat authorization should not be coupled to validation of unrelated
+    // runtime sections such as Stripe or storage. Preserve any explicit model
+    // restriction directly from the environment and continue fail-soft.
+    logger.warn('[model-policy] Runtime config unavailable; using direct model allowlist fallback', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    const modelIds = (env.LLM_MODEL_ALLOWLIST ?? '')
+      .split(',')
+      .map((modelId) => modelId.trim())
+      .filter(Boolean)
+    return modelIds.length ? new Set(modelIds) : null
+  }
+}
+
 /**
  * Resolve which model IDs the user may use.
  *
@@ -35,11 +61,8 @@ export async function resolveAuthorizedModelIds(args: {
     })
   }
 
-  const runtimeConfig = await getOverlayRuntimeConfig()
   const context = { entitlements: args.entitlements, user: null }
-  const runtimeChatAllowlist = runtimeConfig.llm.modelAllowlist.length
-    ? new Set(runtimeConfig.llm.modelAllowlist)
-    : null
+  const runtimeChatAllowlist = await resolveRuntimeChatAllowlist()
 
   const policyChatModels =
     overlayAppConfig.modelPolicy?.filterChatModels?.(AVAILABLE_MODELS, context) ??


### PR DESCRIPTION
## Summary
- keep chat model authorization independent of unrelated runtime config validation
- preserve `LLM_MODEL_ALLOWLIST` directly when the full config cannot load
- add focused regression tests for validated, fallback, and catalog-wide authorization

## QA
- `NODE_OPTIONS=--require=./scripts/register-server-only.cjs ./node_modules/.bin/tsx --test src/server/ai/model-policy-authority.test.ts` (3/3 pass)
- targeted ESLint: no errors (one pre-existing layer warning)
- full typecheck blocked in the fresh worktree by missing nested desktop submodule imports