### PR TITLE
Fix collaborative chat correctness foundation

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -111,6 +111,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout v4
+        with:
+          submodules: recursive
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -111,8 +111,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout v4
-        with:
-          submodules: recursive
+
+      - name: Initialize desktop submodule for boundary checks
+        run: git submodule update --init --depth=1 overlay-desktop
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node v4

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as collaboration_agents from "../collaboration/agents.js";
 import type * as collaboration_channels from "../collaboration/channels.js";
 import type * as collaboration_conversationMigration from "../collaboration/conversationMigration.js";
 import type * as collaboration_directMessages from "../collaboration/directMessages.js";
+import type * as collaboration_events from "../collaboration/events.js";
 import type * as collaboration_sharing from "../collaboration/sharing.js";
 import type * as collaboration_workspaces from "../collaboration/workspaces.js";
 import type * as crons from "../crons.js";
@@ -89,6 +90,7 @@ declare const fullApi: ApiFromModules<{
   "collaboration/channels": typeof collaboration_channels;
   "collaboration/conversationMigration": typeof collaboration_conversationMigration;
   "collaboration/directMessages": typeof collaboration_directMessages;
+  "collaboration/events": typeof collaboration_events;
   "collaboration/sharing": typeof collaboration_sharing;
   "collaboration/workspaces": typeof collaboration_workspaces;
   crons: typeof crons;

--- a/convex/chat/conversations.ts
+++ b/convex/chat/conversations.ts
@@ -7,6 +7,7 @@ import type { Doc, Id } from '../_generated/dataModel'
 import type { MutationCtx, QueryCtx } from '../_generated/server'
 import { requireAccessToken, validateServerSecret } from '../lib/auth'
 import { applyStorageUsageDelta } from '../files/lib/storageQuota'
+import { recordConversationEvent } from '../collaboration/events'
 
 const generatedUiVariant = v.object({
   id: v.string(),
@@ -807,6 +808,8 @@ export const getRecentMessages = query({
     limit: v.optional(v.number()),
     beforeCreatedAt: v.optional(v.number()),
     compactToolPayloads: v.optional(v.boolean()),
+    mainOnly: v.optional(v.boolean()),
+    threadRootMessageId: v.optional(v.id('conversationMessages')),
     workspaceId: v.optional(v.string()),
   },
   handler: async (ctx, {
@@ -818,6 +821,8 @@ export const getRecentMessages = query({
     limit,
     beforeCreatedAt,
     compactToolPayloads,
+    mainOnly,
+    threadRootMessageId,
   }) => {
     try {
       await authorizeUserAccess({ userId, accessToken, serverSecret })
@@ -851,7 +856,13 @@ export const getRecentMessages = query({
       })
       .order('desc')
       .take(scanLimit)
-    const messages = selectRecentConversationMessages(recentScan, safeLimit)
+    const scopedScan = recentScan.filter((message) => (
+      (mainOnly ? !message.threadRootMessageId : true)
+      && (threadRootMessageId ? message.threadRootMessageId === threadRootMessageId : true)
+    ))
+    const messages = mainOnly || threadRootMessageId
+      ? scopedScan.slice(0, safeLimit).sort((a, b) => a.createdAt - b.createdAt)
+      : selectRecentConversationMessages(scopedScan, safeLimit)
     const generating = messages.filter((message) => message.status === 'generating')
     if (generating.length === 0) {
       return messages.map((message) => compactMessageForHistory(message, compactToolPayloads))
@@ -1056,6 +1067,13 @@ export const addMessage = mutation({
       ? (await ctx.db.patch(match._id, payload), match._id)
       : await ctx.db.insert('conversationMessages', payload)
     await ctx.db.patch(args.conversationId, { lastModified: now, updatedAt: now })
+    await recordConversationEvent(ctx, {
+      conversationId: args.conversationId,
+      workspaceId: conversation.workspaceId,
+      userId: args.userId,
+      type: match ? 'message.updated' : 'message.created',
+      messageId: msgId,
+    })
 
 	    if (args.role === 'user' && args.skipMemoryExtraction !== true) {
 	      try {
@@ -1155,6 +1173,13 @@ export const startGeneratingMessage = mutation({
       ? (await ctx.db.patch(match._id, payload), match._id)
       : await ctx.db.insert('conversationMessages', payload)
     await ctx.db.patch(args.conversationId, { lastModified: now, updatedAt: now })
+    await recordConversationEvent(ctx, {
+      conversationId: args.conversationId,
+      workspaceId: conversation?.workspaceId,
+      userId: args.userId,
+      type: match ? 'message.updated' : 'message.created',
+      messageId: id,
+    })
     return id
   },
 })
@@ -1218,6 +1243,14 @@ export const finalizeGeneratingMessage = mutation({
     })
     await deleteMessageDeltas(ctx, args.messageId)
     await ctx.db.patch(message.conversationId, { lastModified: now, updatedAt: now })
+    const conversation = await ctx.db.get(message.conversationId)
+    await recordConversationEvent(ctx, {
+      conversationId: message.conversationId,
+      workspaceId: conversation?.workspaceId,
+      userId: message.userId,
+      type: 'message.completed',
+      messageId: args.messageId,
+    })
   },
 })
 
@@ -1296,6 +1329,14 @@ export const failGeneratingMessage = mutation({
     })
     await deleteMessageDeltas(ctx, messageId)
     await ctx.db.patch(message.conversationId, { lastModified: now, updatedAt: now })
+    const conversation = await ctx.db.get(message.conversationId)
+    await recordConversationEvent(ctx, {
+      conversationId: message.conversationId,
+      workspaceId: conversation?.workspaceId,
+      userId: message.userId,
+      type: 'message.failed',
+      messageId,
+    })
   },
 })
 

--- a/convex/collaboration/directMessages.ts
+++ b/convex/collaboration/directMessages.ts
@@ -95,6 +95,7 @@ async function participantView(
     updatedAt: participant.updatedAt,
     removedAt: participant.removedAt,
     lastReadAt: participant.lastReadAt,
+    lastReadSequence: participant.lastReadSequence,
     markedUnreadAt: participant.markedUnreadAt,
     archivedAt: participant.archivedAt,
   }
@@ -163,7 +164,6 @@ export const createDirectMessage = mutation({
       }
     }
 
-    let sourceMessages: Doc<'conversationMessages'>[] = []
     if (args.sourceConversationId) {
       const source = await ctx.db.get(args.sourceConversationId)
       if (
@@ -173,9 +173,6 @@ export const createDirectMessage = mutation({
         || (source.conversationType ?? 'personal') !== 'personal'
         || source.deletedAt
       ) throw new Error('The source Personal chat is unavailable')
-      sourceMessages = await ctx.db.query('conversationMessages')
-        .withIndex('by_conversationId_createdAt', (q) => q.eq('conversationId', source._id))
-        .collect()
     }
 
     const now = Date.now()
@@ -232,13 +229,6 @@ export const createDirectMessage = mutation({
       createdAt: now,
       updatedAt: now,
     })
-    for (const message of sourceMessages) {
-      const { _id: _messageId, _creationTime: _createdByConvex, clientNonce: _clientNonce, ...copy } = message
-      void _messageId
-      void _createdByConvex
-      void _clientNonce
-      await ctx.db.insert('conversationMessages', { ...copy, conversationId })
-    }
     return {
       conversationId,
       workspaceId: args.workspaceId,
@@ -312,6 +302,9 @@ export const addParticipant = mutation({
   handler: async (ctx, args) => {
     const access = await requireConversationAccess(ctx, args)
     if (access.participant?.role !== 'moderator') throw new Error('CONVERSATION_MODERATOR_REQUIRED')
+    if (access.conversation?.conversationType === 'dm') {
+      throw new Error('DIRECT_MESSAGE_REQUIRES_NEW_GROUP')
+    }
     const principal = await ctx.db.query('workspacePrincipals')
       .withIndex('by_principalId', (q) => q.eq('principalId', args.principalId))
       .unique()
@@ -409,6 +402,7 @@ export const updateParticipantState = mutation({
     conversationId: v.id('conversations'),
     markRead: v.optional(v.boolean()),
     markUnread: v.optional(v.boolean()),
+    readSequence: v.optional(v.number()),
     notificationLevel: v.optional(v.union(v.literal('all'), v.literal('mentions'), v.literal('muted'))),
     workspaceId: v.string(),
     serverSecret: v.optional(v.string()),
@@ -418,10 +412,22 @@ export const updateParticipantState = mutation({
     const participant = access.participant
     if (!participant) throw new Error('CONVERSATION_ACCESS_DENIED')
     const now = Date.now()
+    const requestedReadSequence = Number.isSafeInteger(args.readSequence) && (args.readSequence ?? 0) >= 0
+      ? args.readSequence
+      : undefined
+    let readSequence = requestedReadSequence
+    if (args.markRead || requestedReadSequence !== undefined) {
+      const events = await ctx.db.query('conversationEvents')
+        .withIndex('by_conversationId_createdAt', (q) => q.eq('conversationId', args.conversationId))
+        .collect()
+      const latestSequence = events.reduce((max, event) => Math.max(max, event._creationTime), 0)
+      readSequence = Math.min(requestedReadSequence ?? Number.MAX_SAFE_INTEGER, latestSequence)
+    }
     const patch = {
       ...(args.notificationLevel ? { notificationLevel: args.notificationLevel } : {}),
       ...(args.archived !== undefined ? { archivedAt: args.archived ? now : undefined } : {}),
-      ...(args.markRead ? { lastReadAt: now, markedUnreadAt: undefined } : {}),
+      ...(args.markRead ? { lastReadAt: now, lastReadSequence: readSequence ?? 0, markedUnreadAt: undefined } : {}),
+      ...(readSequence !== undefined && !args.markRead ? { lastReadSequence: readSequence } : {}),
       ...(args.markUnread ? { markedUnreadAt: now } : {}),
       updatedAt: now,
     }
@@ -434,6 +440,7 @@ export const upsertPresence = mutation({
   args: {
     actorUserId: v.string(),
     conversationId: v.optional(v.id('conversations')),
+    sessionId: v.optional(v.string()),
     status: v.union(v.literal('online'), v.literal('away'), v.literal('offline')),
     typing: v.optional(v.boolean()),
     workspaceId: v.string(),
@@ -442,14 +449,17 @@ export const upsertPresence = mutation({
   handler: async (ctx, args) => {
     const actor = await requireActor(ctx, args)
     if (args.conversationId) await requireConversationAccess(ctx, { ...args, conversationId: args.conversationId })
-    const existing = await ctx.db.query('workspacePresence')
+    const sessionId = args.sessionId?.trim() || 'legacy'
+    const existingRows = await ctx.db.query('workspacePresence')
       .withIndex('by_workspaceId_principalId', (q) => (
         q.eq('workspaceId', args.workspaceId).eq('principalId', actor.principalId)
-      )).unique()
+      )).collect()
+    const existing = existingRows.find((row) => (row.sessionId ?? 'legacy') === sessionId)
     const now = Date.now()
     const value = {
       workspaceId: args.workspaceId,
       principalId: actor.principalId,
+      sessionId,
       conversationId: args.conversationId,
       status: args.status,
       lastSeenAt: now,
@@ -479,25 +489,40 @@ export const listPresence = query({
         q.eq('conversationId', args.conversationId).eq('status', 'active')
       )).collect()
     const now = Date.now()
-    const result = []
+    const sessionsByPrincipal = new Map<string, Array<Doc<'workspacePresence'>>>()
     for (const participant of participants) {
-      const presence = await ctx.db.query('workspacePresence')
+      const presenceRows = await ctx.db.query('workspacePresence')
         .withIndex('by_workspaceId_principalId', (q) => (
           q.eq('workspaceId', args.workspaceId).eq('principalId', participant.principalId)
-        )).unique()
-      if (!presence) continue
-      const stale = now - presence.lastSeenAt > 120_000
-      result.push({
-        workspaceId: presence.workspaceId,
-        principalId: presence.principalId,
-        conversationId: presence.conversationId,
-        status: stale ? 'offline' as const : presence.status,
-        typing: !stale && Boolean(presence.typingExpiresAt && presence.typingExpiresAt > now),
-        lastSeenAt: presence.lastSeenAt,
-        typingExpiresAt: presence.typingExpiresAt,
-      })
+        )).collect()
+      const sessions = presenceRows
+        .filter((row) => !row.conversationId || row.conversationId === args.conversationId)
+      if (sessions.length > 0) sessionsByPrincipal.set(participant.principalId, sessions)
     }
-    return result
+    return [...sessionsByPrincipal.values()].map((sessions) => {
+      const active = sessions
+        .filter((session) => now - session.lastSeenAt <= 120_000)
+        .filter((session) => session.status !== 'offline')
+        .sort((left, right) => right.updatedAt - left.updatedAt)
+      const latest = [...sessions].sort((left, right) => right.updatedAt - left.updatedAt)[0]!
+      const representative = active[0] ?? latest
+      const status = active.some((session) => session.status === 'online')
+        ? 'online' as const
+        : active.length > 0 ? 'away' as const : 'offline' as const
+      const typing = active.some((session) => Boolean(
+        session.typingExpiresAt && session.typingExpiresAt > now,
+      ))
+      return {
+        workspaceId: representative.workspaceId,
+        principalId: representative.principalId,
+        sessionId: representative.sessionId,
+        conversationId: representative.conversationId,
+        status,
+        typing,
+        lastSeenAt: representative.lastSeenAt,
+        typingExpiresAt: typing ? representative.typingExpiresAt : undefined,
+      }
+    })
   },
 })
 
@@ -514,9 +539,6 @@ export const recordMessageActivity = mutation({
   handler: async (ctx, args) => {
     const access = await requireConversationAccess(ctx, args)
     const now = Date.now()
-    if (access.participant) {
-      await ctx.db.patch(access.participant._id, { lastReadAt: now, markedUnreadAt: undefined, updatedAt: now })
-    }
     const mentions = new Set(args.mentionedPrincipalIds ?? [])
     const participants = await ctx.db.query('conversationParticipants')
       .withIndex('by_conversationId_status', (q) => (
@@ -541,6 +563,78 @@ export const recordMessageActivity = mutation({
         createdAt: now,
       })
     }
+  },
+})
+
+async function accessibleConversationIdsForEvents(
+  ctx: CollaborationCtx,
+  args: { actorUserId: string; workspaceId: string; serverSecret?: string },
+): Promise<Set<Id<'conversations'>>> {
+  const actor = await requireActor(ctx, args)
+  const participantRows = await ctx.db.query('conversationParticipants')
+    .withIndex('by_workspaceId_principalId_status', (q) => (
+      q.eq('workspaceId', args.workspaceId).eq('principalId', actor.principalId).eq('status', 'active')
+    )).collect()
+  const ids = new Set<Id<'conversations'>>(participantRows.map((row) => row.conversationId))
+  const owned = await ctx.db.query('conversations')
+    .withIndex('by_workspaceId_conversationType_lastModified', (q) => q.eq('workspaceId', args.workspaceId))
+    .collect()
+  for (const conversation of owned) {
+    if (conversation.userId === args.actorUserId && (conversation.conversationType ?? 'personal') === 'personal') {
+      ids.add(conversation._id)
+    }
+  }
+  return ids
+}
+
+export const getConversationEventCursor = query({
+  args: {
+    actorUserId: v.string(),
+    workspaceId: v.optional(v.string()),
+    serverSecret: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    if (!args.workspaceId) return 0
+    const accessible = await accessibleConversationIdsForEvents(ctx, {
+      actorUserId: args.actorUserId,
+      workspaceId: args.workspaceId,
+      serverSecret: args.serverSecret,
+    })
+    const events = await ctx.db.query('conversationEvents').collect()
+    return events
+      .filter((event) => accessible.has(event.conversationId))
+      .reduce((max, event) => Math.max(max, event._creationTime), 0)
+  },
+})
+
+export const listConversationEvents = query({
+  args: {
+    actorUserId: v.string(),
+    afterSequence: v.number(),
+    limit: v.number(),
+    workspaceId: v.optional(v.string()),
+    serverSecret: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    if (!args.workspaceId) return []
+    const accessible = await accessibleConversationIdsForEvents(ctx, {
+      actorUserId: args.actorUserId,
+      workspaceId: args.workspaceId,
+      serverSecret: args.serverSecret,
+    })
+    const events = await ctx.db.query('conversationEvents').collect()
+    return events
+      .filter((event) => accessible.has(event.conversationId) && event._creationTime > args.afterSequence)
+      .sort((left, right) => left._creationTime - right._creationTime)
+      .slice(0, Math.max(1, Math.min(200, Math.floor(args.limit))))
+      .map((event) => ({
+        sequence: event._creationTime,
+        conversationId: event.conversationId,
+        type: event.type,
+        messageId: event.messageId,
+        payload: event.payload as Record<string, unknown> | undefined,
+        createdAt: event.createdAt,
+      }))
   },
 })
 

--- a/convex/collaboration/events.ts
+++ b/convex/collaboration/events.ts
@@ -1,0 +1,25 @@
+import type { MutationCtx } from '../_generated/server'
+import type { Id } from '../_generated/dataModel'
+
+/** Append one durable collaboration event behind the provider-neutral contract. */
+export async function recordConversationEvent(
+  ctx: Pick<MutationCtx, 'db'>,
+  args: {
+    conversationId: Id<'conversations'>
+    workspaceId?: string
+    userId: string
+    type: string
+    messageId?: Id<'conversationMessages'>
+    payload?: Record<string, unknown>
+  },
+): Promise<void> {
+  await ctx.db.insert('conversationEvents', {
+    conversationId: args.conversationId,
+    workspaceId: args.workspaceId,
+    userId: args.userId,
+    type: args.type,
+    messageId: args.messageId,
+    payload: args.payload,
+    createdAt: Date.now(),
+  })
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1189,6 +1189,7 @@ export default defineSchema({
     updatedAt: v.number(),
     removedAt: v.optional(v.number()),
     lastReadAt: v.optional(v.number()),
+    lastReadSequence: v.optional(v.number()),
     markedUnreadAt: v.optional(v.number()),
     archivedAt: v.optional(v.number()),
   })
@@ -1199,6 +1200,7 @@ export default defineSchema({
   workspacePresence: defineTable({
     workspaceId: v.string(),
     principalId: v.string(),
+    sessionId: v.optional(v.string()),
     conversationId: v.optional(v.id('conversations')),
     status: v.union(v.literal('online'), v.literal('away'), v.literal('offline')),
     lastSeenAt: v.number(),
@@ -1206,7 +1208,22 @@ export default defineSchema({
     updatedAt: v.number(),
   })
     .index('by_workspaceId_principalId', ['workspaceId', 'principalId'])
+    .index('by_workspaceId_principalId_updatedAt', ['workspaceId', 'principalId', 'updatedAt'])
     .index('by_conversationId_updatedAt', ['conversationId', 'updatedAt']),
+
+  // Provider-neutral durable collaboration events. Convex uses the document
+  // creation time as the monotonic cursor; Postgres uses its identity sequence.
+  conversationEvents: defineTable({
+    conversationId: v.id('conversations'),
+    workspaceId: v.optional(v.string()),
+    userId: v.string(),
+    type: v.string(),
+    messageId: v.optional(v.id('conversationMessages')),
+    payload: v.optional(v.any()),
+    createdAt: v.number(),
+  })
+    .index('by_conversationId_createdAt', ['conversationId', 'createdAt'])
+    .index('by_userId_createdAt', ['userId', 'createdAt']),
 
   workspaceNotifications: defineTable({
     notificationId: v.string(),

--- a/internal-docs/reports/web-app-complexity-baseline.json
+++ b/internal-docs/reports/web-app-complexity-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-16T06:31:06.157Z",
+  "generatedAt": "2026-08-02T01:19:11.211Z",
   "budgets": {
     "maxProductionFileLoc": 500,
     "maxFunctionComplexity": 25,
@@ -29,90 +29,122 @@
     "src/sentry.edge.config.ts|src/sentry.server.config.ts"
   ],
   "largeProductionFiles": [
+    "packages/overlay-app-core/src/app-shell.ts",
     "packages/overlay-app-core/src/extensions.ts",
+    "packages/overlay-app-core/src/knowledge-surface.ts",
     "packages/overlay-billing/src/adapters/stripe-billing-provider.ts",
     "packages/overlay-chat-core/src/messages.ts",
     "packages/overlay-chat-react/src/components/ChatExperienceHeader.tsx",
-    "packages/overlay-chat-react/src/components/ExchangeBlock.tsx",
     "packages/overlay-chat-react/src/components/GeneratedUiCard.tsx",
+    "packages/overlay-chat-react/src/styles/chat-surface.css",
+    "packages/overlay-modules-react/src/knowledge/surface.tsx",
     "packages/overlay-modules-react/src/knowledge/view-header.tsx",
-    "src/app/globals.css",
+    "packages/overlay-modules-react/src/notes/editor.tsx",
+    "packages/overlay-modules-react/src/notes/inline-diff-extension.ts",
+    "packages/overlay-workspace-contracts/src/types.ts",
     "src/app/pricing/PricingClient.tsx",
     "src/components/layout/AppSidebar.tsx",
+    "src/components/layout/AppSidebarInlinePanels.tsx",
+    "src/components/share/ShareDialog.tsx",
     "src/features/account/components/OnboardingTour.tsx",
+    "src/features/admin/authorization/AuthorizationAdminPanel.tsx",
     "src/features/chat/components/ChatExperience.tsx",
+    "src/features/chat/components/ChatInlinePanel.tsx",
+    "src/features/chat/components/DirectMessageExperience.tsx",
+    "src/features/chat/components/chat-interface/MentionInput.tsx",
     "src/features/chat/components/chat/useChatModelSelectionController.ts",
-    "src/features/knowledge/components/KnowledgeView.tsx",
-    "src/features/marketing/components/MarketingShowcase.tsx",
-    "src/features/notebook/components/InlineDiffExtension.ts",
-    "src/features/notebook/components/NotebookEditor.tsx",
+    "src/features/chat/components/collaboration/RoomMessageItem.tsx",
+    "src/features/knowledge-bases/components/KnowledgeBaseWorkspace.tsx",
     "src/features/projects/components/ProjectsView.tsx",
+    "src/features/workspaces/components/WorkspaceSettingsPanel.tsx",
     "src/server/ai/gateway/gateway-search-tools.ts",
     "src/server/ai/sandbox/daytona.ts",
+    "src/server/app-api/v1/conversations/act/extension-plan/route.ts",
     "src/server/app-api/v1/conversations/act/route.ts",
     "src/server/app-data/contracts/app-data-repository-contract.ts",
     "src/server/auth/workos-auth.ts",
+    "src/server/authorization/authorization-route-policy.ts",
     "src/server/automations/AutomationService.ts",
     "src/server/automations/PostgresAutomationRepository.ts",
+    "src/server/bootstrap.ts",
     "src/server/config/env-overrides.ts",
     "src/server/conversations/PostgresActConversationRepository.ts",
+    "src/server/conversations/PostgresConversationCollaborationRepository.ts",
     "src/server/database/postgres/schema.ts",
     "src/server/files/FileService.ts",
     "src/server/files/PostgresFileRepository.ts",
+    "src/server/knowledge-bases/KnowledgeBaseService.ts",
+    "src/server/knowledge-bases/PostgresKnowledgeBaseRepositories.ts",
     "src/server/tools/mcp-tools.ts",
     "src/server/tools/tools/build.ts",
     "src/server/tools/tools/overlay-executes.ts",
+    "src/server/workspaces/ConvexWorkspaceRepository.ts",
+    "src/server/workspaces/PostgresWorkspaceRepository.ts",
+    "src/server/workspaces/WorkspaceService.ts",
     "src/shared/config/overlayConfigSchema.ts",
     "src/shared/schemas/api-boundary.ts"
   ],
   "complexFunctionCounts": {
+    "src/components/layout/AppSidebar.tsx#AppSidebar": 1,
     "src/shared/config/overlayConfigSchema.ts#callback": 1,
+    "src/features/chat/components/ChatExperience.tsx#ChatExperience": 1,
+    "src/app/api/v1/_utils/bff.ts#handleBffRoute": 1,
+    "src/features/chat/components/ChatMessage.tsx#TextChatMessage": 1,
     "src/server/app-api/v1/settings/route.ts#PATCH": 1,
     "src/components/providers/AppSettingsProvider.tsx#isAppSettingsPayload": 1,
-    "src/features/chat/components/ChatMessage.tsx#TextChatMessage": 1,
-    "src/components/layout/AppSidebar.tsx#AppSidebar": 1,
-    "src/features/chat/components/ChatExperience.tsx#ChatExperience": 1,
     "src/server/app-api/v1/generate-video/route.ts#start": 1,
     "src/shared/tools/output-types.ts#classifyOutputType": 1,
     "packages/overlay-chat-core/src/visual-sequence.ts#buildAssistantVisualSequence": 1,
     "packages/overlay-tools-core/src/mcp-schema-to-zod.ts#jsonSchemaToZod": 1,
     "src/app/app/settings/page.tsx#SettingsPage": 1,
+    "src/features/chat/components/DirectMessageExperience.tsx#DirectMessageExperience": 1,
     "src/features/chat/components/chat/useChatConversationLoader.ts#callback": 1,
+    "src/server/app-api/v1/generate-image/route.ts#POST": 1,
     "src/server/bootstrap.ts#assertSelectedProviderConfig": 1,
     "packages/overlay-chat-core/src/agent-assistant-text.ts#isNimLeakedNarrationLine": 1,
-    "src/server/app-api/v1/generate-image/route.ts#POST": 1,
+    "src/features/workspaces/components/WorkspaceSwitcher.tsx#WorkspaceSwitcher": 1,
+    "src/server/account/PostgresAccountDataDeletionRepository.ts#countUserRows": 1,
     "src/shared/chat/persist-assistant-turn.ts#buildAssistantPersistenceFromSteps": 1,
     "packages/overlay-chat-react/src/components/ChatExperienceHeader.tsx#ChatExperienceHeader": 1,
-    "src/features/notebook/components/InlineDiffExtension.ts#parseMarkdownLine": 1,
-    "src/server/account/PostgresAccountDataDeletionRepository.ts#countUserRows": 1,
-    "src/components/layout/AppSidebar.tsx#callback": 1,
-    "src/shared/tools/tool-result-summary.ts#summarizeToolResultForTranscript": 1,
-    "packages/overlay-chat-react/src/components/ExchangeBlock.tsx#ExchangeBlock": 1,
-    "src/features/notebook/components/InlineDiffExtension.ts#parseMarkdownLines": 1,
-    "src/server/files/PostgresFileRepository.ts#callback": 1,
-    "src/features/files/lib/export/markdown.ts#walk": 1,
-    "src/features/knowledge/components/KnowledgeView.tsx#KnowledgeView": 1,
+    "packages/overlay-modules-react/src/knowledge/surface.tsx#SharedKnowledgeSurface": 1,
+    "packages/overlay-modules-react/src/notes/inline-diff-extension.ts#parseMarkdownLine": 1,
     "src/server/app-api/v1/browser-task/route.ts#POST": 1,
     "src/server/tools/tools/build.ts#buildOverlayToolSet": 1,
-    "packages/overlay-chat-react/src/components/ExchangeBlock.tsx#callback": 1,
+    "src/shared/tools/tool-result-summary.ts#summarizeToolResultForTranscript": 1,
+    "packages/overlay-modules-react/src/notes/inline-diff-extension.ts#parseMarkdownLines": 1,
+    "src/server/app-api/v1/conversations/act/route.ts#POST": 1,
+    "src/server/files/PostgresFileRepository.ts#callback": 1,
+    "src/server/knowledge/mention-resolver.ts#resolveOne": 1,
+    "src/features/files/lib/export/markdown.ts#walk": 1,
+    "src/features/chat/components/collaboration/RoomMessageItem.tsx#RoomMessageItem": 1,
+    "src/app/app/admin/page.tsx#AdminPage": 1,
+    "packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx#ChatExchange": 1,
+    "src/server/database/convex.ts#callConvex": 1,
+    "packages/overlay-chat-react/src/components/transcript/AssistantVisualBlocks.tsx#callback": 1,
     "src/features/chat/components/chat/chat-send-text.ts#sendTextTurn": 1,
+    "src/features/chat/components/chat/toChatTranscriptView.ts#callback": 1,
     "src/server/files/PostgresFileRepository.ts#normalizeFile": 1,
     "src/server/ai/sandbox/PostgresDaytonaReconciliationService.ts#reconcile": 1,
+    "src/server/app-api/v1/conversations/act/route.ts#authorizeActRequest": 1,
     "src/server/automations/AutomationService.ts#buildAutomationUpdateNote": 1,
-    "src/server/knowledge/mention-resolver.ts#resolveOne": 1,
     "packages/overlay-billing/src/adapters/stripe-billing-provider.ts#verifyPaidPlanCheckoutSession": 1,
     "packages/overlay-chat-react/src/components/MediaSlotOutput.tsx#MediaSlotOutput": 1,
-    "src/server/app-api/v1/conversations/act/route.ts#POST": 1,
-    "packages/overlay-chat-react/src/components/tools/BrowserSessionToolBlock.tsx#BrowserSessionToolBlock": 1,
-    "src/server/database/convex.ts#callConvex": 1,
+    "src/server/app-api/v1/conversations/act/extension-plan/route.ts#POST": 1,
+    "src/server/workspaces/PostgresWorkspaceRepository.ts#setSharingPolicy": 1,
     "packages/overlay-chat-core/src/tool-labels.ts#describeComposioIntegrationTool": 1,
+    "packages/overlay-modules-react/src/notes/editor.tsx#CanonicalNotebookEditor": 1,
+    "src/components/share/ShareDialog.tsx#ShareDialogContent": 1,
     "src/features/chat/components/chat/chat-send-media.ts#sendMediaTurn": 1,
     "src/features/chat/components/ChatExperience.tsx#handleBranchConversationAtTurn": 1,
+    "src/features/knowledge-bases/components/KnowledgeBaseWorkspace.tsx#KnowledgeBaseWorkspace": 1,
     "packages/overlay-chat-react/src/lib/web-tool-sources.ts#collectSourceCandidatesFromUnknown": 1,
-    "src/features/files/components/FileViewer.tsx#FileViewer": 1,
-    "src/server/app-api/v1/conversations/act/extension-plan/route.ts#POST": 1
+    "src/features/chat/components/chat-interface/useMentionData.ts#callback": 1,
+    "src/features/chat/components/NewDirectMessageDialog.tsx#NewDirectMessageDialog": 1,
+    "src/features/projects/components/ProjectsView.tsx#ProjectHubBody": 1,
+    "src/features/workspaces/components/WorkspaceSettingsPanel.tsx#WorkspaceSettingsPanel": 1
   },
   "routeHandlersOverBudget": [
+    "src/server/app-api/v1/chat-suggestions/route.ts",
     "src/server/app-api/v1/conversations/act/extension-plan/route.ts",
     "src/server/app-api/v1/conversations/act/route.ts",
     "src/server/app-api/v1/conversations/route.ts",
@@ -186,16 +218,30 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
-      "file": "src/app/account/page.tsx",
+      "file": "src/app/%5F_fixtures/chat-parity/page.tsx",
       "layer": "src/app routes",
-      "loc": 387,
+      "loc": 23,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/%5F_fixtures/file-parity/page.tsx",
+      "layer": "src/app routes",
+      "loc": 22,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/about/page.tsx",
+      "layer": "src/app routes",
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/api/account/delete/route.ts",
       "layer": "src/app/api other",
-      "loc": 63,
+      "loc": 91,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -242,23 +288,16 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
-      "file": "src/app/api/auth/native/provider-keys/route.ts",
-      "layer": "src/app/api other",
-      "loc": 46,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
       "file": "src/app/api/auth/native/refresh/route.ts",
       "layer": "src/app/api other",
-      "loc": 54,
+      "loc": 78,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/api/auth/native/subscription/route.ts",
       "layer": "src/app/api other",
-      "loc": 90,
+      "loc": 54,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -279,7 +318,7 @@
     {
       "file": "src/app/api/auth/session/route.ts",
       "layer": "src/app/api other",
-      "loc": 51,
+      "loc": 55,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -349,14 +388,14 @@
     {
       "file": "src/app/api/latest-release/download/route.ts",
       "layer": "src/app/api other",
-      "loc": 23,
+      "loc": 34,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/api/latest-release/route.ts",
       "layer": "src/app/api other",
-      "loc": 15,
+      "loc": 26,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -382,6 +421,90 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/api/v1/admin/authorization/assignments/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 80,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/authorization/capabilities/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 28,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/authorization/grants/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 75,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/authorization/groups/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 82,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/authorization/memberships/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 68,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/authorization/roles/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 85,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/catalog/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 97,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/governance/export/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 90,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/governance/policies/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 68,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/governance/reviews/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 68,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/knowledge-bases/defaults/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 51,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/admin/knowledge-bases/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 18,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/api/v1/admin/principals/route.ts",
       "layer": "src/app/api/v1 wrappers",
       "loc": 98,
@@ -392,6 +515,20 @@
       "file": "src/app/api/v1/admin/usage/route.ts",
       "layer": "src/app/api/v1 wrappers",
       "loc": 98,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/agents/[agentId]/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 12,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/agents/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -433,12 +570,61 @@
     {
       "file": "src/app/api/v1/capabilities/route.ts",
       "layer": "src/app/api/v1 wrappers",
-      "loc": 42,
+      "loc": 44,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/api/v1/chat-suggestions/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/[conversationId]/messages/[messageId]/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/[conversationId]/participants/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 12,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/[conversationId]/pins/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/[conversationId]/presence/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/[conversationId]/reactions/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/[conversationId]/reports/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/[conversationId]/state/route.ts",
       "layer": "src/app/api/v1 wrappers",
       "loc": 6,
       "classification": "keep",
@@ -459,6 +645,27 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/api/v1/conversations/agent-reply/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/channels/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/direct-messages/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 10,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/api/v1/conversations/events/route.ts",
       "layer": "src/app/api/v1 wrappers",
       "loc": 7,
@@ -473,9 +680,30 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/api/v1/conversations/notifications/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/api/v1/conversations/route.ts",
       "layer": "src/app/api/v1 wrappers",
       "loc": 15,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/saved-messages/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/conversations/search/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -599,6 +827,76 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/api/v1/knowledge-bases/[knowledgeBaseId]/conversations/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/knowledge-bases/[knowledgeBaseId]/diagnostics/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/knowledge-bases/[knowledgeBaseId]/grants/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 12,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/knowledge-bases/[knowledgeBaseId]/reindex/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/knowledge-bases/[knowledgeBaseId]/search/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/knowledge-bases/[knowledgeBaseId]/sources/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 15,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/knowledge-bases/[knowledgeBaseId]/sources/upload/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 7,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/knowledge-bases/personal/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/knowledge-bases/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 15,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/knowledge-bases/share-directory/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 16,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/api/v1/knowledge/search/route.ts",
       "layer": "src/app/api/v1 wrappers",
       "loc": 7,
@@ -676,6 +974,41 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/api/v1/projects/duplicate/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/projects/export/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/projects/grants/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 12,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/projects/knowledge-bases/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 12,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/projects/knowledge-transfer/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/api/v1/projects/route.ts",
       "layer": "src/app/api/v1 wrappers",
       "loc": 15,
@@ -683,9 +1016,44 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/api/v1/projects/share-directory/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/search/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/api/v1/settings/route.ts",
       "layer": "src/app/api/v1 wrappers",
       "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/shares/impact/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/shares/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 12,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/shares/shared-with-me/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -725,6 +1093,97 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/api/v1/workspace-invitations/[invitationId]/accept/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 10,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/[workspaceId]/audit-export/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 10,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/[workspaceId]/governance/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 13,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/[workspaceId]/invitations/[invitationId]/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 13,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/[workspaceId]/invitations/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 13,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/[workspaceId]/lifecycle/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 10,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/[workspaceId]/management/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 10,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/[workspaceId]/members/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 13,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/[workspaceId]/policies/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 13,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/[workspaceId]/teams/[teamId]/members/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 13,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/[workspaceId]/teams/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 13,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/active/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 6,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/workspaces/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/api/webhooks/stripe/route.ts",
       "layer": "src/app/api other",
       "loc": 50,
@@ -732,9 +1191,23 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/app/account/page.tsx",
+      "layer": "src/app routes",
+      "loc": 420,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/app/admin/page.tsx",
       "layer": "src/app routes",
-      "loc": 142,
+      "loc": 235,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/app/agents/page.tsx",
+      "layer": "src/app routes",
+      "loc": 10,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -755,7 +1228,7 @@
     {
       "file": "src/app/app/automations/page.tsx",
       "layer": "src/app routes",
-      "loc": 57,
+      "loc": 65,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -769,7 +1242,7 @@
     {
       "file": "src/app/app/chat/page.tsx",
       "layer": "src/app routes",
-      "loc": 38,
+      "loc": 55,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -783,7 +1256,14 @@
     {
       "file": "src/app/app/files/page.tsx",
       "layer": "src/app routes",
-      "loc": 47,
+      "loc": 52,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/app/home/page.tsx",
+      "layer": "src/app routes",
+      "loc": 22,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -809,6 +1289,34 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/app/invitations/[invitationId]/page.tsx",
+      "layer": "src/app routes",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/app/knowledge/[knowledgeBaseId]/error.tsx",
+      "layer": "src/app routes",
+      "loc": 11,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/app/knowledge/[knowledgeBaseId]/loading.tsx",
+      "layer": "src/app routes",
+      "loc": 1,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/app/knowledge/[knowledgeBaseId]/page.tsx",
+      "layer": "src/app routes",
+      "loc": 105,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/app/knowledge/error.tsx",
       "layer": "src/app routes",
       "loc": 11,
@@ -825,14 +1333,14 @@
     {
       "file": "src/app/app/knowledge/page.tsx",
       "layer": "src/app routes",
-      "loc": 47,
+      "loc": 35,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/app/layout.tsx",
       "layer": "src/app routes",
-      "loc": 64,
+      "loc": 96,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -840,6 +1348,13 @@
       "file": "src/app/app/loading.tsx",
       "layer": "src/app routes",
       "loc": 4,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/app/manifesto/page.tsx",
+      "layer": "src/app routes",
+      "loc": 22,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -874,7 +1389,7 @@
     {
       "file": "src/app/app/notes/page.tsx",
       "layer": "src/app routes",
-      "loc": 11,
+      "loc": 15,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -900,6 +1415,13 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/app/pricing/page.tsx",
+      "layer": "src/app routes",
+      "loc": 24,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/app/projects/error.tsx",
       "layer": "src/app routes",
       "loc": 11,
@@ -916,7 +1438,7 @@
     {
       "file": "src/app/app/projects/page.tsx",
       "layer": "src/app routes",
-      "loc": 35,
+      "loc": 43,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -937,7 +1459,7 @@
     {
       "file": "src/app/app/settings/page.tsx",
       "layer": "src/app routes",
-      "loc": 343,
+      "loc": 362,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -951,7 +1473,7 @@
     {
       "file": "src/app/app/tools/page.tsx",
       "layer": "src/app routes",
-      "loc": 13,
+      "loc": 21,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1000,7 +1522,7 @@
     {
       "file": "src/app/auth/native/callback/route.ts",
       "layer": "src/app routes",
-      "loc": 47,
+      "loc": 28,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1014,7 +1536,7 @@
     {
       "file": "src/app/auth/sign-in/page.tsx",
       "layer": "src/app routes",
-      "loc": 255,
+      "loc": 282,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1026,9 +1548,23 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/download/page.tsx",
+      "layer": "src/app routes",
+      "loc": 32,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/error.tsx",
       "layer": "src/app routes",
       "loc": 24,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/explore/[surface]/page.tsx",
+      "layer": "src/app routes",
+      "loc": 15,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1042,14 +1578,14 @@
     {
       "file": "src/app/home/page.tsx",
       "layer": "src/app routes",
-      "loc": 231,
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/layout.tsx",
       "layer": "src/app routes",
-      "loc": 79,
+      "loc": 83,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1063,21 +1599,21 @@
     {
       "file": "src/app/manifesto/page.tsx",
       "layer": "src/app routes",
-      "loc": 80,
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/page.tsx",
       "layer": "src/app routes",
-      "loc": 4,
+      "loc": 13,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/pricing/page.tsx",
       "layer": "src/app routes",
-      "loc": 6,
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1124,34 +1660,6 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
-      "file": "src/app/use-cases/business/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
-      "file": "src/app/use-cases/content/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
-      "file": "src/app/use-cases/developers/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
-      "file": "src/app/use-cases/education/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
       "file": "src/instrumentation-client.ts",
       "layer": "other",
       "loc": 43,
@@ -1168,9 +1676,23 @@
     {
       "file": "src/middleware.ts",
       "layer": "other",
-      "loc": 262,
+      "loc": 333,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "packages/overlay-chat-react/scripts/check-transcript-boundaries.mjs",
+      "layer": "packages/overlay-chat-react",
+      "loc": 169,
+      "classification": "review",
+      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
+    },
+    {
+      "file": "packages/overlay-chat-react/src/lib/web-tool-sources.ts",
+      "layer": "packages/overlay-chat-react",
+      "loc": 95,
+      "classification": "review",
+      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
     },
     {
       "file": "src/features/chat/components/chat/useEmptyChatStarters.ts",
@@ -1180,23 +1702,9 @@
       "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
     },
     {
-      "file": "src/features/knowledge/components/KnowledgeToolbarMenus.tsx",
+      "file": "src/features/notebook/lib/notebook-editor-blocks.ts",
       "layer": "src/features",
-      "loc": 5,
-      "classification": "review",
-      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
-    },
-    {
-      "file": "src/features/knowledge/components/KnowledgeViewHeader.tsx",
-      "layer": "src/features",
-      "loc": 8,
-      "classification": "review",
-      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
-    },
-    {
-      "file": "src/features/knowledge/components/KnowledgeViewHost.tsx",
-      "layer": "src/features",
-      "loc": 3,
+      "loc": 1,
       "classification": "review",
       "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
     },
@@ -1209,12 +1717,12 @@
     }
   ],
   "totals": {
-    "files": 1193,
-    "code": 133057,
-    "total": 147848,
-    "productionFiles": 1044,
-    "productionCode": 117463,
-    "testFiles": 149,
-    "testCode": 15594
+    "files": 1611,
+    "code": 195599,
+    "total": 216479,
+    "productionFiles": 1348,
+    "productionCode": 164787,
+    "testFiles": 263,
+    "testCode": 30812
   }
 }

--- a/migrations/app-data/0039_conversation_correctness.sql
+++ b/migrations/app-data/0039_conversation_correctness.sql
@@ -1,0 +1,27 @@
+ALTER TABLE "conversation_participants"
+  ADD COLUMN "last_read_sequence" bigint;
+--> statement-breakpoint
+
+ALTER TABLE "workspace_presence"
+  ADD COLUMN "session_id" text NOT NULL DEFAULT 'legacy';
+--> statement-breakpoint
+
+ALTER TABLE "workspace_presence"
+  DROP CONSTRAINT "workspace_presence_pkey";
+--> statement-breakpoint
+
+ALTER TABLE "workspace_presence"
+  ADD CONSTRAINT "workspace_presence_pkey"
+    PRIMARY KEY ("workspace_id", "principal_id", "session_id");
+--> statement-breakpoint
+
+CREATE INDEX "workspace_presence_principal_idx"
+  ON "workspace_presence" ("workspace_id", "principal_id", "updated_at" DESC);
+--> statement-breakpoint
+
+INSERT INTO overlay_app_data_metadata (key, value, updated_at)
+VALUES
+  ('schema_version', '39', now()),
+  ('schema_min_compatible_version', '39', now())
+ON CONFLICT (key) DO UPDATE
+SET value = excluded.value, updated_at = excluded.updated_at;

--- a/migrations/app-data/meta/_journal.json
+++ b/migrations/app-data/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1786474800000,
       "tag": "0038_workspace_governance_policy",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1786561200000,
+      "tag": "0039_conversation_correctness",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3241,7 +3241,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3264,7 +3263,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3284,7 +3282,6 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
       "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3307,7 +3304,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3324,7 +3320,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3341,7 +3336,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3358,7 +3352,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3375,7 +3368,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3392,7 +3384,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3409,7 +3400,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3426,7 +3416,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3443,7 +3432,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3460,7 +3448,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3477,7 +3464,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3500,7 +3486,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3523,7 +3508,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3546,7 +3530,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3569,7 +3552,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3592,7 +3574,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3615,7 +3596,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3638,7 +3618,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3658,7 +3637,6 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
       "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3675,7 +3653,6 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
       "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3689,7 +3666,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -3709,7 +3685,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3729,7 +3704,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3749,7 +3723,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/packages/overlay-api-client/src/chat/conversations-client.ts
+++ b/packages/overlay-api-client/src/chat/conversations-client.ts
@@ -316,7 +316,7 @@ export class ConversationsClient {
 
   updatePresence(
     conversationId: string,
-    body: { status: 'online' | 'away' | 'offline'; typing?: boolean },
+    body: { status: 'online' | 'away' | 'offline'; typing?: boolean; sessionId?: string },
     init?: MutationRequestInit,
   ) {
     return this.http.json<{ presence: ConversationPresence }>(

--- a/packages/overlay-api-client/src/chat/types.ts
+++ b/packages/overlay-api-client/src/chat/types.ts
@@ -10,6 +10,8 @@ export interface ConversationQuery extends PaginationQuery {
   includeDeleted?: boolean
   limit?: number
   beforeCreatedAt?: number
+  mainOnly?: boolean
+  threadRootMessageId?: string
   compactToolPayloads?: boolean
 }
 

--- a/packages/overlay-workspace-contracts/src/types.ts
+++ b/packages/overlay-workspace-contracts/src/types.ts
@@ -286,6 +286,8 @@ export type ConversationParticipant = {
   updatedAt: number
   removedAt?: number
   lastReadAt?: number
+  /** Durable event cursor last actually seen in this conversation. */
+  lastReadSequence?: number
   markedUnreadAt?: number
   archivedAt?: number
 }
@@ -309,11 +311,15 @@ export type ConversationParticipantStateInput = {
   archived?: boolean
   markUnread?: boolean
   markRead?: boolean
+  /** Optional explicit event boundary; omitted markRead advances to the server's current boundary. */
+  readSequence?: number
 }
 
 export type ConversationPresence = {
   workspaceId: string
   principalId: string
+  /** Browser/tab identity; presence is aggregated across active sessions. */
+  sessionId?: string
   conversationId?: string
   status: 'online' | 'away' | 'offline'
   typing: boolean

--- a/src/features/chat/components/DirectMessageExperience.tsx
+++ b/src/features/chat/components/DirectMessageExperience.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react'
 import { AppScreenBody, AppScreenHeader, AppScreenShell } from '@overlay/modules-react/shell'
 import dynamic from 'next/dynamic'
+import { useRouter } from 'next/navigation'
 import { AttachmentPreviewDialog } from '@overlay/chat-react'
 import type {
   ChannelSummary,
@@ -47,8 +48,14 @@ import { useComposerTextState } from './chat/useComposerTextState'
 import { useChatPanels } from './chat/useChatPanels'
 import { useChatShellPanels } from './chat/useChatShellPanels'
 import { buildTextTurnPayload } from './chat/chat-send-body-builders'
+import { usePostgresConversationEvents } from './chat/usePostgresConversationEvents'
 import { RoomMessageItem, roomMessageDomId } from './collaboration/RoomMessageItem'
-import { toRoomMessageView, type RoomMessageRecord } from './collaboration/room-message-view'
+import {
+  compareRoomMessageRecords,
+  mergeRoomMessages,
+  toRoomMessageView,
+  type RoomMessageRecord,
+} from './collaboration/room-message-view'
 import {
   RoomPeoplePanel,
   RoomPinnedPanel,
@@ -126,6 +133,20 @@ const SHOWCASE_MESSAGES: OptimisticMessage[] = [
   },
 ]
 
+function roomDayKey(timestamp: number): string {
+  const date = new Date(timestamp)
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
+}
+
+function roomDayLabel(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString([], {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
 export function DirectMessageExperience({
   conversationId,
   showcase = false,
@@ -137,6 +158,7 @@ export function DirectMessageExperience({
 }) {
   const { activeWorkspaceId } = useWorkspace()
   const { capabilities } = useOverlayCapabilities()
+  const router = useRouter()
   const [participants, setParticipants] = useState<ConversationParticipant[]>(
     showcase ? SHOWCASE_PARTICIPANTS : [],
   )
@@ -150,6 +172,8 @@ export function DirectMessageExperience({
     showcase ? SHOWCASE_MESSAGES : [],
   )
   const [loading, setLoading] = useState(!showcase)
+  const [hasMoreMessages, setHasMoreMessages] = useState(false)
+  const [loadingOlderMessages, setLoadingOlderMessages] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [roomPanel, setRoomPanel] = useState<RoomPanelKind | null>(null)
   const [addPeopleOpen, setAddPeopleOpen] = useState(false)
@@ -194,8 +218,11 @@ export function DirectMessageExperience({
   /** Latest messages for callbacks that must not close over a stale render. */
   const messagesRef = useRef<OptimisticMessage[]>(messages)
   messagesRef.current = messages
+  const sessionIdRef = useRef<string | null>(null)
+  const activeConversationRef = useRef<string | null>(conversationId)
+  const stickToBottomRef = useRef(true)
+  activeConversationRef.current = conversationId
   const lastTypingSentAt = useRef(0)
-  const lastNotificationReadAt = useRef(0)
 
   // ── composer state (identical wiring to the personal chat composer) ─────────
   const [composerNotice, setComposerNotice] = useState<string | null>(null)
@@ -265,36 +292,91 @@ export function DirectMessageExperience({
         threadRootMessageId?: string
         status?: 'generating' | 'completed' | 'error'
       }>
-    }>({ conversationId, messages: true, limit: 100 })
-    const persisted = (result.messages ?? []).map((message) => ({
+      hasMore?: boolean
+    }>({ conversationId, messages: true, limit: 100, mainOnly: true })
+    const threadResult = threadRootId
+      ? await overlayAppClient.conversations.get<{
+          messages: Array<{
+            id: string
+            authorKind: RoomMessageRecord['authorKind']
+            authorPrincipalId?: string
+            content?: string
+            parts?: Array<{ type?: string; text?: string; url?: string; mediaType?: string; fileName?: string }>
+            createdAt: number
+            editedAt?: number
+            deletedAt?: number
+            clientNonce?: string
+            threadRootMessageId?: string
+            status?: 'generating' | 'completed' | 'error'
+          }>
+        }>({ conversationId, messages: true, limit: 100, threadRootMessageId: threadRootId })
+      : null
+    setHasMoreMessages(result.hasMore === true)
+    const persisted = [...(result.messages ?? []), ...(threadResult?.messages ?? [])].map((message) => ({
       ...message,
       content: message.content
         ?? message.parts?.find((part) => part.type === 'text')?.text
         ?? '',
       turnId: message.id,
     }))
-    setMessages((current) => {
-      const persistedNonces = new Set(persisted.map((message) => message.clientNonce).filter(Boolean))
-      const pending = current.filter((message) => (
-        message.delivery && message.clientNonce && !persistedNonces.has(message.clientNonce)
-      ))
-      return [...persisted, ...pending].sort((a, b) => a.createdAt - b.createdAt)
-    })
-    await overlayAppClient.conversations.updateParticipantState(conversationId, { markRead: true })
-    if (Date.now() - lastNotificationReadAt.current > 10_000) {
-      lastNotificationReadAt.current = Date.now()
-      const { notifications } = await overlayAppClient.conversations.notifications({
-        unreadOnly: true,
-        limit: 100,
-      })
-      const notificationIds = notifications
-        .filter((notification) => notification.conversationId === conversationId)
-        .map((notification) => notification.id)
-      if (notificationIds.length > 0) {
-        await overlayAppClient.conversations.markNotificationsRead(notificationIds)
-      }
+    setMessages((current) => mergeRoomMessages(persisted, current))
+  }, [conversationId, threadRootId])
+
+  const loadOlderMessages = useCallback(async () => {
+    if (showcase || loadingOlderMessages || !hasMoreMessages) return
+    const earliest = messagesRef.current
+      .filter((message) => !message.threadRootMessageId)
+      .reduce<number | undefined>((value, message) => value === undefined ? message.createdAt : Math.min(value, message.createdAt), undefined)
+    if (earliest === undefined) return
+    setLoadingOlderMessages(true)
+    try {
+      const result = await overlayAppClient.conversations.get<{
+        messages: Array<{
+          id: string
+          authorKind: RoomMessageRecord['authorKind']
+          authorPrincipalId?: string
+          content?: string
+          parts?: Array<{ type?: string; text?: string; url?: string; mediaType?: string; fileName?: string }>
+          createdAt: number
+          editedAt?: number
+          deletedAt?: number
+          clientNonce?: string
+          threadRootMessageId?: string
+          status?: 'generating' | 'completed' | 'error'
+        }>
+        hasMore?: boolean
+      }>({ conversationId, messages: true, limit: 100, beforeCreatedAt: earliest, mainOnly: true })
+      setHasMoreMessages(result.hasMore === true)
+      const older = (result.messages ?? []).map((message) => ({
+        ...message,
+        content: message.content
+          ?? message.parts?.find((part) => part.type === 'text')?.text
+          ?? '',
+        turnId: message.id,
+      }))
+      setMessages((current) => mergeRoomMessages(older, current))
+    } catch {
+      setNotice('Older messages could not be loaded.')
+    } finally {
+      setLoadingOlderMessages(false)
     }
-  }, [conversationId])
+  }, [conversationId, hasMoreMessages, loadingOlderMessages, showcase])
+
+  const markVisibleRead = useCallback(async () => {
+    if (showcase || document.visibilityState !== 'visible') return
+    const node = listRef.current
+    if (!node || node.scrollHeight - node.scrollTop - node.clientHeight > 96) return
+    await overlayAppClient.conversations.updateParticipantState(conversationId, { markRead: true })
+  }, [conversationId, showcase])
+
+  usePostgresConversationEvents({
+    activeChatIdRef: activeConversationRef,
+    enabled: !showcase,
+    hasActiveLocalStream: () => Object.keys(streamingAgentReplies).length > 0,
+    loadChats: async () => {},
+    onRemoteStop: () => {},
+    reloadActiveConversation: loadMessages,
+  })
 
   const loadPresence = useCallback(async () => {
     const result = await overlayAppClient.conversations.presence(conversationId)
@@ -328,25 +410,30 @@ export function DirectMessageExperience({
           if (!cancelled) setLoading(false)
         })
     }, 0)
-    void overlayAppClient.conversations.updatePresence(conversationId, { status: 'online' })
-    const messagesTimer = window.setInterval(() => void loadMessages().catch(() => undefined), 2_000)
+    const sessionId = sessionIdRef.current ?? crypto.randomUUID()
+    sessionIdRef.current = sessionId
+    void overlayAppClient.conversations.updatePresence(conversationId, { status: 'online', sessionId })
     const presenceTimer = window.setInterval(() => void loadPresence().catch(() => undefined), 3_000)
     const heartbeatTimer = window.setInterval(() => {
-      void overlayAppClient.conversations.updatePresence(conversationId, { status: 'online' })
+      void overlayAppClient.conversations.updatePresence(conversationId, { status: 'online', sessionId })
     }, 45_000)
     return () => {
       cancelled = true
       window.clearTimeout(initialLoadTimer)
-      window.clearInterval(messagesTimer)
       window.clearInterval(presenceTimer)
       window.clearInterval(heartbeatTimer)
-      void overlayAppClient.conversations.updatePresence(conversationId, { status: 'offline' })
+      void overlayAppClient.conversations.updatePresence(conversationId, { status: 'offline', sessionId })
     }
   }, [conversationId, loadCollaboration, loadMessages, loadParticipants, loadPresence, showcase])
 
   useEffect(() => {
+    if (loading) return
+    void markVisibleRead()
+  }, [loading, markVisibleRead, messages.length])
+
+  useEffect(() => {
     const node = listRef.current
-    if (node) node.scrollTop = node.scrollHeight
+    if (node && stickToBottomRef.current) node.scrollTop = node.scrollHeight
   }, [messages.length])
 
   // Restore a half-written message when the room reopens. Storage failures are
@@ -480,7 +567,7 @@ export function DirectMessageExperience({
     const optimisticId = `optimistic_${clientNonce}`
     const threadRootMessageId = options?.threadRootMessageId
     if (showcase) {
-      setMessages((current) => [...current, {
+    setMessages((current) => [...current, {
         id: optimisticId,
         turnId,
         authorKind: 'human',
@@ -490,7 +577,7 @@ export function DirectMessageExperience({
         createdAt: options?.existing?.createdAt ?? Date.now(),
         clientNonce,
         threadRootMessageId,
-      } satisfies OptimisticMessage].sort((a, b) => a.createdAt - b.createdAt))
+      } satisfies OptimisticMessage].sort(compareRoomMessageRecords))
       return
     }
     setMessages((current) => [
@@ -507,7 +594,7 @@ export function DirectMessageExperience({
         delivery: 'sending',
         threadRootMessageId,
       } satisfies OptimisticMessage,
-    ].sort((a, b) => a.createdAt - b.createdAt))
+    ].sort(compareRoomMessageRecords))
     try {
       const mentionedPrincipalIds = resolveMentionTargets(text)
       const agentParticipants = participants.filter((participant) => participant.principalType === 'agent')
@@ -689,6 +776,7 @@ export function DirectMessageExperience({
       void overlayAppClient.conversations.updatePresence(conversationId, {
         status: 'online',
         typing: Boolean(text.trim()),
+        sessionId: sessionIdRef.current ?? undefined,
       })
     }
   }
@@ -828,7 +916,7 @@ export function DirectMessageExperience({
     renderAttachmentViewer,
   })
 
-  function renderMessage(message: OptimisticMessage, options?: { inThread?: boolean }) {
+  function renderMessage(message: OptimisticMessage, options?: { inThread?: boolean; grouped?: boolean }) {
     const author = participants.find((participant) => participant.principalId === message.authorPrincipalId)
     const view = toRoomMessageView({
       message,
@@ -873,6 +961,7 @@ export function DirectMessageExperience({
         onRetrySend={() => void sendMessage(message.content, { existing: message, threadRootMessageId: message.threadRootMessageId })}
         onOpenAttachmentPreview={openAttachmentPreview}
         highlighted={highlightedMessageId === message.id}
+        grouped={options?.grouped}
       />
     )
   }
@@ -1125,9 +1214,28 @@ export function DirectMessageExperience({
             <div className="overlay-chat-surface relative min-h-0 flex-1">
               <div
                 ref={listRef}
+                onScroll={() => {
+                  const node = listRef.current
+                  if (node) {
+                    const distanceFromBottom = node.scrollHeight - node.scrollTop - node.clientHeight
+                    stickToBottomRef.current = distanceFromBottom <= 96
+                    if (node.scrollTop <= 120 && hasMoreMessages) void loadOlderMessages()
+                  }
+                  void markVisibleRead()
+                }}
                 className="h-full min-h-0 w-full overflow-y-auto overflow-x-hidden overscroll-contain px-3 py-3 sm:px-4 sm:py-4"
               >
                 <div className="mx-auto flex min-h-full w-full min-w-0 max-w-4xl flex-col gap-5 sm:gap-6">
+                  {hasMoreMessages ? (
+                    <button
+                      type="button"
+                      onClick={() => void loadOlderMessages()}
+                      disabled={loadingOlderMessages}
+                      className="mx-auto rounded-lg border border-[var(--border)] px-3 py-1.5 text-xs text-[var(--muted)] hover:bg-[var(--surface-subtle)] disabled:opacity-60"
+                    >
+                      {loadingOlderMessages ? 'Loading older messages…' : 'Load older messages'}
+                    </button>
+                  ) : null}
                   {loading ? (
                     <div className="space-y-5" aria-label="Loading messages">
                       {[0, 1, 2].map((row) => (
@@ -1147,7 +1255,31 @@ export function DirectMessageExperience({
                       </p>
                     </div>
                   ) : (
-                    mainMessages.map((message) => renderMessage(message))
+                    mainMessages.map((message, index) => {
+                      const previous = mainMessages[index - 1]
+                      const grouped = Boolean(
+                        previous
+                        && Boolean(message.authorPrincipalId)
+                        && Boolean(previous.authorPrincipalId)
+                        && previous.authorPrincipalId === message.authorPrincipalId
+                        && previous.authorKind === message.authorKind
+                        && message.createdAt - previous.createdAt <= 5 * 60_000,
+                      )
+                      const showDayDivider = !previous
+                        || roomDayKey(previous.createdAt) !== roomDayKey(message.createdAt)
+                      return (
+                        <div key={`room-message-row-${message.id}`} className="contents">
+                          {showDayDivider ? (
+                            <div className="flex items-center gap-3 py-1 text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--muted-light)]">
+                              <span className="h-px flex-1 bg-[var(--border)]" />
+                              <span>{roomDayLabel(message.createdAt)}</span>
+                              <span className="h-px flex-1 bg-[var(--border)]" />
+                            </div>
+                          ) : null}
+                          {renderMessage(message, { grouped })}
+                        </div>
+                      )
+                    })
                   )}
                   {mainStreamingReplies.map((reply) => renderStreamingAgentReply(reply))}
                   {agentResponding && mainStreamingReplies.length === 0 ? (
@@ -1282,8 +1414,13 @@ export function DirectMessageExperience({
           showcase={showcase}
           workspaceId={currentParticipant?.workspaceId ?? ''}
           addToConversationId={conversationId}
+          addToConversationType={conversationType}
           excludedPrincipalIds={participants.map((participant) => participant.principalId)}
           onOpenChange={setAddPeopleOpen}
+          onCreated={({ id }) => {
+            const view = conversationType === 'channel' ? 'channels' : 'dms'
+            router.push(`/app/chat?view=${view}&id=${encodeURIComponent(id)}`)
+          }}
           onParticipantsAdded={() => {
             setAddPeopleOpen(false)
             void loadParticipants()

--- a/src/features/chat/components/NewChannelDialog.tsx
+++ b/src/features/chat/components/NewChannelDialog.tsx
@@ -62,12 +62,22 @@ export function NewChannelDialog({
     setBusy(true)
     setError(null)
     try {
-      const { channel } = await overlayAppClient.conversations.createChannel({
+      const response = await overlayAppClient.conversations.createChannel({
         name: name.trim(),
         topic: topic.trim() || undefined,
         visibility,
         principalIds: visibility === 'private' ? selected : undefined,
       })
+      // The BFF returns a typed success envelope, but validation/policy
+      // failures are JSON error envelopes. Guard the boundary so a rejected
+      // create never turns into an opaque `channel.conversationId` crash.
+      const channel = response.channel
+      if (!channel) {
+        const errorMessage = 'error' in response && typeof response.error === 'string'
+          ? response.error
+          : 'Could not create channel.'
+        throw new Error(errorMessage)
+      }
       onCreated({ id: channel.conversationId, title: channel.name })
       setName('')
       setTopic('')

--- a/src/features/chat/components/NewDirectMessageDialog.tsx
+++ b/src/features/chat/components/NewDirectMessageDialog.tsx
@@ -35,6 +35,7 @@ export function NewDirectMessageDialog({
   workspaceId,
   sourceConversationId,
   addToConversationId,
+  addToConversationType = 'channel',
   showcase = false,
   excludedPrincipalIds = [],
   onOpenChange,
@@ -45,6 +46,7 @@ export function NewDirectMessageDialog({
   workspaceId: string
   sourceConversationId?: string
   addToConversationId?: string
+  addToConversationType?: 'dm' | 'channel'
   showcase?: boolean
   excludedPrincipalIds?: string[]
   onOpenChange(open: boolean): void
@@ -120,7 +122,7 @@ export function NewDirectMessageDialog({
     setBusy(true)
     setError(null)
     try {
-      if (addToConversationId) {
+      if (addToConversationId && addToConversationType === 'channel') {
         await Promise.all(selected.map((principalId) => (
           overlayAppClient.conversations.addParticipant(addToConversationId, principalId)
         )))
@@ -131,7 +133,9 @@ export function NewDirectMessageDialog({
         return
       }
       const { directMessage } = await overlayAppClient.conversations.createDirectMessage({
-        principalIds: selected,
+        principalIds: addToConversationId
+          ? [...excludedPrincipalIds, ...selected]
+          : selected,
         sourceConversationId,
       })
       onCreated?.({ id: directMessage.conversationId, title: directMessage.title })
@@ -166,9 +170,11 @@ export function NewDirectMessageDialog({
     <DialogFrame
       open={open}
       onOpenChange={onOpenChange}
-      title={addToConversationId ? 'Add people' : sourceConversationId ? 'Continue with people' : 'New direct message'}
+      title={addToConversationId && addToConversationType === 'dm' ? 'Start a group DM' : addToConversationId ? 'Add people' : sourceConversationId ? 'Continue with people' : 'New direct message'}
       description={addToConversationId
-        ? 'New participants can read the full conversation history.'
+        ? addToConversationType === 'dm'
+          ? 'Overlay will start a new group DM without copying this private history.'
+          : 'People added to this channel can read its history.'
         : sourceConversationId
         ? 'Choose people. Overlay will fork this Personal chat so the original stays private.'
         : 'Choose one person for a DM or several people for a group DM.'}
@@ -178,7 +184,7 @@ export function NewDirectMessageDialog({
             Cancel
           </Button>
           <Button variant="primary" onClick={() => void create()} disabled={busy || selected.length === 0}>
-            {busy ? 'Working…' : addToConversationId ? 'Add people' : sourceConversationId ? 'Continue in DM' : 'Start message'}
+            {busy ? 'Working…' : addToConversationId && addToConversationType === 'dm' ? 'Start group DM' : addToConversationId ? 'Add people' : sourceConversationId ? 'Continue in DM' : 'Start message'}
           </Button>
         </>
       )}

--- a/src/features/chat/components/collaboration/RoomMessageItem.test.tsx
+++ b/src/features/chat/components/collaboration/RoomMessageItem.test.tsx
@@ -3,7 +3,13 @@ import test from 'node:test'
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { RoomMessageItem } from './RoomMessageItem'
-import { isOwnRoomMessage, toRoomMessageView, type RoomMessageRecord } from './room-message-view'
+import {
+  compareRoomMessageRecords,
+  isOwnRoomMessage,
+  mergeRoomMessages,
+  toRoomMessageView,
+  type RoomMessageRecord,
+} from './room-message-view'
 
 ;(globalThis as typeof globalThis & { React: typeof React }).React = React
 
@@ -136,4 +142,13 @@ test('attachment summaries become chips, not body text', () => {
   assert.equal(view.text, 'Latest numbers')
   assert.deepEqual(view.documentNames, ['q3.csv'])
   assert.equal(view.images.length, 1)
+})
+
+test('room reconciliation uses deterministic ordering and replaces optimistic duplicates', () => {
+  const persisted = record({ id: 'message_real', createdAt: 20, clientNonce: 'nonce_1', content: 'saved' })
+  const pending = record({ id: 'optimistic_nonce_1', createdAt: 19, clientNonce: 'nonce_1', content: 'pending', delivery: 'sending' })
+  const later = record({ id: 'message_z', createdAt: 20, authorPrincipalId: 'principal_maya' })
+  const merged = mergeRoomMessages([persisted, later], [pending])
+  assert.deepEqual(merged.map((message) => message.id), ['message_real', 'message_z'])
+  assert.ok(compareRoomMessageRecords(merged[0]!, merged[1]!) < 0)
 })

--- a/src/features/chat/components/collaboration/RoomMessageItem.tsx
+++ b/src/features/chat/components/collaboration/RoomMessageItem.tsx
@@ -80,6 +80,8 @@ export type RoomMessageItemProps = {
   onOpenAttachmentPreview: (preview: AttachmentPreview) => void
   /** Briefly outlines the message after a jump from the pinned or thread list. */
   highlighted?: boolean
+  /** Consecutive messages from the same author use a compact transcript row. */
+  grouped?: boolean
 }
 
 /** Rooms do not surface draft review; agent drafts are handled in personal chat. */
@@ -120,6 +122,7 @@ export function RoomMessageItem({
   onRetrySend,
   onOpenAttachmentPreview,
   highlighted = false,
+  grouped = false,
 }: RoomMessageItemProps) {
   const { mine } = message
   const isAgent = message.authorKind === 'agent' || message.authorKind === 'model'
@@ -236,7 +239,11 @@ export function RoomMessageItem({
    * even when a teammate wrote them, which is exactly the confusion a shared
    * room cannot afford.
    */
-  const meta = (
+  const meta = grouped ? (
+    <time className={`px-1 text-[10px] text-[var(--muted-light)] opacity-0 transition-opacity group-hover/exchange:opacity-100 ${mine ? 'text-right' : 'text-left'}`}>
+      {timeLabel}
+    </time>
+  ) : (
     <div className={`flex items-center gap-2 px-1 ${mine ? 'justify-end' : ''}`}>
       <span className="inline-flex min-w-0 items-center gap-1.5 text-xs font-medium text-[var(--foreground)]">
         {isAgent ? (

--- a/src/features/chat/components/collaboration/room-message-view.ts
+++ b/src/features/chat/components/collaboration/room-message-view.ts
@@ -26,6 +26,27 @@ export type RoomMessageRecord = {
   status?: 'generating' | 'completed' | 'error'
 }
 
+/** Stable ordering and optimistic reconciliation for room messages. */
+export function compareRoomMessageRecords(left: Pick<RoomMessageRecord, 'id' | 'createdAt'>, right: Pick<RoomMessageRecord, 'id' | 'createdAt'>): number {
+  return left.createdAt - right.createdAt || left.id.localeCompare(right.id)
+}
+
+export function mergeRoomMessages(
+  persisted: RoomMessageRecord[],
+  current: RoomMessageRecord[],
+): RoomMessageRecord[] {
+  const merged = new Map<string, RoomMessageRecord>()
+  for (const message of persisted) {
+    merged.set(message.clientNonce ? `nonce:${message.clientNonce}` : `id:${message.id}`, message)
+  }
+  for (const message of current) {
+    const key = message.clientNonce ? `nonce:${message.clientNonce}` : `id:${message.id}`
+    const existing = merged.get(key)
+    if (!existing || (existing.delivery && !message.delivery)) merged.set(key, message)
+  }
+  return [...merged.values()].sort(compareRoomMessageRecords)
+}
+
 /** The server appends "[Attached 2 images: a.png]" to stored content; thumbnails already say that. */
 const ATTACHMENT_SUMMARY = /\[Attached [^\]]*\]/g
 

--- a/src/server/app-api/v1/conversations/[conversationId]/presence/route.ts
+++ b/src/server/app-api/v1/conversations/[conversationId]/presence/route.ts
@@ -32,6 +32,9 @@ export async function PATCH(_request: Request, context: AppApiRouteContext) {
         actorUserId: context.auth.userId,
         workspaceId: context.workspace.workspace.id,
         conversationId: await id(context),
+        sessionId: typeof context.parsedJson.sessionId === 'string'
+          ? context.parsedJson.sessionId.trim()
+          : undefined,
         status,
         typing: context.parsedJson.typing === true,
       })

--- a/src/server/app-api/v1/conversations/[conversationId]/state/route.ts
+++ b/src/server/app-api/v1/conversations/[conversationId]/state/route.ts
@@ -19,6 +19,7 @@ export async function PATCH(_request: Request, context: AppApiRouteContext) {
         archived: input.archived,
         markUnread: input.markUnread,
         markRead: input.markRead,
+        readSequence: input.readSequence,
       })
     return NextResponse.json({ participant })
   } catch (_error) {

--- a/src/server/app-api/v1/conversations/route.ts
+++ b/src/server/app-api/v1/conversations/route.ts
@@ -76,6 +76,8 @@ export async function GET(request: NextRequest, context: AppApiRouteContext) {
     const messageLimit = readPositiveIntParam(searchParams.get('limit'), 100)
     const beforeCreatedAtParam = searchParams.get('beforeCreatedAt')
     const beforeCreatedAt = beforeCreatedAtParam ? Number(beforeCreatedAtParam) : undefined
+    const mainOnly = readBooleanParam(searchParams.get('mainOnly'))
+    const threadRootMessageId = searchParams.get('threadRootMessageId')?.trim() || undefined
     const compactToolPayloads = readBooleanParam(searchParams.get('compactToolPayloads')) === true
     const workspaceId = context.workspace.workspace.id
     const conversationType = conversationTypeForView(searchParams.get('view'))
@@ -112,6 +114,8 @@ export async function GET(request: NextRequest, context: AppApiRouteContext) {
             workspaceId,
             limit: messageLimit,
             ...(Number.isFinite(beforeCreatedAt) ? { beforeCreatedAt } : {}),
+            ...(mainOnly !== undefined ? { mainOnly } : {}),
+            ...(threadRootMessageId ? { threadRootMessageId } : {}),
             compactToolPayloads,
           })
         } catch (error) {

--- a/src/server/collaboration/phase8-characterization.test.ts
+++ b/src/server/collaboration/phase8-characterization.test.ts
@@ -93,7 +93,16 @@ test('Phase 8 persists policy, directory identity, and export history', async ()
     'workspace_audit_exports',
     "'schema_version', '38'",
   ]) assert.match(migration, new RegExp(invariant.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
-  assert.equal(APP_DATA_SCHEMA_VERSION, 38)
+  const correctnessMigration = await readFile(
+    `${root}/migrations/app-data/0039_conversation_correctness.sql`,
+    'utf8',
+  )
+  for (const invariant of [
+    'last_read_sequence',
+    'session_id',
+    'workspace_presence_principal_idx',
+  ]) assert.match(correctnessMigration, new RegExp(invariant))
+  assert.equal(APP_DATA_SCHEMA_VERSION, 39)
 })
 
 test('Phase 8 audit export covers membership, grants, messages, runs, and approvals', () => {

--- a/src/server/conversations/ActConversationRepository.ts
+++ b/src/server/conversations/ActConversationRepository.ts
@@ -162,6 +162,8 @@ export interface ActConversationRepository {
     compactToolPayloads?: boolean
     conversationId: Id<'conversations'>
     limit: number
+    mainOnly?: boolean
+    threadRootMessageId?: string
     userId: string
     workspaceId?: string
   }): Promise<ConversationMessageRow[]>

--- a/src/server/conversations/ConversationCollaborationRepository.ts
+++ b/src/server/conversations/ConversationCollaborationRepository.ts
@@ -63,6 +63,7 @@ export interface ConversationCollaborationRepository {
   upsertPresence(args: {
     actorUserId: string
     conversationId?: string
+    sessionId?: string
     status: 'online' | 'away' | 'offline'
     typing?: boolean
     workspaceId: string

--- a/src/server/conversations/ConvexActConversationRepository.ts
+++ b/src/server/conversations/ConvexActConversationRepository.ts
@@ -79,10 +79,13 @@ export class ConvexActConversationRepository implements ActConversationRepositor
     compactToolPayloads?: boolean
     conversationId: Id<'conversations'>
     limit: number
+    mainOnly?: boolean
+    threadRootMessageId?: string
     userId: string
   }): Promise<ConversationMessageRow[]> {
     return await convex.query<ConversationMessageRow[]>('chat/conversations:getRecentMessages', {
       ...args,
+      threadRootMessageId: args.threadRootMessageId as Id<'conversationMessages'> | undefined,
       serverSecret: this.serverSecret,
     }) ?? []
   }
@@ -368,20 +371,30 @@ export class ConvexActConversationRepository implements ActConversationRepositor
     return await convex.query<SharedConversationRow | null>('chat/conversations:getPublicByToken', args)
   }
 
-  async getConversationEventCursor(_args: { userId: string; workspaceId?: string }): Promise<number> {
-    return 0
+  async getConversationEventCursor(args: { userId: string; workspaceId?: string }): Promise<number> {
+    return await convex.query<number>('collaboration/directMessages:getConversationEventCursor', {
+      actorUserId: args.userId,
+      workspaceId: args.workspaceId,
+      serverSecret: this.serverSecret,
+    }) ?? 0
   }
 
-  async listConversationEvents(_args: {
+  async listConversationEvents(args: {
     afterSequence: number
     limit: number
     userId: string
     workspaceId?: string
   }): Promise<ConversationEventRow[]> {
-    return []
+    return await convex.query<ConversationEventRow[]>('collaboration/directMessages:listConversationEvents', {
+      actorUserId: args.userId,
+      afterSequence: args.afterSequence,
+      limit: args.limit,
+      workspaceId: args.workspaceId,
+      serverSecret: this.serverSecret,
+    }) ?? []
   }
 
-  async waitForConversationEvents(_args: {
+  async waitForConversationEvents(args: {
     afterSequence: number
     limit: number
     signal?: AbortSignal
@@ -389,7 +402,10 @@ export class ConvexActConversationRepository implements ActConversationRepositor
     userId: string
     workspaceId?: string
   }): Promise<ConversationEventRow[]> {
-    return []
+    const first = await this.listConversationEvents(args)
+    if (first.length > 0 || args.signal?.aborted) return first
+    await delay(Math.min(Math.max(250, args.timeoutMs), 1_000), args.signal)
+    return args.signal?.aborted ? [] : await this.listConversationEvents(args)
   }
 
   async recordUsageBatch(args: {
@@ -402,4 +418,14 @@ export class ConvexActConversationRepository implements ActConversationRepositor
       serverSecret: this.serverSecret,
     })
   }
+}
+
+function delay(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, milliseconds)
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer)
+      resolve()
+    }, { once: true })
+  })
 }

--- a/src/server/conversations/ConvexConversationCollaborationRepository.ts
+++ b/src/server/conversations/ConvexConversationCollaborationRepository.ts
@@ -121,6 +121,7 @@ implements ConversationCollaborationRepository {
     markRead?: boolean
     markUnread?: boolean
     notificationLevel?: 'all' | 'mentions' | 'muted'
+    readSequence?: number
     workspaceId: string
   }) {
     return await convex.mutation<ConversationParticipant>('collaboration/directMessages:updateParticipantState', {
@@ -133,6 +134,7 @@ implements ConversationCollaborationRepository {
   async upsertPresence(args: {
     actorUserId: string
     conversationId?: string
+    sessionId?: string
     status: 'online' | 'away' | 'offline'
     typing?: boolean
     workspaceId: string

--- a/src/server/conversations/PostgresActConversationRepository.ts
+++ b/src/server/conversations/PostgresActConversationRepository.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 
 import { randomBytes, randomUUID } from 'node:crypto'
-import { and, asc, desc, eq, gt, gte, inArray, isNull, lt, or } from 'drizzle-orm'
+import { and, asc, desc, eq, exists, gt, gte, inArray, isNull, lt, or } from 'drizzle-orm'
 import { DEFAULT_APP_SETTINGS } from '@overlay/app-core'
 import type { OverlayPostgresDb } from '@/server/database/postgres/client'
 import { withTransientPostgresReadRetry } from '@/server/database/postgres/transient-errors'
@@ -10,6 +10,7 @@ import {
   conversationEvents,
   conversationMessageDeltas,
   conversationMessages,
+  conversationParticipants,
   conversations,
   projects,
   skills,
@@ -208,7 +209,22 @@ export class PostgresActConversationRepository implements ActConversationReposit
         args.workspaceId ? eq(conversations.workspaceId, args.workspaceId) : undefined,
       ))
       .limit(1)
-    return row ? mapConversationRow(row) : null
+    if (!row) return null
+    if (!args.workspaceId || row.conversationType === 'personal') {
+      return row.userId === args.userId ? mapConversationRow(row) : null
+    }
+    const [participant] = await this.db
+      .select({ principalId: conversationParticipants.principalId })
+      .from(conversationParticipants)
+      .innerJoin(workspacePrincipals, eq(workspacePrincipals.id, conversationParticipants.principalId))
+      .where(and(
+        eq(conversationParticipants.conversationId, row.id),
+        eq(conversationParticipants.status, 'active'),
+        eq(workspacePrincipals.userId, args.userId),
+        eq(workspacePrincipals.type, 'human'),
+      ))
+      .limit(1)
+    return participant ? mapConversationRow(row) : null
   }
 
   async listConversations(args: {
@@ -260,6 +276,8 @@ export class PostgresActConversationRepository implements ActConversationReposit
     compactToolPayloads?: boolean
     conversationId: ConversationId
     limit: number
+    mainOnly?: boolean
+    threadRootMessageId?: string
     userId: string
     workspaceId?: string
   }): Promise<ConversationMessageRow[]> {
@@ -269,6 +287,8 @@ export class PostgresActConversationRepository implements ActConversationReposit
     const filters = [
       eq(conversationMessages.conversationId, args.conversationId),
       args.workspaceId ? undefined : eq(conversationMessages.userId, args.userId),
+      args.mainOnly ? isNull(conversationMessages.threadRootMessageId) : undefined,
+      args.threadRootMessageId ? eq(conversationMessages.threadRootMessageId, args.threadRootMessageId) : undefined,
       beforeCreatedAt ? lt(conversationMessages.createdAt, beforeCreatedAt) : undefined,
     ].filter(Boolean)
 
@@ -276,7 +296,7 @@ export class PostgresActConversationRepository implements ActConversationReposit
       .select()
       .from(conversationMessages)
       .where(and(...filters))
-      .orderBy(desc(conversationMessages.createdAt))
+      .orderBy(desc(conversationMessages.createdAt), desc(conversationMessages.id))
       .limit(limit)
 
     return rows.reverse().map(mapConversationMessageRow)
@@ -295,7 +315,7 @@ export class PostgresActConversationRepository implements ActConversationReposit
         eq(conversationMessages.conversationId, args.conversationId),
         args.workspaceId ? undefined : eq(conversationMessages.userId, args.userId),
       ))
-      .orderBy(conversationMessages.createdAt)
+      .orderBy(asc(conversationMessages.createdAt), asc(conversationMessages.id))
     return rows.map(mapConversationMessageRow)
   }
 
@@ -311,6 +331,11 @@ export class PostgresActConversationRepository implements ActConversationReposit
   }): Promise<void> {
     const now = new Date()
     await this.db.transaction(async (tx) => {
+      const conversation = await assertPostgresConversationMutationAccess(tx, {
+        conversationId: args.conversationId,
+        userId: args.userId,
+        workspaceId: args.workspaceId,
+      })
       if (args.projectId !== undefined) {
         await assertActivePostgresProject(tx, {
           projectId: args.projectId,
@@ -329,9 +354,8 @@ export class PostgresActConversationRepository implements ActConversationReposit
           updatedAt: now,
         })
         .where(and(
-          eq(conversations.id, args.conversationId),
-          args.workspaceId ? undefined : eq(conversations.userId, args.userId),
-          args.workspaceId ? eq(conversations.workspaceId, args.workspaceId) : undefined,
+          eq(conversations.id, conversation.id),
+          isNull(conversations.deletedAt),
         ))
         .returning({ id: conversations.id })
       if (updated.length > 0) {
@@ -351,6 +375,11 @@ export class PostgresActConversationRepository implements ActConversationReposit
   }): Promise<void> {
     const now = new Date()
     await this.db.transaction(async (tx) => {
+      const conversation = await assertPostgresConversationMutationAccess(tx, {
+        conversationId: args.conversationId,
+        userId: args.userId,
+        workspaceId: args.workspaceId,
+      })
       const updated = await tx
         .update(conversations)
         .set({
@@ -359,9 +388,8 @@ export class PostgresActConversationRepository implements ActConversationReposit
           updatedAt: now,
         })
         .where(and(
-          eq(conversations.id, args.conversationId),
-          args.workspaceId ? undefined : eq(conversations.userId, args.userId),
-          args.workspaceId ? eq(conversations.workspaceId, args.workspaceId) : undefined,
+          eq(conversations.id, conversation.id),
+          isNull(conversations.deletedAt),
         ))
         .returning({ id: conversations.id })
       if (updated.length > 0) {
@@ -477,6 +505,20 @@ export class PostgresActConversationRepository implements ActConversationReposit
         isNull(conversations.deletedAt),
       )).limit(1)
       if (!conversation) throw new Error('WORKSPACE_ACCESS_DENIED')
+      if (conversation.conversationType !== 'personal') {
+        const [membership] = await tx
+          .select({ principalId: conversationParticipants.principalId })
+          .from(conversationParticipants)
+          .innerJoin(workspacePrincipals, eq(workspacePrincipals.id, conversationParticipants.principalId))
+          .where(and(
+            eq(conversationParticipants.conversationId, conversation.id),
+            eq(conversationParticipants.status, 'active'),
+            eq(workspacePrincipals.userId, args.userId),
+            eq(workspacePrincipals.type, 'human'),
+          ))
+          .limit(1)
+        if (!membership) throw new Error('WORKSPACE_ACCESS_DENIED')
+      }
       if (args.threadRootMessageId) {
         const [root] = await tx.select({ id: conversationMessages.id })
           .from(conversationMessages)
@@ -1081,7 +1123,7 @@ export class PostgresActConversationRepository implements ActConversationReposit
       .select()
       .from(conversationMessages)
       .where(eq(conversationMessages.conversationId, conversation.id))
-      .orderBy(asc(conversationMessages.createdAt))
+      .orderBy(asc(conversationMessages.createdAt), asc(conversationMessages.id))
     return {
       _id: conversation.id,
       title: conversation.title,
@@ -1098,8 +1140,21 @@ export class PostgresActConversationRepository implements ActConversationReposit
         .from(conversationEvents)
         .innerJoin(conversations, eq(conversations.id, conversationEvents.conversationId))
         .where(and(
-          eq(conversationEvents.userId, args.userId),
           args.workspaceId ? eq(conversations.workspaceId, args.workspaceId) : undefined,
+          or(
+            eq(conversations.userId, args.userId),
+            exists(
+              this.db.select({ id: conversationParticipants.conversationId })
+                .from(conversationParticipants)
+                .innerJoin(workspacePrincipals, eq(workspacePrincipals.id, conversationParticipants.principalId))
+                .where(and(
+                  eq(conversationParticipants.conversationId, conversationEvents.conversationId),
+                  eq(conversationParticipants.status, 'active'),
+                  eq(workspacePrincipals.userId, args.userId),
+                  eq(workspacePrincipals.type, 'human'),
+                )),
+            ),
+          ),
         ))
         .orderBy(desc(conversationEvents.sequence))
         .limit(1)
@@ -1119,9 +1174,22 @@ export class PostgresActConversationRepository implements ActConversationReposit
         .from(conversationEvents)
         .innerJoin(conversations, eq(conversations.id, conversationEvents.conversationId))
         .where(and(
-          eq(conversationEvents.userId, args.userId),
           gt(conversationEvents.sequence, args.afterSequence),
           args.workspaceId ? eq(conversations.workspaceId, args.workspaceId) : undefined,
+          or(
+            eq(conversations.userId, args.userId),
+            exists(
+              this.db.select({ id: conversationParticipants.conversationId })
+                .from(conversationParticipants)
+                .innerJoin(workspacePrincipals, eq(workspacePrincipals.id, conversationParticipants.principalId))
+                .where(and(
+                  eq(conversationParticipants.conversationId, conversationEvents.conversationId),
+                  eq(conversationParticipants.status, 'active'),
+                  eq(workspacePrincipals.userId, args.userId),
+                  eq(workspacePrincipals.type, 'human'),
+                )),
+            ),
+          ),
         ))
         .orderBy(asc(conversationEvents.sequence))
         .limit(Math.max(1, Math.min(200, Math.floor(args.limit))))
@@ -1151,12 +1219,11 @@ export class PostgresActConversationRepository implements ActConversationReposit
 
       const remainingMs = deadline - Date.now()
       if (remainingMs <= 0) return []
-      const listenerConnected = this.eventNotifier.getHealth().connected
       const waiter = await this.eventNotifier.createWaiter({
         signal: args.signal,
-        // LISTEN is only a wake-up optimization. While disconnected, check the
-        // durable cursor every second so recovery never depends on a process restart.
-        timeoutMs: Math.min(remainingMs, listenerConnected ? remainingMs : 1_000),
+        // LISTEN is a wake-up optimization. Check the durable authorized cursor
+        // every second as well so a sender's event wakes every room member.
+        timeoutMs: Math.min(remainingMs, 1_000),
         userId: args.userId,
       })
       events = await this.listConversationEvents(args)
@@ -1199,6 +1266,49 @@ function conversationListWhere(args: {
         )
       : undefined,
   )
+}
+
+/**
+ * Mutations must use the same ownership boundary as reads and message writes.
+ * A workspace id alone is not authorization: shared rooms require an active
+ * participant whose human principal belongs to the requesting user.
+ */
+async function assertPostgresConversationMutationAccess<T extends Pick<OverlayPostgresDb, 'select'>>(
+  tx: T,
+  args: { conversationId: string; userId: string; workspaceId?: string },
+): Promise<typeof conversations.$inferSelect> {
+  const [conversation] = await tx
+    .select()
+    .from(conversations)
+    .where(and(
+      eq(conversations.id, args.conversationId),
+      args.workspaceId ? eq(conversations.workspaceId, args.workspaceId) : undefined,
+      isNull(conversations.deletedAt),
+    ))
+    .limit(1)
+  if (!conversation) throw new Error('WORKSPACE_ACCESS_DENIED')
+
+  if (conversation.conversationType === 'personal') {
+    if (conversation.userId !== args.userId) throw new Error('WORKSPACE_ACCESS_DENIED')
+    return conversation
+  }
+
+  if (!args.workspaceId) throw new Error('WORKSPACE_ACCESS_DENIED')
+  const [participant] = await tx
+    .select({ principalId: conversationParticipants.principalId })
+    .from(conversationParticipants)
+    .innerJoin(workspacePrincipals, eq(workspacePrincipals.id, conversationParticipants.principalId))
+    .where(and(
+      eq(conversationParticipants.conversationId, conversation.id),
+      eq(conversationParticipants.workspaceId, args.workspaceId),
+      eq(conversationParticipants.status, 'active'),
+      eq(workspacePrincipals.userId, args.userId),
+      eq(workspacePrincipals.type, 'human'),
+      isNull(workspacePrincipals.archivedAt),
+    ))
+    .limit(1)
+  if (!participant) throw new Error('WORKSPACE_ACCESS_DENIED')
+  return conversation
 }
 
 function mapConversationRow(row: typeof conversations.$inferSelect): ConversationListRow {

--- a/src/server/conversations/PostgresConversationCollaborationRepository.ts
+++ b/src/server/conversations/PostgresConversationCollaborationRepository.ts
@@ -288,20 +288,6 @@ implements ConversationCollaborationRepository {
         createdAt: now,
       })
 
-      if (args.sourceConversationId) {
-        const sourceMessages = await tx.select().from(conversationMessages)
-          .where(eq(conversationMessages.conversationId, args.sourceConversationId))
-          .orderBy(conversationMessages.createdAt)
-        if (sourceMessages.length > 0) {
-          await tx.insert(conversationMessages).values(sourceMessages.map((message) => ({
-            ...message,
-            id: `message_${randomUUID()}`,
-            conversationId,
-            clientNonce: undefined,
-          })))
-        }
-      }
-
       const invitees = eligible.map(({ principal }) => principal).filter((principal) => principal.id !== actor.id)
       if (invitees.length > 0) {
         await tx.insert(workspaceNotifications).values(invitees.map((principal) => ({
@@ -404,6 +390,16 @@ implements ConversationCollaborationRepository {
     workspaceId: string
   }): Promise<ConversationParticipant> {
     const actor = await this.requireModerator(args)
+    const [conversation] = await this.db.select({ conversationType: conversations.conversationType })
+      .from(conversations)
+      .where(and(
+        eq(conversations.id, args.conversationId),
+        eq(conversations.workspaceId, args.workspaceId),
+        isNull(conversations.deletedAt),
+      )).limit(1)
+    if (conversation?.conversationType === 'dm') {
+      throw new Error('DIRECT_MESSAGE_REQUIRES_NEW_GROUP')
+    }
     const [principal] = await this.db.select().from(workspacePrincipals)
       .innerJoin(workspaceMemberships, and(
         eq(workspaceMemberships.workspaceId, workspacePrincipals.workspaceId),
@@ -482,15 +478,29 @@ implements ConversationCollaborationRepository {
     markRead?: boolean
     markUnread?: boolean
     notificationLevel?: 'all' | 'mentions' | 'muted'
+    readSequence?: number
     workspaceId: string
   }): Promise<ConversationParticipant> {
     const actor = await this.requireActor(args)
     if (!await this.canAccessConversation(args)) throw new Error('CONVERSATION_ACCESS_DENIED')
     const now = new Date()
+    const requestedReadSequence = Number.isSafeInteger(args.readSequence) && (args.readSequence ?? 0) >= 0
+      ? args.readSequence
+      : undefined
+    let readSequence = requestedReadSequence
+    if (args.markRead || requestedReadSequence !== undefined) {
+      const [event] = await this.db.select({ sequence: conversationEvents.sequence })
+        .from(conversationEvents)
+        .where(eq(conversationEvents.conversationId, args.conversationId))
+        .orderBy(desc(conversationEvents.sequence))
+        .limit(1)
+      readSequence = Math.min(requestedReadSequence ?? Number.MAX_SAFE_INTEGER, event?.sequence ?? 0)
+    }
     const [row] = await this.db.update(conversationParticipants).set({
       ...(args.notificationLevel ? { notificationLevel: args.notificationLevel } : {}),
       ...(args.archived !== undefined ? { archivedAt: args.archived ? now : null } : {}),
-      ...(args.markRead ? { lastReadAt: now, markedUnreadAt: null } : {}),
+      ...(args.markRead ? { lastReadAt: now, lastReadSequence: readSequence ?? 0, markedUnreadAt: null } : {}),
+      ...(readSequence !== undefined && !args.markRead ? { lastReadSequence: readSequence } : {}),
       ...(args.markUnread ? { markedUnreadAt: now } : {}),
       updatedAt: now,
     }).where(and(
@@ -505,6 +515,7 @@ implements ConversationCollaborationRepository {
   async upsertPresence(args: {
     actorUserId: string
     conversationId?: string
+    sessionId?: string
     status: 'online' | 'away' | 'offline'
     typing?: boolean
     workspaceId: string
@@ -515,19 +526,21 @@ implements ConversationCollaborationRepository {
       conversationId: args.conversationId,
     })) throw new Error('CONVERSATION_ACCESS_DENIED')
     const now = new Date()
+    const sessionId = args.sessionId?.trim() || 'legacy'
     const typingExpiresAt = args.typing && args.conversationId
       ? new Date(now.getTime() + 6_000)
       : null
     const [row] = await this.db.insert(workspacePresence).values({
       workspaceId: args.workspaceId,
       principalId: actor.id,
+      sessionId,
       conversationId: args.conversationId,
       status: args.status,
       lastSeenAt: now,
       typingExpiresAt,
       updatedAt: now,
     }).onConflictDoUpdate({
-      target: [workspacePresence.workspaceId, workspacePresence.principalId],
+      target: [workspacePresence.workspaceId, workspacePresence.principalId, workspacePresence.sessionId],
       set: {
         conversationId: args.conversationId ?? null,
         status: args.status,
@@ -552,9 +565,35 @@ implements ConversationCollaborationRepository {
         eq(conversationParticipants.conversationId, args.conversationId),
         eq(conversationParticipants.status, 'active'),
       ))
-      .where(eq(workspacePresence.workspaceId, args.workspaceId))
+      .where(and(
+        eq(workspacePresence.workspaceId, args.workspaceId),
+        or(
+          isNull(workspacePresence.conversationId),
+          eq(workspacePresence.conversationId, args.conversationId),
+        ),
+      ))
     const now = new Date()
-    return rows.map((row) => mapPresence(row.workspace_presence, now))
+    const sessionsByPrincipal = new Map<string, Array<typeof rows[number]['workspace_presence']>>()
+    for (const row of rows) {
+      const sessions = sessionsByPrincipal.get(row.workspace_presence.principalId) ?? []
+      sessions.push(row.workspace_presence)
+      sessionsByPrincipal.set(row.workspace_presence.principalId, sessions)
+    }
+    return [...sessionsByPrincipal.values()].map((sessions) => {
+      const active = sessions
+        .filter((session) => now.getTime() - session.lastSeenAt.getTime() <= 120_000)
+        .filter((session) => session.status !== 'offline')
+        .sort((left, right) => right.updatedAt.getTime() - left.updatedAt.getTime())
+      const latest = [...sessions].sort((left, right) => right.updatedAt.getTime() - left.updatedAt.getTime())[0]!
+      const representative = active[0] ?? latest
+      const status = active.some((session) => session.status === 'online')
+        ? 'online'
+        : active.length > 0 ? 'away' : 'offline'
+      const typing = active.some((session) => Boolean(
+        session.typingExpiresAt && session.typingExpiresAt.getTime() > now.getTime(),
+      ))
+      return mapPresence({ ...representative, status }, now, { typing })
+    })
   }
 
   async recordMessageActivity(args: {
@@ -579,14 +618,6 @@ implements ConversationCollaborationRepository {
       && (participant.notificationLevel !== 'mentions' || mentions.has(participant.principalId))
     ))
     await this.db.transaction(async (tx) => {
-      await tx.update(conversationParticipants).set({
-        lastReadAt: now,
-        markedUnreadAt: null,
-        updatedAt: now,
-      }).where(and(
-        eq(conversationParticipants.conversationId, args.conversationId),
-        eq(conversationParticipants.principalId, actor.id),
-      ))
       if (recipients.length > 0) {
         await tx.insert(workspaceNotifications).values(recipients.map((recipient) => ({
           id: `notification_${randomUUID()}`,
@@ -942,6 +973,7 @@ function mapParticipant(
     updatedAt: row.updatedAt.getTime(),
     removedAt: row.removedAt?.getTime(),
     lastReadAt: row.lastReadAt?.getTime(),
+    lastReadSequence: row.lastReadSequence ?? undefined,
     markedUnreadAt: row.markedUnreadAt?.getTime(),
     archivedAt: row.archivedAt?.getTime(),
   }
@@ -950,14 +982,16 @@ function mapParticipant(
 function mapPresence(
   row: typeof workspacePresence.$inferSelect,
   now: Date,
+  overrides: { typing?: boolean } = {},
 ): ConversationPresence {
   const stale = now.getTime() - row.lastSeenAt.getTime() > 120_000
   return {
     workspaceId: row.workspaceId,
     principalId: row.principalId,
+    sessionId: row.sessionId,
     conversationId: row.conversationId ?? undefined,
     status: stale ? 'offline' : row.status,
-    typing: !stale && Boolean(row.typingExpiresAt && row.typingExpiresAt > now),
+    typing: !stale && (overrides.typing ?? Boolean(row.typingExpiresAt && row.typingExpiresAt > now)),
     lastSeenAt: row.lastSeenAt.getTime(),
     typingExpiresAt: row.typingExpiresAt?.getTime(),
   }

--- a/src/server/conversations/postgres-direct-messages.test.ts
+++ b/src/server/conversations/postgres-direct-messages.test.ts
@@ -191,11 +191,11 @@ test('Postgres direct messages are participant-scoped and realtime-ready', {
       workspaceId,
       conversationId: created.conversationId as never,
     }), true)
-    assert.equal((await conversations.getConversationMessages({
+    assert.deepEqual((await conversations.getConversationMessages({
       workspaceId,
       conversationId: created.conversationId as never,
       userId: memberUserId,
-    }))[0]?.content, 'Source context')
+    })).filter((message) => message.content === 'Source context'), [])
 
     const clientNonce = `${scope}_nonce`
     const messageId = await conversations.addMessage({
@@ -231,6 +231,20 @@ test('Postgres direct messages are participant-scoped and realtime-ready', {
       body: 'Hello owner',
       mentionedPrincipalIds: [ownerPrincipalId],
     })
+    const markedRead = await collaboration.updateParticipantState({
+      actorUserId: memberUserId,
+      workspaceId,
+      conversationId: created.conversationId,
+      markRead: true,
+    })
+    assert.ok((markedRead.lastReadSequence ?? 0) > 0)
+    const cappedRead = await collaboration.updateParticipantState({
+      actorUserId: memberUserId,
+      workspaceId,
+      conversationId: created.conversationId,
+      readSequence: Number.MAX_SAFE_INTEGER,
+    })
+    assert.equal(cappedRead.lastReadSequence, markedRead.lastReadSequence)
     const notifications = await collaboration.listNotifications({
       actorUserId: ownerUserId,
       workspaceId,
@@ -246,12 +260,25 @@ test('Postgres direct messages are participant-scoped and realtime-ready', {
       conversationId: created.conversationId,
       status: 'online',
       typing: true,
+      sessionId: 'tab-a',
+    })
+    await collaboration.upsertPresence({
+      actorUserId: memberUserId,
+      workspaceId,
+      conversationId: created.conversationId,
+      status: 'offline',
+      sessionId: 'tab-b',
     })
     assert.equal((await collaboration.listPresence({
       actorUserId: ownerUserId,
       workspaceId,
       conversationId: created.conversationId,
     })).find((row) => row.principalId === memberPrincipalId)?.typing, true)
+    assert.equal((await collaboration.listPresence({
+      actorUserId: ownerUserId,
+      workspaceId,
+      conversationId: created.conversationId,
+    })).find((row) => row.principalId === memberPrincipalId)?.status, 'online')
 
     assert.equal(await collaboration.editMessage({
       actorUserId: ownerUserId,
@@ -292,6 +319,15 @@ test('Postgres direct messages are participant-scoped and realtime-ready', {
       workspaceId,
       conversationId: created.conversationId,
     }), false)
+    await assert.rejects(
+      conversations.updateConversation({
+        workspaceId,
+        conversationId: created.conversationId as never,
+        userId: memberUserId,
+        title: 'Should remain private',
+      }),
+      /WORKSPACE_ACCESS_DENIED/,
+    )
   } finally {
     await db.delete(workspaces).where(inArray(workspaces.id, [personalWorkspaceId, workspaceId]))
     await db.delete(users).where(inArray(users.id, [ownerUserId, memberUserId]))

--- a/src/server/database/postgres/schema-compatibility.ts
+++ b/src/server/database/postgres/schema-compatibility.ts
@@ -3,8 +3,8 @@ import 'server-only'
 import type { Pool } from 'pg'
 import { createOverlayPostgresPool } from './client'
 
-export const APP_DATA_SCHEMA_VERSION = 38
-export const APP_DATA_MINIMUM_SCHEMA_VERSION = 38
+export const APP_DATA_SCHEMA_VERSION = 39
+export const APP_DATA_MINIMUM_SCHEMA_VERSION = 39
 export const APP_DATA_MIGRATION_LOCK_ID = 6_849_331_027
 
 export type AppDataSchemaCompatibility = {

--- a/src/server/database/postgres/schema.ts
+++ b/src/server/database/postgres/schema.ts
@@ -1361,6 +1361,7 @@ export const conversationParticipants = pgTable('conversation_participants', {
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
   removedAt: timestamp('removed_at', { withTimezone: true }),
   lastReadAt: timestamp('last_read_at', { withTimezone: true }),
+  lastReadSequence: bigint('last_read_sequence', { mode: 'number' }),
   markedUnreadAt: timestamp('marked_unread_at', { withTimezone: true }),
   archivedAt: timestamp('archived_at', { withTimezone: true }),
 }, (table) => [
@@ -1395,6 +1396,7 @@ export const workspacePresence = pgTable('workspace_presence', {
     .notNull()
     .references(() => workspaces.id, { onDelete: 'cascade' }),
   principalId: text('principal_id').notNull(),
+  sessionId: text('session_id').notNull().default('legacy'),
   conversationId: text('conversation_id')
     .references(() => conversations.id, { onDelete: 'set null' }),
   status: workspacePresenceStatus('status').default('online').notNull(),
@@ -1402,13 +1404,14 @@ export const workspacePresence = pgTable('workspace_presence', {
   typingExpiresAt: timestamp('typing_expires_at', { withTimezone: true }),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 }, (table) => [
-  primaryKey({ columns: [table.workspaceId, table.principalId] }),
+  primaryKey({ columns: [table.workspaceId, table.principalId, table.sessionId] }),
   foreignKey({
     columns: [table.workspaceId, table.principalId],
     foreignColumns: [workspacePrincipals.workspaceId, workspacePrincipals.id],
     name: 'workspace_presence_principal_fk',
   }).onDelete('cascade'),
   index('workspace_presence_conversation_idx').on(table.conversationId, table.updatedAt),
+  index('workspace_presence_principal_idx').on(table.workspaceId, table.principalId, table.updatedAt),
 ])
 
 export const workspaceNotifications = pgTable('workspace_notifications', {

--- a/src/shared/schemas/api-boundary.ts
+++ b/src/shared/schemas/api-boundary.ts
@@ -1031,6 +1031,137 @@ export const webApiExcludedRouteDefinitions = [
     routePath: '/api/v1/extensions/[extensionId]/[...path]',
     reason: 'Extension proxy route. It is not part of the stable public web API reference.',
   },
+  // These are browser-facing application BFF routes used by the workspace UI.
+  // They are intentionally not part of the stable external API reference yet;
+  // keeping the exclusions explicit still makes route-coverage drift fail closed.
+  {
+    routePath: '/api/v1/agents',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/agents/[agentId]',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/[conversationId]/messages/[messageId]',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/[conversationId]/participants',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/[conversationId]/pins',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/[conversationId]/presence',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/[conversationId]/reactions',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/[conversationId]/reports',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/[conversationId]/state',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/agent-reply',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/channels',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/direct-messages',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/notifications',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/saved-messages',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/conversations/search',
+    reason: 'Collaboration application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/search',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/shares',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/shares/impact',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/shares/shared-with-me',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspace-invitations/[invitationId]/accept',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/active',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/[workspaceId]/audit-export',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/[workspaceId]/governance',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/[workspaceId]/invitations',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/[workspaceId]/invitations/[invitationId]',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/[workspaceId]/lifecycle',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/[workspaceId]/management',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/[workspaceId]/members',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/[workspaceId]/policies',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/[workspaceId]/teams',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
+  {
+    routePath: '/api/v1/workspaces/[workspaceId]/teams/[teamId]/members',
+    reason: 'Workspace application BFF route; not a stable public API reference.',
+  },
 ] as const satisfies readonly WebApiExcludedRouteDefinition[]
 
 const webApiBoundaryDefinitionList: readonly WebApiBoundaryDefinition[] = webApiBoundaryDefinitions


### PR DESCRIPTION
Implements the correctness foundation for DMs and Channels:

- durable provider-neutral conversation events for Postgres and Convex
- deterministic ordering and optimistic deduplication
- real participant read cursors capped to durable event boundaries
- session-isolated, multi-tab presence aggregation
- main/thread history filters with older-message pagination
- private DM forking without copying personal history
- participant-scoped room reads/messages and lifecycle mutations
- room date separators/grouping and thread UI smoke coverage
- channel creation errors surfaced as policy messages instead of client crashes

Validation completed:
- npx tsc --noEmit --pretty false
- npm run lint:changed and full pre-push lint
- npm run build
- npm run test:workspaces:postgres (14/14)
- npm run test:workspaces:convex (11/11) from the dedicated staging worktree
- npm run test:workspaces:phase8:unit (147/147)
- npm run test:workspaces:phase8:ui (31/31)
- Playwright showcase smoke for DMs, Channels, composer, and threads with 0 console errors
- authenticated local feature smoke with production WorkOS auth override and the feature Convex revision: organization workspace creation, channel creation, sidebar appearance, and two message POSTs returned 200 with 0 application console errors
- staging Convex dev deployment restored after feature QA data cleanup; both worktrees clean

Remote gates are green for docs, schema/routing, lockfile/lint/complexity/typecheck/audit, dependency review, secret scan, Semgrep, CodeQL, and JS/TS analysis. The `Vercel – overlay-landing` failure is expected because that project only deploys main; the staging project correctly reports success via its ignored-build lane.

The PR is ready to merge.