### PR TITLE
ci: add release safety rails

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # actions/checkout v4
 
+      - name: Check out desktop transcript contract
+        run: git submodule update --init --depth 1 overlay-desktop
+
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node v4
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -106,7 +106,7 @@ jobs:
         run: echo "Skipping dependency review because GitHub dependency graph is disabled for this repository."
 
   dependency-audit:
-    name: Lockfile, Lint, Complexity, Typecheck, and Audit
+    name: Required Quality and Security Gates
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -140,6 +140,19 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck
+
+      - name: Build
+        env:
+          INTERNAL_API_SECRET: test-internal-secret
+          NEXT_PUBLIC_CONVEX_URL: https://fixture.convex.cloud
+          OVERLAY_DEPLOYMENT_ENV: test
+        run: npm run build
+
+      - name: Verify core route contracts
+        run: npm run test:route-characterization
+
+      - name: Verify migration and endpoint safety rails
+        run: npm run check:config && npm run test:release-safety
 
       - name: Audit production dependencies
         run: npm run security:audit

--- a/internal-docs/reports/web-app-complexity-baseline.json
+++ b/internal-docs/reports/web-app-complexity-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-16T06:31:06.157Z",
+  "generatedAt": "2026-08-02T03:13:03.203Z",
   "budgets": {
     "maxProductionFileLoc": 500,
     "maxFunctionComplexity": 25,
@@ -30,22 +30,21 @@
   ],
   "largeProductionFiles": [
     "packages/overlay-app-core/src/extensions.ts",
+    "packages/overlay-app-core/src/knowledge-surface.ts",
     "packages/overlay-billing/src/adapters/stripe-billing-provider.ts",
     "packages/overlay-chat-core/src/messages.ts",
     "packages/overlay-chat-react/src/components/ChatExperienceHeader.tsx",
-    "packages/overlay-chat-react/src/components/ExchangeBlock.tsx",
     "packages/overlay-chat-react/src/components/GeneratedUiCard.tsx",
+    "packages/overlay-chat-react/src/styles/chat-surface.css",
+    "packages/overlay-modules-react/src/knowledge/surface.tsx",
     "packages/overlay-modules-react/src/knowledge/view-header.tsx",
-    "src/app/globals.css",
+    "packages/overlay-modules-react/src/notes/editor.tsx",
+    "packages/overlay-modules-react/src/notes/inline-diff-extension.ts",
     "src/app/pricing/PricingClient.tsx",
     "src/components/layout/AppSidebar.tsx",
     "src/features/account/components/OnboardingTour.tsx",
     "src/features/chat/components/ChatExperience.tsx",
     "src/features/chat/components/chat/useChatModelSelectionController.ts",
-    "src/features/knowledge/components/KnowledgeView.tsx",
-    "src/features/marketing/components/MarketingShowcase.tsx",
-    "src/features/notebook/components/InlineDiffExtension.ts",
-    "src/features/notebook/components/NotebookEditor.tsx",
     "src/features/projects/components/ProjectsView.tsx",
     "src/server/ai/gateway/gateway-search-tools.ts",
     "src/server/ai/sandbox/daytona.ts",
@@ -67,11 +66,11 @@
   ],
   "complexFunctionCounts": {
     "src/shared/config/overlayConfigSchema.ts#callback": 1,
+    "src/components/layout/AppSidebar.tsx#AppSidebar": 1,
+    "src/features/chat/components/ChatExperience.tsx#ChatExperience": 1,
     "src/server/app-api/v1/settings/route.ts#PATCH": 1,
     "src/components/providers/AppSettingsProvider.tsx#isAppSettingsPayload": 1,
     "src/features/chat/components/ChatMessage.tsx#TextChatMessage": 1,
-    "src/components/layout/AppSidebar.tsx#AppSidebar": 1,
-    "src/features/chat/components/ChatExperience.tsx#ChatExperience": 1,
     "src/server/app-api/v1/generate-video/route.ts#start": 1,
     "src/shared/tools/output-types.ts#classifyOutputType": 1,
     "packages/overlay-chat-core/src/visual-sequence.ts#buildAssistantVisualSequence": 1,
@@ -83,36 +82,38 @@
     "src/server/app-api/v1/generate-image/route.ts#POST": 1,
     "src/shared/chat/persist-assistant-turn.ts#buildAssistantPersistenceFromSteps": 1,
     "packages/overlay-chat-react/src/components/ChatExperienceHeader.tsx#ChatExperienceHeader": 1,
-    "src/features/notebook/components/InlineDiffExtension.ts#parseMarkdownLine": 1,
+    "packages/overlay-modules-react/src/knowledge/surface.tsx#SharedKnowledgeSurface": 1,
+    "packages/overlay-modules-react/src/notes/inline-diff-extension.ts#parseMarkdownLine": 1,
     "src/server/account/PostgresAccountDataDeletionRepository.ts#countUserRows": 1,
     "src/components/layout/AppSidebar.tsx#callback": 1,
     "src/shared/tools/tool-result-summary.ts#summarizeToolResultForTranscript": 1,
-    "packages/overlay-chat-react/src/components/ExchangeBlock.tsx#ExchangeBlock": 1,
-    "src/features/notebook/components/InlineDiffExtension.ts#parseMarkdownLines": 1,
-    "src/server/files/PostgresFileRepository.ts#callback": 1,
-    "src/features/files/lib/export/markdown.ts#walk": 1,
-    "src/features/knowledge/components/KnowledgeView.tsx#KnowledgeView": 1,
+    "packages/overlay-modules-react/src/notes/inline-diff-extension.ts#parseMarkdownLines": 1,
     "src/server/app-api/v1/browser-task/route.ts#POST": 1,
+    "src/server/files/PostgresFileRepository.ts#callback": 1,
+    "packages/overlay-modules-react/src/extensions/mcp.tsx#McpServerDialog": 1,
+    "src/features/files/lib/export/markdown.ts#walk": 1,
+    "packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx#ChatExchange": 1,
     "src/server/tools/tools/build.ts#buildOverlayToolSet": 1,
-    "packages/overlay-chat-react/src/components/ExchangeBlock.tsx#callback": 1,
+    "packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx#callback": 1,
     "src/features/chat/components/chat/chat-send-text.ts#sendTextTurn": 1,
+    "src/features/chat/components/chat/toChatTranscriptView.ts#callback": 1,
     "src/server/files/PostgresFileRepository.ts#normalizeFile": 1,
     "src/server/ai/sandbox/PostgresDaytonaReconciliationService.ts#reconcile": 1,
+    "src/server/app-api/v1/conversations/act/route.ts#POST": 1,
     "src/server/automations/AutomationService.ts#buildAutomationUpdateNote": 1,
     "src/server/knowledge/mention-resolver.ts#resolveOne": 1,
     "packages/overlay-billing/src/adapters/stripe-billing-provider.ts#verifyPaidPlanCheckoutSession": 1,
     "packages/overlay-chat-react/src/components/MediaSlotOutput.tsx#MediaSlotOutput": 1,
-    "src/server/app-api/v1/conversations/act/route.ts#POST": 1,
-    "packages/overlay-chat-react/src/components/tools/BrowserSessionToolBlock.tsx#BrowserSessionToolBlock": 1,
     "src/server/database/convex.ts#callConvex": 1,
     "packages/overlay-chat-core/src/tool-labels.ts#describeComposioIntegrationTool": 1,
+    "packages/overlay-modules-react/src/notes/editor.tsx#CanonicalNotebookEditor": 1,
     "src/features/chat/components/chat/chat-send-media.ts#sendMediaTurn": 1,
     "src/features/chat/components/ChatExperience.tsx#handleBranchConversationAtTurn": 1,
-    "packages/overlay-chat-react/src/lib/web-tool-sources.ts#collectSourceCandidatesFromUnknown": 1,
-    "src/features/files/components/FileViewer.tsx#FileViewer": 1,
-    "src/server/app-api/v1/conversations/act/extension-plan/route.ts#POST": 1
+    "src/server/app-api/v1/conversations/act/extension-plan/route.ts#POST": 1,
+    "packages/overlay-chat-react/src/lib/web-tool-sources.ts#collectSourceCandidatesFromUnknown": 1
   },
   "routeHandlersOverBudget": [
+    "src/server/app-api/v1/chat-suggestions/route.ts",
     "src/server/app-api/v1/conversations/act/extension-plan/route.ts",
     "src/server/app-api/v1/conversations/act/route.ts",
     "src/server/app-api/v1/conversations/route.ts",
@@ -186,16 +187,30 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
-      "file": "src/app/account/page.tsx",
+      "file": "src/app/%5F_fixtures/chat-parity/page.tsx",
       "layer": "src/app routes",
-      "loc": 387,
+      "loc": 23,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/%5F_fixtures/file-parity/page.tsx",
+      "layer": "src/app routes",
+      "loc": 22,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/about/page.tsx",
+      "layer": "src/app routes",
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/api/account/delete/route.ts",
       "layer": "src/app/api other",
-      "loc": 63,
+      "loc": 91,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -242,23 +257,16 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
-      "file": "src/app/api/auth/native/provider-keys/route.ts",
-      "layer": "src/app/api other",
-      "loc": 46,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
       "file": "src/app/api/auth/native/refresh/route.ts",
       "layer": "src/app/api other",
-      "loc": 54,
+      "loc": 78,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/api/auth/native/subscription/route.ts",
       "layer": "src/app/api other",
-      "loc": 90,
+      "loc": 54,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -279,7 +287,7 @@
     {
       "file": "src/app/api/auth/session/route.ts",
       "layer": "src/app/api other",
-      "loc": 51,
+      "loc": 55,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -349,14 +357,14 @@
     {
       "file": "src/app/api/latest-release/download/route.ts",
       "layer": "src/app/api other",
-      "loc": 23,
+      "loc": 34,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/api/latest-release/route.ts",
       "layer": "src/app/api other",
-      "loc": 15,
+      "loc": 26,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -606,6 +614,20 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/api/v1/mcps/oauth/callback/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 238,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/api/v1/mcps/oauth/route.ts",
+      "layer": "src/app/api/v1 wrappers",
+      "loc": 9,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/api/v1/mcps/route.ts",
       "layer": "src/app/api/v1 wrappers",
       "loc": 15,
@@ -732,6 +754,13 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/app/account/page.tsx",
+      "layer": "src/app routes",
+      "loc": 415,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/app/admin/page.tsx",
       "layer": "src/app routes",
       "loc": 142,
@@ -755,7 +784,7 @@
     {
       "file": "src/app/app/automations/page.tsx",
       "layer": "src/app routes",
-      "loc": 57,
+      "loc": 65,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -769,7 +798,7 @@
     {
       "file": "src/app/app/chat/page.tsx",
       "layer": "src/app routes",
-      "loc": 38,
+      "loc": 55,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -783,7 +812,14 @@
     {
       "file": "src/app/app/files/page.tsx",
       "layer": "src/app routes",
-      "loc": 47,
+      "loc": 52,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/app/home/page.tsx",
+      "layer": "src/app routes",
+      "loc": 22,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -832,7 +868,7 @@
     {
       "file": "src/app/app/layout.tsx",
       "layer": "src/app routes",
-      "loc": 64,
+      "loc": 71,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -840,6 +876,13 @@
       "file": "src/app/app/loading.tsx",
       "layer": "src/app routes",
       "loc": 4,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/app/manifesto/page.tsx",
+      "layer": "src/app routes",
+      "loc": 22,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -874,7 +917,7 @@
     {
       "file": "src/app/app/notes/page.tsx",
       "layer": "src/app routes",
-      "loc": 11,
+      "loc": 15,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -900,6 +943,13 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/app/pricing/page.tsx",
+      "layer": "src/app routes",
+      "loc": 24,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/app/projects/error.tsx",
       "layer": "src/app routes",
       "loc": 11,
@@ -916,7 +966,7 @@
     {
       "file": "src/app/app/projects/page.tsx",
       "layer": "src/app routes",
-      "loc": 35,
+      "loc": 43,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -937,7 +987,7 @@
     {
       "file": "src/app/app/settings/page.tsx",
       "layer": "src/app routes",
-      "loc": 343,
+      "loc": 346,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -951,7 +1001,7 @@
     {
       "file": "src/app/app/tools/page.tsx",
       "layer": "src/app routes",
-      "loc": 13,
+      "loc": 21,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1000,7 +1050,7 @@
     {
       "file": "src/app/auth/native/callback/route.ts",
       "layer": "src/app routes",
-      "loc": 47,
+      "loc": 28,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1014,7 +1064,7 @@
     {
       "file": "src/app/auth/sign-in/page.tsx",
       "layer": "src/app routes",
-      "loc": 255,
+      "loc": 282,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1026,9 +1076,23 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
+      "file": "src/app/download/page.tsx",
+      "layer": "src/app routes",
+      "loc": 32,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
       "file": "src/app/error.tsx",
       "layer": "src/app routes",
       "loc": 24,
+      "classification": "keep",
+      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "src/app/explore/[surface]/page.tsx",
+      "layer": "src/app routes",
+      "loc": 15,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1042,14 +1106,14 @@
     {
       "file": "src/app/home/page.tsx",
       "layer": "src/app routes",
-      "loc": 231,
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/layout.tsx",
       "layer": "src/app routes",
-      "loc": 79,
+      "loc": 81,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1063,21 +1127,21 @@
     {
       "file": "src/app/manifesto/page.tsx",
       "layer": "src/app routes",
-      "loc": 80,
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/page.tsx",
       "layer": "src/app routes",
-      "loc": 4,
+      "loc": 13,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
       "file": "src/app/pricing/page.tsx",
       "layer": "src/app routes",
-      "loc": 6,
+      "loc": 4,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
@@ -1124,34 +1188,6 @@
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
     },
     {
-      "file": "src/app/use-cases/business/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
-      "file": "src/app/use-cases/content/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
-      "file": "src/app/use-cases/developers/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
-      "file": "src/app/use-cases/education/page.tsx",
-      "layer": "src/app routes",
-      "loc": 7,
-      "classification": "keep",
-      "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
-    },
-    {
       "file": "src/instrumentation-client.ts",
       "layer": "other",
       "loc": 43,
@@ -1168,9 +1204,23 @@
     {
       "file": "src/middleware.ts",
       "layer": "other",
-      "loc": 262,
+      "loc": 301,
       "classification": "keep",
       "reason": "Framework entrypoint discovered by file-system routing or runtime hooks."
+    },
+    {
+      "file": "packages/overlay-chat-react/scripts/check-transcript-boundaries.mjs",
+      "layer": "packages/overlay-chat-react",
+      "loc": 169,
+      "classification": "review",
+      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
+    },
+    {
+      "file": "packages/overlay-chat-react/src/lib/web-tool-sources.ts",
+      "layer": "packages/overlay-chat-react",
+      "loc": 95,
+      "classification": "review",
+      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
     },
     {
       "file": "src/features/chat/components/chat/useEmptyChatStarters.ts",
@@ -1180,23 +1230,9 @@
       "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
     },
     {
-      "file": "src/features/knowledge/components/KnowledgeToolbarMenus.tsx",
+      "file": "src/features/notebook/lib/notebook-editor-blocks.ts",
       "layer": "src/features",
-      "loc": 5,
-      "classification": "review",
-      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
-    },
-    {
-      "file": "src/features/knowledge/components/KnowledgeViewHeader.tsx",
-      "layer": "src/features",
-      "loc": 8,
-      "classification": "review",
-      "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
-    },
-    {
-      "file": "src/features/knowledge/components/KnowledgeViewHost.tsx",
-      "layer": "src/features",
-      "loc": 3,
+      "loc": 1,
       "classification": "review",
       "reason": "No static fan-in found. Classify as keep, merge, or delete before changing."
     },
@@ -1209,12 +1245,12 @@
     }
   ],
   "totals": {
-    "files": 1193,
-    "code": 133057,
-    "total": 147848,
-    "productionFiles": 1044,
-    "productionCode": 117463,
-    "testFiles": 149,
-    "testCode": 15594
+    "files": 1289,
+    "code": 145801,
+    "total": 162120,
+    "productionFiles": 1102,
+    "productionCode": 127523,
+    "testFiles": 187,
+    "testCode": 18278
   }
 }

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "check:tenant-boundaries": "tsx scripts/check-tenant-boundaries.ts",
     "license:check": "tsx scripts/check-licensing.ts",
     "test:route-characterization": "NEXT_PUBLIC_CONVEX_URL=https://fixture.convex.cloud INTERNAL_API_SECRET=test-internal-secret NODE_OPTIONS=--require=./scripts/register-server-only.cjs tsx --test src/server/files/FileService.test.ts src/server/automations/AutomationService.test.ts src/server/billing/BillingCustomerService.test.ts src/server/billing/BillingCheckoutService.test.ts src/server/conversations/ActConversationService.test.ts src/server/app-api/v1/route-characterization.test.ts",
+    "test:release-safety": "NODE_OPTIONS=--require=./scripts/register-server-only.cjs tsx --test src/server/database/postgres/schema-compatibility.test.ts src/server/app-api/public-route-security.test.ts src/server/security/browser-mutation-origin.test.ts",
     "check:providers": "NEXT_PUBLIC_CONVEX_URL=https://fixture.convex.cloud NODE_OPTIONS=--conditions=react-server tsx --test src/server/bootstrap.test.ts src/server/auth/better-auth.test.ts src/server/auth/providers/oidc-auth-provider.test.ts && npm run check:vendor-boundaries",
     "test:phase6-routes": "NEXT_PUBLIC_CONVEX_URL=https://fixture.convex.cloud NODE_OPTIONS=--conditions=react-server tsx --test src/server/phase6-release-gates.test.ts",
     "check:phase6": "tsx scripts/check-phase6-release-gates.ts",

--- a/src/app/api/v1/_utils/bff.ts
+++ b/src/app/api/v1/_utils/bff.ts
@@ -21,7 +21,7 @@ import {
   runtimeConfigErrorResponse,
 } from '@/server/capabilities'
 import { parseApiBoundaryInput } from '@/server/app-api/boundary'
-import { isOverlayConfigError } from '@/server/config'
+import { getOverlayRuntimeConfig, isOverlayConfigError } from '@/server/config'
 import { getOverlayServerContext } from '@/server/bootstrap'
 import {
   appDataRouteUnsupportedResponse,
@@ -33,6 +33,7 @@ import {
 } from '@/server/billing/owner-funded-operations'
 import { hashOperationalIdentifier } from '@/server/security/operational-key-hash'
 import { logSecurityEvent } from '@/server/observability/security-events'
+import { rejectCrossSiteBrowserMutation } from '@/server/security/browser-mutation-origin'
 
 const API_KEY_CANDIDATE_RATE_LIMITS = [
   { bucket: 'api-key-auth:candidate:ip', limit: 60, windowMs: 60_000 },
@@ -44,6 +45,13 @@ const API_KEY_REQUEST_RATE_LIMIT = {
   limit: 300,
   windowMs: 10 * 60_000,
 } as const
+
+const DEFAULT_AUTHENTICATED_ROUTE_RATE_LIMITS = [
+  { bucket: 'api:default:ip', limit: 600, windowMs: 10 * 60_000 },
+  { bucket: 'api:default:user', limit: 300, windowMs: 10 * 60_000 },
+] as const
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
 
 export type BffRouteContext = {
   params: Promise<Record<string, string | string[]>>
@@ -67,8 +75,9 @@ export async function handleBffRoute(
   }
   let appDataCapabilities
   let idempotencyRepository
+  let serverContext!: ReturnType<typeof getOverlayServerContext>
   try {
-    const serverContext = getOverlayServerContext()
+    serverContext = getOverlayServerContext()
     appDataCapabilities = serverContext.appDataCapabilities
     idempotencyRepository = serverContext.appData.repositories.idempotency
   } catch (error) {
@@ -138,6 +147,17 @@ export async function handleBffRoute(
     )
   }
 
+  let runtimeConfig
+  try {
+    runtimeConfig = await getOverlayRuntimeConfig()
+    if (runtimeConfig.features.apiMutationOriginGuard !== false) {
+      const originResponse = rejectCrossSiteBrowserMutation(request, auth)
+      if (originResponse) return originResponse
+    }
+  } catch (error) {
+    return runtimeConfigErrorResponse(error)
+  }
+
   const ownerFundedOperation = getOwnerFundedOperation(
     request.method,
     request.nextUrl.pathname,
@@ -180,6 +200,12 @@ export async function handleBffRoute(
     pathname: request.nextUrl.pathname,
     userId: auth.userId,
   })
+  if (runtimeConfig.features.apiDefaultRateLimit !== false && rateLimits.length === 0) {
+    rateLimits.push(...DEFAULT_AUTHENTICATED_ROUTE_RATE_LIMITS.map((rule) => ({
+      ...rule,
+      key: rule.bucket.endsWith(':ip') ? clientIp : auth.userId,
+    })))
+  }
   if (auth.authType === 'api-key' && auth.apiKeyId) {
     rateLimits.push({ ...API_KEY_REQUEST_RATE_LIMIT, key: auth.apiKeyId })
   }
@@ -214,7 +240,57 @@ export async function handleBffRoute(
     async () => service(request, serviceContext),
     { repository: idempotencyRepository },
   )
-  return standardizePaginatedListResponse(request, response)
+  const standardizedResponse = await standardizePaginatedListResponse(request, response)
+  if (!SAFE_METHODS.has(request.method.toUpperCase())) {
+    await recordBffMutationAudit({
+      auth,
+      clientIp,
+      request,
+      response: standardizedResponse,
+      serverContext,
+    })
+  }
+  return standardizedResponse
+}
+
+async function recordBffMutationAudit(args: {
+  auth: NonNullable<Awaited<ReturnType<typeof resolveAuthenticatedAppUser>>>
+  clientIp: string
+  request: NextRequest
+  response: Response
+  serverContext: ReturnType<typeof getOverlayServerContext>
+}): Promise<void> {
+  const actorType = args.auth.authType === 'api-key'
+    ? 'api_key'
+    : args.auth.authType === 'service'
+      ? 'service'
+      : 'user'
+  try {
+    await args.serverContext.auditService.record({
+      action: 'api.mutation.completed',
+      actorType,
+      actorUserId: args.auth.userId,
+      ...(actorType === 'api_key' ? { actorApiKeyId: args.auth.apiKeyId } : {}),
+      ipAddress: args.clientIp,
+      metadata: {
+        method: args.request.method.toUpperCase(),
+        path: args.request.nextUrl.pathname,
+        statusCode: args.response.status,
+      },
+      outcome: args.response.ok ? 'success' : 'failure',
+      resourceId: args.request.nextUrl.pathname,
+      resourceType: 'api_route',
+    })
+  } catch (_error) {
+    // Audit infrastructure must not turn a completed customer mutation into a second,
+    // externally visible failure. The security event preserves an actionable signal.
+    logSecurityEvent('api_mutation_audit_failed', {
+      authType: args.auth.authType,
+      method: args.request.method.toUpperCase(),
+      path: args.request.nextUrl.pathname,
+      userHash: hashOperationalIdentifier('security-user:v1', args.auth.userId),
+    })
+  }
 }
 
 function getBearerToken(request: NextRequest): string | undefined {

--- a/src/app/api/v1/_utils/bff.ts
+++ b/src/app/api/v1/_utils/bff.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import type { CapabilityCheck } from '@overlay/app-core'
 import type { AppApiRouteContext } from '@/server/app-api/bff-context'
-import { resolveAuthenticatedAppUser } from '@/server/auth/app-api-auth'
+import {
+  resolveAuthenticatedAppUser,
+  type AuthenticatedAppUser,
+} from '@/server/auth/app-api-auth'
 import {
   enforceRateLimits,
   getClientIp,
@@ -105,81 +108,23 @@ export async function handleBffRoute(
   if (parsedInput.error) return parsedInput.error
   const clientIp = getClientIp(request)
   const bearer = getBearerToken(request)
-  if (isApiKeyCandidate(bearer)) {
-    let apiKeyCandidateLimit: Response | null
-    try {
-      apiKeyCandidateLimit = await enforceRateLimits(
-        request,
-        API_KEY_CANDIDATE_RATE_LIMITS.map((rule) => ({ ...rule, key: clientIp })),
-      )
-    } catch (error) {
-      if (isOverlayConfigError(error)) return runtimeConfigErrorResponse(error)
-      throw error
-    }
-    if (apiKeyCandidateLimit) return apiKeyCandidateLimit
-  }
+  const apiKeyCandidateLimit = await enforceApiKeyCandidateRateLimit(request, bearer, clientIp)
+  if (apiKeyCandidateLimit) return apiKeyCandidateLimit
 
-  let auth
-  try {
-    auth = await resolveAuthenticatedAppUser(request, parsedInput.parsedJson, {
-      clientIp,
-      requiredApiKeyScopes: getRequiredApiKeyScopesForRoute(
-        request.method,
-        request.nextUrl.pathname,
-      ),
-    })
-  } catch (error) {
-    if (isOverlayConfigError(error)) return runtimeConfigErrorResponse(error)
-    throw error
-  }
-  if (!auth) {
-    return NextResponse.json(
-      { error: 'Unauthorized' },
-      {
-        status: 401,
-        headers: {
-          'Cache-Control': 'no-store',
-          'WWW-Authenticate': bearer
-            ? 'Bearer error="invalid_token"'
-            : 'Bearer',
-        },
-      },
-    )
-  }
+  const authResult = await resolveBffRouteAuth(request, parsedInput.parsedJson, bearer, clientIp)
+  if (authResult instanceof Response) return authResult
+  const auth = authResult
 
-  let runtimeConfig
+  let bffSafety
   try {
-    runtimeConfig = await getOverlayRuntimeConfig()
-    if (runtimeConfig.features.apiMutationOriginGuard !== false) {
-      const originResponse = rejectCrossSiteBrowserMutation(request, auth)
-      if (originResponse) return originResponse
-    }
+    bffSafety = await resolveBffSafety(request, auth)
   } catch (error) {
     return runtimeConfigErrorResponse(error)
   }
+  if (bffSafety.originResponse) return bffSafety.originResponse
 
-  const ownerFundedOperation = getOwnerFundedOperation(
-    request.method,
-    request.nextUrl.pathname,
-  )
-  if (
-    ownerFundedOperationRequiresIdempotencyKey(ownerFundedOperation) &&
-    !request.headers.get('idempotency-key')?.trim()
-  ) {
-    logSecurityEvent('owner_funded_idempotency_missing', {
-      authType: auth.authType,
-      operation: ownerFundedOperation.id,
-      userHash: hashOperationalIdentifier('security-user:v1', auth.userId),
-    })
-    return NextResponse.json(
-      {
-        error: 'Idempotency-Key header is required for owner-funded operations',
-        code: 'idempotency_key_required',
-        operation: ownerFundedOperation.id,
-      },
-      { status: 428 },
-    )
-  }
+  const ownerFundedIdempotencyResponse = requireOwnerFundedIdempotency(request, auth)
+  if (ownerFundedIdempotencyResponse) return ownerFundedIdempotencyResponse
 
   const rateLimits = getEndpointRateLimitSpecs({
     ...(clientIp !== 'unknown'
@@ -200,26 +145,12 @@ export async function handleBffRoute(
     pathname: request.nextUrl.pathname,
     userId: auth.userId,
   })
-  if (runtimeConfig.features.apiDefaultRateLimit !== false && rateLimits.length === 0) {
-    rateLimits.push(...DEFAULT_AUTHENTICATED_ROUTE_RATE_LIMITS.map((rule) => ({
-      ...rule,
-      key: rule.bucket.endsWith(':ip') ? clientIp : auth.userId,
-    })))
-  }
+  addDefaultAuthenticatedRouteRateLimits(rateLimits, bffSafety.defaultRateLimitEnabled, clientIp, auth.userId)
   if (auth.authType === 'api-key' && auth.apiKeyId) {
     rateLimits.push({ ...API_KEY_REQUEST_RATE_LIMIT, key: auth.apiKeyId })
   }
-  if (rateLimits.length > 0) {
-    let rateLimitResponse: Response | null
-    try {
-      rateLimitResponse = await enforceRateLimits(request, rateLimits)
-    } catch (error) {
-      if (isOverlayConfigError(error)) return runtimeConfigErrorResponse(error)
-      throw error
-    }
-    if (rateLimitResponse) return rateLimitResponse
-    markRateLimitsSatisfied(request)
-  }
+  const rateLimitResponse = await enforceBffRouteRateLimits(request, rateLimits)
+  if (rateLimitResponse) return rateLimitResponse
 
   const serviceContext = {
     params: Promise.resolve({}),
@@ -241,16 +172,132 @@ export async function handleBffRoute(
     { repository: idempotencyRepository },
   )
   const standardizedResponse = await standardizePaginatedListResponse(request, response)
-  if (!SAFE_METHODS.has(request.method.toUpperCase())) {
-    await recordBffMutationAudit({
-      auth,
-      clientIp,
-      request,
-      response: standardizedResponse,
-      serverContext,
-    })
-  }
+  await recordBffMutationAuditIfNeeded({ auth, clientIp, request, response: standardizedResponse, serverContext })
   return standardizedResponse
+}
+
+async function resolveBffSafety(
+  request: NextRequest,
+  auth: NonNullable<Awaited<ReturnType<typeof resolveAuthenticatedAppUser>>>,
+): Promise<{ defaultRateLimitEnabled: boolean; originResponse: Response | null }> {
+  const runtimeConfig = await getOverlayRuntimeConfig()
+  return {
+    defaultRateLimitEnabled: runtimeConfig.features.apiDefaultRateLimit !== false,
+    originResponse: runtimeConfig.features.apiMutationOriginGuard !== false
+      ? rejectCrossSiteBrowserMutation(request, auth)
+      : null,
+  }
+}
+
+async function enforceApiKeyCandidateRateLimit(
+  request: NextRequest,
+  bearer: string | undefined,
+  clientIp: string,
+): Promise<Response | null> {
+  if (!isApiKeyCandidate(bearer)) return null
+  try {
+    return await enforceRateLimits(
+      request,
+      API_KEY_CANDIDATE_RATE_LIMITS.map((rule) => ({ ...rule, key: clientIp })),
+    )
+  } catch (error) {
+    if (isOverlayConfigError(error)) return runtimeConfigErrorResponse(error)
+    throw error
+  }
+}
+
+async function resolveBffRouteAuth(
+  request: NextRequest,
+  parsedJson: Record<string, unknown>,
+  bearer: string | undefined,
+  clientIp: string,
+): Promise<AuthenticatedAppUser | Response> {
+  try {
+    const auth = await resolveAuthenticatedAppUser(request, parsedJson, {
+      clientIp,
+      requiredApiKeyScopes: getRequiredApiKeyScopesForRoute(
+        request.method,
+        request.nextUrl.pathname,
+      ),
+    })
+    if (auth) return auth
+  } catch (error) {
+    if (isOverlayConfigError(error)) return runtimeConfigErrorResponse(error)
+    throw error
+  }
+
+  return NextResponse.json(
+    { error: 'Unauthorized' },
+    {
+      status: 401,
+      headers: {
+        'Cache-Control': 'no-store',
+        'WWW-Authenticate': bearer ? 'Bearer error="invalid_token"' : 'Bearer',
+      },
+    },
+  )
+}
+
+function requireOwnerFundedIdempotency(
+  request: NextRequest,
+  auth: AuthenticatedAppUser,
+): Response | null {
+  const operation = getOwnerFundedOperation(request.method, request.nextUrl.pathname)
+  if (!ownerFundedOperationRequiresIdempotencyKey(operation) || request.headers.get('idempotency-key')?.trim()) {
+    return null
+  }
+  logSecurityEvent('owner_funded_idempotency_missing', {
+    authType: auth.authType,
+    operation: operation.id,
+    userHash: hashOperationalIdentifier('security-user:v1', auth.userId),
+  })
+  return NextResponse.json(
+    {
+      error: 'Idempotency-Key header is required for owner-funded operations',
+      code: 'idempotency_key_required',
+      operation: operation.id,
+    },
+    { status: 428 },
+  )
+}
+
+function addDefaultAuthenticatedRouteRateLimits(
+  rateLimits: Parameters<typeof enforceRateLimits>[1],
+  enabled: boolean,
+  clientIp: string,
+  userId: string,
+): void {
+  if (!enabled || rateLimits.length > 0) return
+  rateLimits.push(...DEFAULT_AUTHENTICATED_ROUTE_RATE_LIMITS.map((rule) => ({
+    ...rule,
+    key: rule.bucket.endsWith(':ip') ? clientIp : userId,
+  })))
+}
+
+async function enforceBffRouteRateLimits(
+  request: NextRequest,
+  rateLimits: Parameters<typeof enforceRateLimits>[1],
+): Promise<Response | null> {
+  if (rateLimits.length === 0) return null
+  try {
+    const response = await enforceRateLimits(request, rateLimits)
+    if (!response) markRateLimitsSatisfied(request)
+    return response
+  } catch (error) {
+    if (isOverlayConfigError(error)) return runtimeConfigErrorResponse(error)
+    throw error
+  }
+}
+
+async function recordBffMutationAuditIfNeeded(args: {
+  auth: NonNullable<Awaited<ReturnType<typeof resolveAuthenticatedAppUser>>>
+  clientIp: string
+  request: NextRequest
+  response: Response
+  serverContext: ReturnType<typeof getOverlayServerContext>
+}): Promise<void> {
+  if (SAFE_METHODS.has(args.request.method.toUpperCase())) return
+  await recordBffMutationAudit(args)
 }
 
 async function recordBffMutationAudit(args: {

--- a/src/app/api/v1/_utils/bff.ts
+++ b/src/app/api/v1/_utils/bff.ts
@@ -172,17 +172,29 @@ export async function handleBffRoute(
     { repository: idempotencyRepository },
   )
   const standardizedResponse = await standardizePaginatedListResponse(request, response)
-  await recordBffMutationAuditIfNeeded({ auth, clientIp, request, response: standardizedResponse, serverContext })
+  await recordBffMutationAuditIfNeeded({
+    auth,
+    clientIp,
+    enabled: bffSafety.mutationAuditEnabled,
+    request,
+    response: standardizedResponse,
+    serverContext,
+  })
   return standardizedResponse
 }
 
 async function resolveBffSafety(
   request: NextRequest,
   auth: NonNullable<Awaited<ReturnType<typeof resolveAuthenticatedAppUser>>>,
-): Promise<{ defaultRateLimitEnabled: boolean; originResponse: Response | null }> {
+): Promise<{
+  defaultRateLimitEnabled: boolean
+  mutationAuditEnabled: boolean
+  originResponse: Response | null
+}> {
   const runtimeConfig = await getOverlayRuntimeConfig()
   return {
     defaultRateLimitEnabled: runtimeConfig.features.apiDefaultRateLimit !== false,
+    mutationAuditEnabled: runtimeConfig.features.apiMutationAudit !== false,
     originResponse: runtimeConfig.features.apiMutationOriginGuard !== false
       ? rejectCrossSiteBrowserMutation(request, auth)
       : null,
@@ -292,11 +304,12 @@ async function enforceBffRouteRateLimits(
 async function recordBffMutationAuditIfNeeded(args: {
   auth: NonNullable<Awaited<ReturnType<typeof resolveAuthenticatedAppUser>>>
   clientIp: string
+  enabled: boolean
   request: NextRequest
   response: Response
   serverContext: ReturnType<typeof getOverlayServerContext>
 }): Promise<void> {
-  if (SAFE_METHODS.has(args.request.method.toUpperCase())) return
+  if (!args.enabled || SAFE_METHODS.has(args.request.method.toUpperCase())) return
   await recordBffMutationAudit(args)
 }
 

--- a/src/app/api/v1/mcps/oauth/callback/route.ts
+++ b/src/app/api/v1/mcps/oauth/callback/route.ts
@@ -76,13 +76,28 @@ export async function GET(request: NextRequest) {
   }
 
   // Consuming first means a replayed state can never be used twice, even on the error paths below.
-  const repository = getOverlayServerContext().appData.repositories.mcpServers
+  const serverContext = getOverlayServerContext()
+  const repository = serverContext.appData.repositories.mcpServers
   const session = await repository.consumeOAuthSession({ sessionId: state }).catch((_error) => null)
   if (!session) {
     return NextResponse.redirect(settingsUrl({ mcpOAuth: 'error', reason: 'expired_state' }), {
       headers: NO_STORE,
     })
   }
+  await serverContext.auditService.record({
+    action: 'mcp.oauth.callback.consumed',
+    actorType: 'system',
+    actorUserId: session.userId,
+    ipAddress: getClientIp(request),
+    metadata: { surface: session.surface },
+    outcome: 'success',
+    resourceId: session.mcpServerId,
+    resourceType: 'mcp_server',
+  }).catch((error) => {
+    logger.warn('[MCP] OAuth callback audit write failed', {
+      reason: error instanceof Error ? error.message : 'unknown',
+    })
+  })
 
   if (providerError) {
     logger.warn('[MCP] OAuth provider returned an error', { providerError })

--- a/src/server/app-api/public-route-security.test.ts
+++ b/src/server/app-api/public-route-security.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, sep } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { PUBLIC_V1_ROUTE_SECURITY_EXCEPTIONS } from './public-route-security'
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'app')
+const v1Root = join(appRoot, 'api', 'v1')
+
+function routeFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return routeFiles(path)
+    return entry.isFile() && entry.name === 'route.ts' ? [path] : []
+  })
+}
+
+function routePath(file: string): string {
+  const routeDirectory = dirname(relative(appRoot, file))
+  return `/${routeDirectory.split(sep).join('/')}`.replace(/\/route$/, '')
+}
+
+function exportedMethods(source: string): string[] {
+  return [...source.matchAll(/export\s+(?:async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\b/g)]
+    .map((match) => match[1]!)
+    .sort()
+}
+
+test('every public v1 route uses the security BFF or declares complete replacement controls', () => {
+  for (const file of routeFiles(v1Root)) {
+    const source = readFileSync(file, 'utf8')
+    if (/handleBffRoute\s*\(/.test(source)) continue
+
+    const path = routePath(file)
+    const exception = PUBLIC_V1_ROUTE_SECURITY_EXCEPTIONS[
+      path as keyof typeof PUBLIC_V1_ROUTE_SECURITY_EXCEPTIONS
+    ]
+    assert.ok(exception, `${path} must use handleBffRoute or declare replacement controls`)
+    assert.deepEqual(exportedMethods(source), [...exception.methods].sort(), `${path} method list drifted`)
+    for (const control of Object.values(exception.controls)) {
+      assert.ok(control.trim(), `${path} must declare every security control`)
+    }
+    if (path === '/api/v1/mcps/oauth/callback') {
+      assert.match(source, /enforceRateLimits\s*\(/)
+      assert.match(source, /consumeOAuthSession\s*\(/)
+      assert.match(source, /auditService\.record\s*\(/)
+    }
+  }
+})
+
+test('every declared exception has a route file', () => {
+  for (const path of Object.keys(PUBLIC_V1_ROUTE_SECURITY_EXCEPTIONS)) {
+    const file = join(appRoot, path.slice(1), 'route.ts')
+    assert.equal(existsSync(file), true, `${path} no longer has a route file`)
+  }
+})

--- a/src/server/app-api/public-route-security.ts
+++ b/src/server/app-api/public-route-security.ts
@@ -1,0 +1,47 @@
+import 'server-only'
+
+/**
+ * The default public v1 route is `handleBffRoute`, which supplies authentication,
+ * capability/authorization boundaries, origin checks for cookie mutations, rate
+ * limits, idempotency support, and a payload-free mutation audit. A route may opt
+ * out only when its protocol makes that impossible; each exception must state its
+ * replacement controls here.
+ */
+export const PUBLIC_V1_ROUTE_SECURITY_EXCEPTIONS = {
+  '/api/v1/capabilities': {
+    methods: ['GET'],
+    reason: 'Public, read-only deployment capability discovery.',
+    controls: {
+      authentication: 'not-applicable-read-only',
+      authorization: 'returns only the redacted capability summary',
+      rateLimit: 'not-applicable-read-only',
+      csrf: 'not-applicable-read-only',
+      idempotency: 'not-applicable-read-only',
+      audit: 'not-applicable-read-only',
+    },
+  },
+  '/api/v1/discovery': {
+    methods: ['GET'],
+    reason: 'Public, read-only protocol discovery for desktop clients.',
+    controls: {
+      authentication: 'not-applicable-read-only',
+      authorization: 'returns only non-secret protocol metadata',
+      rateLimit: 'not-applicable-read-only',
+      csrf: 'not-applicable-read-only',
+      idempotency: 'not-applicable-read-only',
+      audit: 'not-applicable-read-only',
+    },
+  },
+  '/api/v1/mcps/oauth/callback': {
+    methods: ['GET', 'POST'],
+    reason: 'Third-party OAuth redirects and desktop confirmation cannot use app-session auth.',
+    controls: {
+      authentication: 'single-use state or sealed confirmation cookie',
+      authorization: 'state is bound to the user and MCP server',
+      rateLimit: 'endpoint-specific IP limits',
+      csrf: 'OAuth state plus sealed same-site confirmation cookie',
+      idempotency: 'OAuth state is consumed once before any exchange',
+      audit: 'durable MCP OAuth lifecycle audit event',
+    },
+  },
+} as const

--- a/src/server/config/env-overrides.ts
+++ b/src/server/config/env-overrides.ts
@@ -362,6 +362,7 @@ function featuresFromEnv(env: EnvSource): OverlayRuntimeConfigLayer {
     analytics: readFeatureBool(env, 'ANALYTICS'),
     errorReporting: readFeatureBool(env, 'ERROR_REPORTING'),
     apiDefaultRateLimit: readFeatureBool(env, 'API_DEFAULT_RATE_LIMIT'),
+    apiMutationAudit: readFeatureBool(env, 'API_MUTATION_AUDIT'),
     apiMutationOriginGuard: readFeatureBool(env, 'API_MUTATION_ORIGIN_GUARD'),
     billing: readFeatureBool(env, 'BILLING') ?? readBool(env, 'BILLING_ENABLED'),
     webhooks: readFeatureBool(env, 'WEBHOOKS') ?? readBool(env, 'WEBHOOKS_ENABLED'),

--- a/src/server/config/env-overrides.ts
+++ b/src/server/config/env-overrides.ts
@@ -361,6 +361,8 @@ function featuresFromEnv(env: EnvSource): OverlayRuntimeConfigLayer {
     webSearch: readFeatureBool(env, 'WEB_SEARCH'),
     analytics: readFeatureBool(env, 'ANALYTICS'),
     errorReporting: readFeatureBool(env, 'ERROR_REPORTING'),
+    apiDefaultRateLimit: readFeatureBool(env, 'API_DEFAULT_RATE_LIMIT'),
+    apiMutationOriginGuard: readFeatureBool(env, 'API_MUTATION_ORIGIN_GUARD'),
     billing: readFeatureBool(env, 'BILLING') ?? readBool(env, 'BILLING_ENABLED'),
     webhooks: readFeatureBool(env, 'WEBHOOKS') ?? readBool(env, 'WEBHOOKS_ENABLED'),
     apiKeys: readFeatureBool(env, 'API_KEYS') ?? readBool(env, 'API_KEYS_ENABLED'),

--- a/src/server/config/loadOverlayConfig.test.ts
+++ b/src/server/config/loadOverlayConfig.test.ts
@@ -134,6 +134,8 @@ test('configOverridesFromEnv maps enterprise v2 feature, provider, and complianc
     OVERLAY_FEATURE_BROWSER_USE: 'false',
     OVERLAY_FEATURE_SANDBOXES: 'false',
     OVERLAY_FEATURE_ANALYTICS: 'false',
+    OVERLAY_FEATURE_API_DEFAULT_RATE_LIMIT: 'false',
+    OVERLAY_FEATURE_API_MUTATION_ORIGIN_GUARD: 'false',
     OVERLAY_PROVIDER_SANDBOX: 'none',
     OVERLAY_PROVIDER_BROWSER: 'none',
     OVERLAY_PROVIDER_WEB_SEARCH: 'none',
@@ -149,6 +151,8 @@ test('configOverridesFromEnv maps enterprise v2 feature, provider, and complianc
     browserUse: false,
     sandboxes: false,
     analytics: false,
+    apiDefaultRateLimit: false,
+    apiMutationOriginGuard: false,
   })
   assert.deepEqual(overrides.providers, {
     database: { provider: 'convex' },

--- a/src/server/config/loadOverlayConfig.test.ts
+++ b/src/server/config/loadOverlayConfig.test.ts
@@ -135,6 +135,7 @@ test('configOverridesFromEnv maps enterprise v2 feature, provider, and complianc
     OVERLAY_FEATURE_SANDBOXES: 'false',
     OVERLAY_FEATURE_ANALYTICS: 'false',
     OVERLAY_FEATURE_API_DEFAULT_RATE_LIMIT: 'false',
+    OVERLAY_FEATURE_API_MUTATION_AUDIT: 'false',
     OVERLAY_FEATURE_API_MUTATION_ORIGIN_GUARD: 'false',
     OVERLAY_PROVIDER_SANDBOX: 'none',
     OVERLAY_PROVIDER_BROWSER: 'none',
@@ -152,6 +153,7 @@ test('configOverridesFromEnv maps enterprise v2 feature, provider, and complianc
     sandboxes: false,
     analytics: false,
     apiDefaultRateLimit: false,
+    apiMutationAudit: false,
     apiMutationOriginGuard: false,
   })
   assert.deepEqual(overrides.providers, {

--- a/src/server/database/postgres/schema-compatibility.test.ts
+++ b/src/server/database/postgres/schema-compatibility.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { evaluateAppDataSchemaCompatibility } from './schema-compatibility'
+import {
+  APP_DATA_MINIMUM_SCHEMA_VERSION,
+  APP_DATA_SCHEMA_VERSION,
+  evaluateAppDataSchemaCompatibility,
+} from './schema-compatibility'
 
 test('schema compatibility permits a one-release rolling upgrade and rollback window', () => {
   assert.equal(
@@ -44,5 +48,19 @@ test('schema compatibility rejects a database older than the runtime minimum', (
       runtimeMinimumSchemaVersion: 9,
     }).compatible,
     false,
+  )
+})
+
+test('current schema keeps the previous runtime inside the rolling upgrade window', () => {
+  const previousRuntimeMaximum = APP_DATA_SCHEMA_VERSION - 1
+  assert.ok(previousRuntimeMaximum >= APP_DATA_MINIMUM_SCHEMA_VERSION)
+  assert.equal(
+    evaluateAppDataSchemaCompatibility({
+      databaseMinimumRuntimeVersion: APP_DATA_MINIMUM_SCHEMA_VERSION,
+      databaseSchemaVersion: APP_DATA_SCHEMA_VERSION,
+      runtimeMaximumSchemaVersion: previousRuntimeMaximum,
+      runtimeMinimumSchemaVersion: APP_DATA_MINIMUM_SCHEMA_VERSION - 1,
+    }).compatible,
+    true,
   )
 })

--- a/src/server/security/browser-mutation-origin.test.ts
+++ b/src/server/security/browser-mutation-origin.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { NextRequest } from 'next/server'
+import { rejectCrossSiteBrowserMutation } from './browser-mutation-origin'
+
+function request(method: string, headers: HeadersInit = {}): NextRequest {
+  return new NextRequest('https://overlay.test/api/v1/automations', { method, headers })
+}
+
+const sessionAuth = {
+  accessToken: 'session-token',
+  authType: 'session' as const,
+  userId: 'user_1',
+}
+
+test('rejects cross-site cookie-authenticated mutations', () => {
+  const response = rejectCrossSiteBrowserMutation(
+    request('POST', { origin: 'https://attacker.test', 'sec-fetch-site': 'cross-site' }),
+    sessionAuth,
+  )
+
+  assert.equal(response?.status, 403)
+})
+
+test('allows same-origin browser mutations and credential-authenticated API callers', () => {
+  assert.equal(
+    rejectCrossSiteBrowserMutation(
+      request('POST', { origin: 'https://overlay.test', 'sec-fetch-site': 'same-origin' }),
+      sessionAuth,
+    ),
+    null,
+  )
+  assert.equal(
+    rejectCrossSiteBrowserMutation(
+      request('POST', { origin: 'https://attacker.test', 'sec-fetch-site': 'cross-site' }),
+      { ...sessionAuth, authType: 'api-key' },
+    ),
+    null,
+  )
+})
+
+test('does not apply origin checks to safe methods', () => {
+  assert.equal(
+    rejectCrossSiteBrowserMutation(
+      request('GET', { origin: 'https://attacker.test', 'sec-fetch-site': 'cross-site' }),
+      sessionAuth,
+    ),
+    null,
+  )
+})

--- a/src/server/security/browser-mutation-origin.ts
+++ b/src/server/security/browser-mutation-origin.ts
@@ -1,0 +1,37 @@
+import 'server-only'
+
+import { NextResponse, type NextRequest } from 'next/server'
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+type BrowserMutationAuth = {
+  authType: 'session' | 'api-key' | 'service' | 'access-token'
+}
+
+/**
+ * Cookie-authenticated browser mutations must come from this application. API-key,
+ * service, and bearer-token callers are intentionally unaffected: they do not rely
+ * on a browser session cookie and already prove possession of a credential.
+ */
+export function rejectCrossSiteBrowserMutation(
+  request: NextRequest,
+  auth: BrowserMutationAuth,
+): NextResponse | null {
+  if (auth.authType !== 'session' || SAFE_METHODS.has(request.method.toUpperCase())) {
+    return null
+  }
+
+  const origin = request.headers.get('origin')
+  const fetchSite = request.headers.get('sec-fetch-site')?.toLowerCase()
+  if (
+    fetchSite === 'cross-site' ||
+    (origin !== null && origin !== request.nextUrl.origin)
+  ) {
+    return NextResponse.json(
+      { error: 'Invalid request origin' },
+      { status: 403, headers: { 'Cache-Control': 'no-store' } },
+    )
+  }
+
+  return null
+}

--- a/src/shared/config/defaultOverlayRuntimeConfig.ts
+++ b/src/shared/config/defaultOverlayRuntimeConfig.ts
@@ -30,6 +30,7 @@ export const DEFAULT_OVERLAY_RUNTIME_CONFIG = {
     analytics: true,
     errorReporting: true,
     apiDefaultRateLimit: true,
+    apiMutationAudit: true,
     // Kept independently switchable so an unexpected client compatibility issue can
     // be rolled back without weakening authentication, authorization, or rate limits.
     apiMutationOriginGuard: true,

--- a/src/shared/config/defaultOverlayRuntimeConfig.ts
+++ b/src/shared/config/defaultOverlayRuntimeConfig.ts
@@ -29,6 +29,10 @@ export const DEFAULT_OVERLAY_RUNTIME_CONFIG = {
     webSearch: true,
     analytics: true,
     errorReporting: true,
+    apiDefaultRateLimit: true,
+    // Kept independently switchable so an unexpected client compatibility issue can
+    // be rolled back without weakening authentication, authorization, or rate limits.
+    apiMutationOriginGuard: true,
     billing: true,
     webhooks: false,
     apiKeys: false,

--- a/src/shared/config/overlayConfigSchema.ts
+++ b/src/shared/config/overlayConfigSchema.ts
@@ -71,6 +71,8 @@ const OverlayFeatureFlagsSchema = z
     webSearch: z.boolean().optional(),
     analytics: z.boolean().optional(),
     errorReporting: z.boolean().optional(),
+    apiDefaultRateLimit: z.boolean().optional(),
+    apiMutationOriginGuard: z.boolean().optional(),
     billing: z.boolean().optional(),
     webhooks: z.boolean().optional(),
     apiKeys: z.boolean().optional(),

--- a/src/shared/config/overlayConfigSchema.ts
+++ b/src/shared/config/overlayConfigSchema.ts
@@ -72,6 +72,7 @@ const OverlayFeatureFlagsSchema = z
     analytics: z.boolean().optional(),
     errorReporting: z.boolean().optional(),
     apiDefaultRateLimit: z.boolean().optional(),
+    apiMutationAudit: z.boolean().optional(),
     apiMutationOriginGuard: z.boolean().optional(),
     billing: z.boolean().optional(),
     webhooks: z.boolean().optional(),

--- a/src/shared/schemas/api-boundary.ts
+++ b/src/shared/schemas/api-boundary.ts
@@ -633,6 +633,10 @@ export const webApiBoundaryDefinitions = [
 
 export const webApiExcludedRouteDefinitions = [
   {
+    routePath: '/api/v1/mcps/oauth/callback',
+    reason: 'Third-party OAuth redirect and desktop confirmation flow; it is protected by single-use state rather than the public API authentication scheme.',
+  },
+  {
     routePath: '/api/v1/extensions/[extensionId]/[...path]',
     reason: 'Extension proxy route. It is not part of the stable public web API reference.',
   },


### PR DESCRIPTION
## Summary
- extends required PR security gates with an optimized build, core route characterization, config checks, schema compatibility, and endpoint security tests
- centralizes safe defaults for BFF routes: cookie-mutation origin protection, default authenticated route limits, idempotency support, and payload-free mutation audit records
- requires every public v1 route to use the BFF or declare complete replacement controls; documents and tests the OAuth callback exception
- adds feature-flag rollback controls: OVERLAY_FEATURE_API_DEFAULT_RATE_LIMIT and OVERLAY_FEATURE_API_MUTATION_ORIGIN_GUARD

## Compatibility
- additive config fields only; no public request or response contract changes
- source behavior guards default on but may be rolled back independently without disabling auth, authorization, or existing endpoint-specific limits

## Verification
- npm run lint (passes with 56 existing warnings)
- npx tsc --noEmit
- npm run test:release-safety
- npm run check:config
- npm run test:route-characterization
- INTERNAL_API_SECRET=test-internal-secret NEXT_PUBLIC_CONVEX_URL=https://fixture.convex.cloud OVERLAY_DEPLOYMENT_ENV=test npm run build
- npm run security:audit (0 production vulnerabilities)

No UI changes; UI QA is not applicable.