### PR TITLE
fix: restore enterprise image build

### DIFF
--- a/Dockerfile.enterprise-runtime
+++ b/Dockerfile.enterprise-runtime
@@ -6,6 +6,7 @@ ENV NEXT_OUTPUT_MODE=standalone
 
 COPY .npmrc package.json package-lock.json ./
 COPY packages ./packages
+COPY scripts/install-git-hooks.mjs ./scripts/install-git-hooks.mjs
 RUN npm ci --include=dev --no-audit --no-fund \
   --fetch-retries=5 \
   --fetch-retry-mintimeout=20000 \


### PR DESCRIPTION
Restores the Docker build by making npm's prepare lifecycle script available before npm ci.\n\nValidation:\n- npm ci (canonical main worktree)\n- git diff --check\n- remote Publish overlay-web job on this PR