### PR TITLE
Fix chat lifecycle, sources, and media model catalog

### DIFF
--- a/docs/develop/api-source-of-truth.mdx
+++ b/docs/develop/api-source-of-truth.mdx
@@ -30,6 +30,12 @@ The web app owns backend route contracts for every surface. Desktop, mobile, Chr
 
 Surfaces should use bootstrap first, then render their native shell from those registries.
 
+`GET /api/v1/model-catalog` returns the authorized live AI Gateway catalog for
+language, image, and video models. Clients register only media entries whose
+Gateway pricing shape is supported by Overlay's reservation calculator; unpriced
+media models stay unavailable instead of creating unreconcilable usage. The
+settings model catalog uses this route for chat enablement and image/video defaults.
+
 ## Agent environments
 
 `/api/v1/agent-environments/**` is the only public control plane for connected hosts. Browser
@@ -97,6 +103,12 @@ Persistent chat context and hybrid retrieval both resolve memories by `workspace
 - Serialized collaboration messages may include `editedAt` and `editHistory: Array<{ content, editedAt }>`. Both Convex and Postgres append the replaced body before an edit.
 - `PATCH /api/v1/conversations/notifications` accepts either `notificationIds` or `conversationId`. Opening a DM or channel uses `conversationId` so only that room's unread activity is cleared.
 - Convex-backed browsers use native `watchConversationListVersion` and `watchNotifications` subscriptions. `/api/v1/conversations/events` is reserved for the Postgres provider and must not be mounted as a Convex fallback.
+- Personal chat creation is deferred until the first send. Newly created DMs and
+  channels are client-side drafts until their first message succeeds: they are not
+  inserted into the sidebar list, and navigating away removes the current member
+  from the empty room (falling back to a self-archive when the room must retain a
+  human participant). A successful or remotely observed first message commits the
+  draft and emits the ordinary conversation-created event.
 
 ## Personal Chat AgentRun contracts
 
@@ -118,6 +130,10 @@ credentials are never public contract fields.
   through `createModelCallToUIChunkTransform` so the client receives token,
   tool, and approval updates in real time. Work mode closes the stream when the
   workflow finalizes or fails.
+- Both Chat and Work streams preserve provider-native `source-url` and
+  `source-document` UI parts. The transcript adapter owns compatibility with the
+  legacy `source` shape and projects incomplete tool/reasoning part states to a
+  terminal state once their response is completed, cancelled, interrupted, or failed.
 - `GET /api/v1/conversations/run?conversationId=<id>` returns an active
   `AgentRun` when any model slot is non-terminal, otherwise the most recent
   terminal run. Clients use this response—not `conversationMessages.status`—to

--- a/packages/overlay-chat-core/src/generated-ui.code-content.test.ts
+++ b/packages/overlay-chat-core/src/generated-ui.code-content.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { looksLikeCodeContent } from './generated-ui'
+
+test('detects HTML, module statements, and CSS without backtracking expressions', () => {
+  assert.equal(looksLikeCodeContent('<section>Hello</section>'), true)
+  assert.equal(looksLikeCodeContent('import value from "package"'), true)
+  assert.equal(looksLikeCodeContent('export const value = 1'), true)
+  assert.equal(looksLikeCodeContent('.card { background-color: black; }'), true)
+})
+
+test('keeps prose that merely contains comparison characters or code words as prose', () => {
+  assert.equal(looksLikeCodeContent('Use import carefully in ordinary prose.'), false)
+  assert.equal(looksLikeCodeContent('The value is < another value and > zero.'), false)
+  assert.equal(looksLikeCodeContent('A card has a background color.'), false)
+})
+
+test('handles long adversarial-looking input in linear time', () => {
+  const repeated = `<a${'a'.repeat(100_000)}`
+  const startedAt = performance.now()
+  assert.equal(looksLikeCodeContent(repeated), false)
+  assert.ok(performance.now() - startedAt < 1_000)
+})

--- a/packages/overlay-chat-core/src/generated-ui.ts
+++ b/packages/overlay-chat-core/src/generated-ui.ts
@@ -163,20 +163,83 @@ export function isGeneratedUiData(value: unknown): value is GeneratedUiData {
   return normalizeGeneratedUiData(value) !== null
 }
 
+function isAsciiLetter(value: string | undefined): boolean {
+  if (!value) return false
+  const code = value.charCodeAt(0)
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+}
+
+function hasAtLeastTwoHtmlLikeTags(text: string): boolean {
+  let tags = 0
+  let cursor = 0
+  while (cursor < text.length) {
+    const open = text.indexOf('<', cursor)
+    if (open < 0) return false
+    const nameStart = text[open + 1] === '/' ? open + 2 : open + 1
+    if (isAsciiLetter(text[nameStart])) {
+      const close = text.indexOf('>', nameStart + 1)
+      if (close < 0) return false
+      tags += 1
+      if (tags >= 2) return true
+      cursor = close + 1
+    } else {
+      cursor = open + 1
+    }
+  }
+  return false
+}
+
+function hasImportOrExportStatement(text: string): boolean {
+  return text.split('\n').some((line) => {
+    const trimmed = line.trimStart()
+    return (trimmed.startsWith('import') && /\s/.test(trimmed[6] ?? ''))
+      || (trimmed.startsWith('export') && /\s/.test(trimmed[6] ?? ''))
+  })
+}
+
+function isCssPropertyName(value: string): boolean {
+  if (!value) return false
+  for (const char of value) {
+    const code = char.charCodeAt(0)
+    const isAlphaNumeric = (code >= 48 && code <= 57)
+      || (code >= 65 && code <= 90)
+      || (code >= 97 && code <= 122)
+    if (!isAlphaNumeric && char !== '_' && char !== '-') return false
+  }
+  return true
+}
+
+function looksLikeCssRule(text: string): boolean {
+  const open = text.indexOf('{')
+  if (open <= 0) return false
+  const selector = text.slice(0, open).trim()
+  if (!selector || selector.includes('@') || selector.includes('\n') || selector.includes('}')) return false
+  const close = text.indexOf('}', open + 1)
+  if (close < 0) return false
+  const body = text.slice(open + 1, close)
+  const colon = body.indexOf(':')
+  if (colon <= 0) return false
+  const semicolon = body.indexOf(';', colon + 1)
+  if (semicolon < 0) return false
+  const property = body.slice(0, colon).trim()
+  const propertyValue = body.slice(colon + 1, semicolon).trim()
+  return isCssPropertyName(property) && !!propertyValue && !propertyValue.includes('{') && !propertyValue.includes('}')
+}
+
 export function looksLikeCodeContent(value: string): boolean {
   const text = value.trim()
   if (!text) return false
   if (/```|~~~/.test(text)) return true
   if (/<!doctype\s+html|<(?:html|head|body|style|script)\b/i.test(text)) return true
-  if ((text.match(/<\/?[a-z][^>]*>/gi)?.length ?? 0) >= 2) return true
-  if (/^\s*(?:import|export)\s+.+$/m.test(text)) return true
+  if (hasAtLeastTwoHtmlLikeTags(text)) return true
+  if (hasImportOrExportStatement(text)) return true
   if (/^\s*(?:const|let|var)\s+[$A-Z_a-z][$\w]*\s*=/m.test(text)) return true
   if (/^\s*(?:async\s+)?function\s+[$A-Z_a-z][$\w]*\s*\(/m.test(text)) return true
   if (/^\s*(?:def|class)\s+[A-Z_a-z]\w*\s*[:(]/m.test(text)) return true
   if (/^\s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER)\b[\s\S]*\b(?:FROM|INTO|TABLE|SET)\b/im.test(text)) return true
   if (/^\s*#!\/(?:usr\/bin\/env\s+)?(?:ba|z|fi)?sh\b/m.test(text)) return true
   if (/^\s*(?:npm|pnpm|yarn|bun|git|docker|kubectl|curl|node|python(?:3)?)\s+\S+/m.test(text)) return true
-  if (/^\s*[^@\n{}]+\{[\s\S]*?[\w-]+\s*:\s*[^;{}]+;/m.test(text)) return true
+  if (looksLikeCssRule(text)) return true
 
   if (/^[{[]/.test(text)) {
     try {

--- a/packages/overlay-chat-core/src/transcript-view.test.ts
+++ b/packages/overlay-chat-core/src/transcript-view.test.ts
@@ -140,6 +140,18 @@ test('normalizes AI SDK source parts and settles stale tools after a completed r
   ])
 })
 
+test('preserves tool input failures after a completed response', () => {
+  const normalized = normalizeTranscriptAssistantParts([{
+    type: 'tool-web_search',
+    toolCallId: 'search-failed',
+    state: 'input-error',
+    input: { query: 'release notes' },
+  }], { terminalState: 'completed' })
+
+  const tool = normalized.blocks.find((block) => block.kind === 'tool')
+  assert.equal(tool?.kind === 'tool' ? tool.state : null, 'output-error')
+})
+
 test('restores image and video output groups without sharing mutable result objects', () => {
   const group = {
     type: 'video' as const,

--- a/packages/overlay-chat-core/src/transcript-view.test.ts
+++ b/packages/overlay-chat-core/src/transcript-view.test.ts
@@ -104,6 +104,42 @@ test('normalizes ordered reasoning, tool, text, file, generated UI, and source p
   }])
 })
 
+test('normalizes AI SDK source parts and settles stale tools after a completed response', () => {
+  const normalized = normalizeTranscriptAssistantParts([
+    {
+      type: 'tool-web_search',
+      toolCallId: 'search-1',
+      state: 'input-available',
+      input: { query: 'release notes' },
+      output: { sources: [{ url: 'https://example.test/release' }] },
+    },
+    {
+      type: 'source-url',
+      sourceId: 'source-1',
+      url: 'https://example.test/release',
+      title: 'Release notes',
+    },
+    {
+      type: 'source-document',
+      sourceId: 'document-1',
+      mediaType: 'application/pdf',
+      title: 'Launch brief',
+      filename: 'launch.pdf',
+    },
+  ], { terminalState: 'completed' })
+
+  const tool = normalized.blocks.find((block) => block.kind === 'tool')
+  assert.equal(tool?.kind === 'tool' ? tool.state : null, 'output-available')
+  assert.deepEqual(normalized.sources.map((source) => ({
+    kind: source.sourceKind,
+    id: source.sourceId,
+    url: source.url,
+  })), [
+    { kind: 'url', id: 'source-1', url: 'https://example.test/release' },
+    { kind: 'document', id: 'document-1', url: undefined },
+  ])
+})
+
 test('restores image and video output groups without sharing mutable result objects', () => {
   const group = {
     type: 'video' as const,

--- a/packages/overlay-chat-core/src/transcript-view.ts
+++ b/packages/overlay-chat-core/src/transcript-view.ts
@@ -205,7 +205,10 @@ export function deriveChatExchangeStatus(input: {
   return 'idle'
 }
 
-export function normalizeTranscriptAssistantParts(parts: readonly unknown[] | undefined): {
+export function normalizeTranscriptAssistantParts(
+  parts: readonly unknown[] | undefined,
+  options: { terminalState?: 'completed' | 'error' | 'cancelled' | 'interrupted' } = {},
+): {
   blocks: AssistantVisualBlock[]
   sources: ChatTranscriptSourceView[]
 } {
@@ -215,7 +218,7 @@ export function normalizeTranscriptAssistantParts(parts: readonly unknown[] | un
 
   const flushVisualChunk = () => {
     if (visualChunk.length === 0) return
-    blocks.push(...buildAssistantVisualSequence(visualChunk))
+    blocks.push(...buildAssistantVisualSequence(visualChunk, options))
     visualChunk = []
   }
 
@@ -230,11 +233,22 @@ export function normalizeTranscriptAssistantParts(parts: readonly unknown[] | un
       mediaType?: unknown
       filename?: unknown
     }
-    if (source.type !== 'source') {
+    const isLegacySource = source.type === 'source'
+    const isUrlSource = source.type === 'source-url'
+    const isDocumentSource = source.type === 'source-document'
+    if (!isLegacySource && !isUrlSource && !isDocumentSource) {
       visualChunk.push(part)
       continue
     }
-    const sourceKind = source.sourceKind === 'url' ? 'url' : source.sourceKind === 'document' ? 'document' : null
+    const sourceKind = isUrlSource
+      ? 'url'
+      : isDocumentSource
+        ? 'document'
+        : source.sourceKind === 'url'
+          ? 'url'
+          : source.sourceKind === 'document'
+            ? 'document'
+            : null
     if (!sourceKind || typeof source.sourceId !== 'string' || !source.sourceId.trim()) {
       visualChunk.push(part)
       continue

--- a/packages/overlay-chat-core/src/transcript-view.ts
+++ b/packages/overlay-chat-core/src/transcript-view.ts
@@ -205,6 +205,41 @@ export function deriveChatExchangeStatus(input: {
   return 'idle'
 }
 
+type RawTranscriptSourcePart = {
+  type?: unknown
+  id?: unknown
+  sourceKind?: unknown
+  sourceId?: unknown
+  url?: unknown
+  title?: unknown
+  mediaType?: unknown
+  filename?: unknown
+}
+
+function normalizedTranscriptSource(
+  part: unknown,
+  originIndex: number,
+): ChatTranscriptSourceView | null {
+  const source = part as RawTranscriptSourcePart
+  let sourceKind: ChatTranscriptSourceView['sourceKind'] | null = null
+  if (source.type === 'source-url') sourceKind = 'url'
+  else if (source.type === 'source-document') sourceKind = 'document'
+  else if (source.type === 'source' && source.sourceKind === 'url') sourceKind = 'url'
+  else if (source.type === 'source' && source.sourceKind === 'document') sourceKind = 'document'
+  if (!sourceKind || typeof source.sourceId !== 'string' || !source.sourceId.trim()) return null
+
+  return {
+    id: typeof source.id === 'string' && source.id.trim() ? source.id : `source-${originIndex}`,
+    sourceKind,
+    sourceId: source.sourceId,
+    ...(typeof source.url === 'string' && source.url ? { url: source.url } : {}),
+    ...(typeof source.title === 'string' && source.title ? { title: source.title } : {}),
+    ...(typeof source.mediaType === 'string' && source.mediaType ? { mediaType: source.mediaType } : {}),
+    ...(typeof source.filename === 'string' && source.filename ? { filename: source.filename } : {}),
+    originIndex,
+  }
+}
+
 export function normalizeTranscriptAssistantParts(
   parts: readonly unknown[] | undefined,
   options: { terminalState?: 'completed' | 'error' | 'cancelled' | 'interrupted' } = {},
@@ -223,47 +258,12 @@ export function normalizeTranscriptAssistantParts(
   }
 
   for (const [originIndex, part] of (parts ?? []).entries()) {
-    const source = part as {
-      type?: unknown
-      id?: unknown
-      sourceKind?: unknown
-      sourceId?: unknown
-      url?: unknown
-      title?: unknown
-      mediaType?: unknown
-      filename?: unknown
-    }
-    const isLegacySource = source.type === 'source'
-    const isUrlSource = source.type === 'source-url'
-    const isDocumentSource = source.type === 'source-document'
-    if (!isLegacySource && !isUrlSource && !isDocumentSource) {
-      visualChunk.push(part)
-      continue
-    }
-    const sourceKind = isUrlSource
-      ? 'url'
-      : isDocumentSource
-        ? 'document'
-        : source.sourceKind === 'url'
-          ? 'url'
-          : source.sourceKind === 'document'
-            ? 'document'
-            : null
-    if (!sourceKind || typeof source.sourceId !== 'string' || !source.sourceId.trim()) {
+    const normalizedSource = normalizedTranscriptSource(part, originIndex)
+    if (!normalizedSource) {
       visualChunk.push(part)
       continue
     }
     flushVisualChunk()
-    const normalizedSource: ChatTranscriptSourceView = {
-      id: typeof source.id === 'string' && source.id.trim() ? source.id : `source-${originIndex}`,
-      sourceKind,
-      sourceId: source.sourceId,
-      ...(typeof source.url === 'string' && source.url ? { url: source.url } : {}),
-      ...(typeof source.title === 'string' && source.title ? { title: source.title } : {}),
-      ...(typeof source.mediaType === 'string' && source.mediaType ? { mediaType: source.mediaType } : {}),
-      ...(typeof source.filename === 'string' && source.filename ? { filename: source.filename } : {}),
-      originIndex,
-    }
     sources.push(normalizedSource)
     blocks.push({
       kind: 'source',

--- a/packages/overlay-chat-core/src/visual-sequence.test.ts
+++ b/packages/overlay-chat-core/src/visual-sequence.test.ts
@@ -33,3 +33,15 @@ test('active remote run status keeps running remote visuals in progress', () => 
   const tools = blocks.filter((block) => block.kind === 'tool')
   assert.deepEqual(tools.map((tool) => tool.state), ['input-available', 'input-available'])
 })
+
+test('repairs a word split across reasoning and text without a trailing-word regex', () => {
+  const blocks = buildAssistantVisualSequence([
+    { type: 'reasoning', text: 'This can', state: 'done' },
+    { type: 'text', text: "'t remain split." },
+  ])
+
+  assert.deepEqual(blocks, [
+    { kind: 'reasoning', key: 'reasoning-0', text: 'This', state: 'done' },
+    { kind: 'text', text: "can't remain split." },
+  ])
+})

--- a/packages/overlay-chat-core/src/visual-sequence.ts
+++ b/packages/overlay-chat-core/src/visual-sequence.ts
@@ -228,6 +228,7 @@ function resolveToolState(
 ) {
   const current = state ?? 'output-available'
   if (TOOL_UI_DONE_STATES.has(current) || current === 'output-error' || current === 'output-denied') return current
+  if (current === 'input-error') return 'output-error'
   if (terminalState) return terminalState === 'completed' ? 'output-available' : 'output-error'
   if (toolName === 'remote_action' && outcome) {
     return outcome === 'completed' ? 'output-available' : 'output-error'

--- a/packages/overlay-chat-core/src/visual-sequence.ts
+++ b/packages/overlay-chat-core/src/visual-sequence.ts
@@ -193,9 +193,10 @@ export function buildAssistantVisualSequence(
       tBlk?.kind === 'text' &&
       /^'[a-zA-Z]/.test(tBlk.text)
     ) {
-      const lastWordMatch = rBlk.text.match(/(\S+)$/)
-      if (lastWordMatch) {
-        const word = lastWordMatch[1]!
+      let wordStart = rBlk.text.length
+      while (wordStart > 0 && !/\s/.test(rBlk.text[wordStart - 1]!)) wordStart -= 1
+      if (wordStart < rBlk.text.length) {
+        const word = rBlk.text.slice(wordStart)
         rBlk.text = rBlk.text.slice(0, rBlk.text.length - word.length).trim()
         tBlk.text = word + tBlk.text
       }

--- a/packages/overlay-chat-core/src/visual-sequence.ts
+++ b/packages/overlay-chat-core/src/visual-sequence.ts
@@ -13,7 +13,12 @@ import type { AssistantVisualBlock } from './types'
 import { getToolName, isReasoningUIPart, isToolUIPart } from './ui-parts'
 
 /** Preserve message `parts` order so tools and text interleave (matches stream / persisted transcript). */
-export function buildAssistantVisualSequence(parts: unknown[] | undefined): AssistantVisualBlock[] {
+export type TerminalAssistantState = 'completed' | 'error' | 'cancelled' | 'interrupted'
+
+export function buildAssistantVisualSequence(
+  parts: unknown[] | undefined,
+  options: { terminalState?: TerminalAssistantState } = {},
+): AssistantVisualBlock[] {
   if (!parts?.length) return []
   const remoteRunOutcome = getRemoteRunOutcome(parts)
   const out: AssistantVisualBlock[] = []
@@ -72,7 +77,7 @@ export function buildAssistantVisualSequence(parts: unknown[] | undefined): Assi
         kind: 'tool',
         key: (inv.toolCallId && inv.toolCallId.trim()) || `legacy-inv-${out.length}`,
         name: inv.toolName as string,
-        state: resolveRemoteToolState(inv.toolName, inv.state, remoteRunOutcome),
+        state: resolveToolState(inv.toolName, inv.state, remoteRunOutcome, options.terminalState),
         toolInput: inv.toolInput,
         toolOutput: inv.toolOutput,
       })
@@ -116,7 +121,7 @@ export function buildAssistantVisualSequence(parts: unknown[] | undefined): Assi
         kind: 'tool',
         key: (part.toolCallId && part.toolCallId.trim()) || `sdk-tool-${out.length}`,
         name: toolName,
-        state: resolveRemoteToolState(toolName, part.state, remoteRunOutcome),
+        state: resolveToolState(toolName, part.state, remoteRunOutcome, options.terminalState),
         toolInput: part.input,
         toolOutput: part.output,
       })
@@ -134,7 +139,7 @@ export function buildAssistantVisualSequence(parts: unknown[] | undefined): Assi
           kind: 'reasoning',
           key: `reasoning-${out.length}`,
           text: merged,
-          state: part.state,
+          state: options.terminalState ? 'done' : part.state,
         })
       }
       continue
@@ -214,13 +219,17 @@ function getRemoteRunOutcome(parts: unknown[]): RemoteRunOutcome | null {
   return null
 }
 
-function resolveRemoteToolState(
+function resolveToolState(
   toolName: string | undefined,
   state: string | undefined,
   outcome: RemoteRunOutcome | null,
+  terminalState?: TerminalAssistantState,
 ) {
   const current = state ?? 'output-available'
-  if (toolName !== 'remote_action' || !outcome || TOOL_UI_DONE_STATES.has(current)
-    || current === 'output-error' || current === 'output-denied') return current
-  return outcome === 'completed' ? 'output-available' : 'output-error'
+  if (TOOL_UI_DONE_STATES.has(current) || current === 'output-error' || current === 'output-denied') return current
+  if (terminalState) return terminalState === 'completed' ? 'output-available' : 'output-error'
+  if (toolName === 'remote_action' && outcome) {
+    return outcome === 'completed' ? 'output-available' : 'output-error'
+  }
+  return current
 }

--- a/packages/overlay-chat-react/src/components/MarkdownMessage.tsx
+++ b/packages/overlay-chat-react/src/components/MarkdownMessage.tsx
@@ -1,5 +1,6 @@
 import 'katex/dist/katex.min.css'
 import { type ReactNode, memo, useMemo } from 'react'
+import { AtSign, BookOpen, Bot, FileText, Hash, Plug, Server, Sparkles } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import type { SourceCitationMap } from '../lib/source-citations'
 import { knowledgeChipLabel, knowledgeSourcesFromCitations } from '../lib/knowledge-sources'
@@ -125,7 +126,17 @@ function MarkdownMessageImpl({
           const linkText = extractLinkText(props.children as ReactNode).trim()
 
           if (isMentionHref(href)) {
-            return <span className={mentionChipClass}>{props.children}</span>
+            const encodedId = typeof href === 'string' ? href.slice('#overlay-mention-'.length) : ''
+            const mention = mentions?.find((item) => encodeURIComponent(item.id) === encodedId)
+            const Icon = mention?.type === 'file' ? FileText
+              : mention?.type === 'knowledge' ? BookOpen
+                : mention?.type === 'connector' ? Plug
+                  : mention?.type === 'automation' ? Bot
+                    : mention?.type === 'skill' ? Sparkles
+                      : mention?.type === 'mcp' ? Server
+                        : mention?.type === 'chat' ? Hash
+                          : AtSign
+            return <span className={`${mentionChipClass} gap-1`}><Icon size={11} strokeWidth={1.75} aria-hidden="true" />{props.children}</span>
           }
 
           // Knowledge citation chip: `#overlay-knowcite-N` (a cited file or memory).
@@ -215,7 +226,7 @@ function MarkdownMessageImpl({
         },
       }
     },
-    [knowledgeSources, sourceCitations, webSources, appBaseUrl, onOpenAttachmentPreview],
+    [knowledgeSources, sourceCitations, webSources, appBaseUrl, mentions, onOpenAttachmentPreview],
   )
   const activeRemarkPlugins = useMemo(
     () => [...markdownRemarkPlugins, createMentionRemarkPlugin(mentions)],

--- a/packages/overlay-chat-react/src/components/exchange/inline-mentions.tsx
+++ b/packages/overlay-chat-react/src/components/exchange/inline-mentions.tsx
@@ -1,4 +1,26 @@
-import { type ReactNode } from 'react'
+import { type ComponentType, type ReactNode } from 'react'
+import {
+  AtSign,
+  BookOpen,
+  Bot,
+  FileText,
+  Hash,
+  Plug,
+  Server,
+  Sparkles,
+  type LucideProps,
+} from 'lucide-react'
+
+const MENTION_ICONS: Record<string, ComponentType<LucideProps>> = {
+  person: AtSign,
+  file: FileText,
+  knowledge: BookOpen,
+  connector: Plug,
+  automation: Bot,
+  skill: Sparkles,
+  mcp: Server,
+  chat: Hash,
+}
 
 export function renderInlineMentions(
   text: string,
@@ -20,6 +42,11 @@ export function renderInlineMentions(
         key={match.index}
         className="inline-flex items-center gap-1 rounded-md bg-[var(--surface-muted)] border border-[var(--border)] px-1.5 py-0.5 text-xs font-medium text-[var(--foreground)] align-middle mx-0.5"
       >
+        {(() => {
+          const mention = sorted.find((item) => item.name === match?.[1])
+          const Icon = MENTION_ICONS[mention?.type ?? 'person'] ?? AtSign
+          return <Icon size={11} strokeWidth={1.75} aria-hidden="true" />
+        })()}
         {match[0]}
       </span>
     )

--- a/packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx
+++ b/packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element -- shared renderer must stay platform-neutral */
 import { lazy, Suspense, useMemo } from 'react'
 import { AlertCircle, FileText, Play, Reply } from 'lucide-react'
-import type { AssistantVisualBlock, ChatExchangeStatus, DraftModalState, ToolVisualBlock } from '@overlay/chat-core'
+import type { AssistantVisualBlock, ChatExchangeStatus, ChatTranscriptSourceView, DraftModalState, ToolVisualBlock } from '@overlay/chat-core'
 import {
   assistantBlocksToPlainText,
   buildAssistantVisualSegments,
@@ -66,6 +66,8 @@ export interface ChatExchangeProps {
   responseModelId: string
   /** Ordered tools, text, and file parts as they appear in the assistant message */
   assistantVisualBlocks: AssistantVisualBlock[]
+  /** Provider-native source parts normalized by the transcript adapter. */
+  responseSources?: readonly ChatTranscriptSourceView[]
   isStreaming: boolean
   isTextStreaming: boolean
   errorMessage: string | null
@@ -110,7 +112,7 @@ export interface ChatExchangeProps {
 }
 
 export function ChatExchange({
-  userMsgId, userBodyText, userDocumentNames, userIndexedAttachments, userImages, exchIdx, responseModelId, assistantVisualBlocks, isStreaming, isTextStreaming, errorMessage,
+  userMsgId, userBodyText, userDocumentNames, userIndexedAttachments, userImages, exchIdx, responseModelId, assistantVisualBlocks, responseSources, isStreaming, isTextStreaming, errorMessage,
   exchModelList, selectedTab, onTabSelect, isLoadingTabs, responseInProgress, status, sourceCitations,
   turnIdForActions, modelLabel, onDeleteTurn, onReply, onBranch, interrupted = false, actionsLocked, isExiting = false, replyThreadMeta, onJumpToReply,
   onOpenDraft, onCreateAutomationDraft, onOpenSources, isSourcesOpenForThis, onRetry, retryDisabled = true, onOpenFilePreview, onOpenAttachmentPreview, userMentions, onContinue, getModelDisplayName,
@@ -132,6 +134,15 @@ export function ChatExchange({
     )
     const toolChainFlags = useMemo(() => computeToolChainFlags(assistantSegments), [assistantSegments])
     const webSources = useMemo(() => collectWebSourcesFromBlocks(assistantVisualBlocks), [assistantVisualBlocks])
+    const providerSources = useMemo<WebSourceItem[]>(() => (responseSources ?? []).flatMap((source) => (
+      source.sourceKind === 'url' && source.url
+        ? [{
+            url: source.url,
+            title: source.title || source.url,
+            origin: 'web-search' as const,
+          }]
+        : []
+    )), [responseSources])
     /**
      * Cited files and memories. Live replies carry the citation map in message
      * metadata; older persisted replies only have the linkified `**Sources:**`
@@ -152,9 +163,14 @@ export function ChatExchange({
      * tool call supplied sources its external links are recovered from there.
      */
     const allSources = useMemo(() => {
-      if (webSources.length > 0) return [...webSources, ...knowledgeSources]
-      return [...externalSourcesFromMarkdown(assistantPlainText), ...knowledgeSources]
-    }, [assistantPlainText, knowledgeSources, webSources])
+      const externalSources = [...providerSources, ...webSources]
+      const candidates = externalSources.length > 0
+        ? [...externalSources, ...knowledgeSources]
+        : [...externalSourcesFromMarkdown(assistantPlainText), ...knowledgeSources]
+      return candidates.filter((source, index) => candidates.findIndex((candidate) => (
+        candidate.url === source.url && candidate.internalHref === source.internalHref
+      )) === index)
+    }, [assistantPlainText, knowledgeSources, providerSources, webSources])
     const normalizedStatus: ChatExchangeStatus = status ?? (
       responseInProgress ? (assistantVisualBlocks.length > 0 ? 'streaming' : 'submitted') : 'completed'
     )

--- a/packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx
+++ b/packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx
@@ -5,17 +5,11 @@ import type { AssistantVisualBlock, ChatExchangeStatus, ChatTranscriptSourceView
 import {
   assistantBlocksToPlainText,
   buildAssistantVisualSegments,
-  collectWebSourcesFromBlocks,
   computeToolChainFlags,
   getDraftFromToolBlock,
   isOverlayGatedToolOutput,
   isUsageExhaustedError,
 } from '@overlay/chat-core'
-import {
-  externalSourcesFromMarkdown,
-  knowledgeCitationsFromMarkdown,
-  knowledgeSourcesFromCitations,
-} from '../../lib/knowledge-sources'
 import type { SourceCitationMap } from '../../lib/source-citations'
 import type { WebSourceItem } from '../../lib/web-sources'
 import { MarkdownMessage } from '../MarkdownMessage'
@@ -41,6 +35,7 @@ import { UsageExhaustedNotice } from '../UsageExhaustedNotice'
 import { ExchangeActions } from './ExchangeActions'
 import { ExchangeLoadingState, exchangeLoadingPresentation } from './ExchangeLoadingState'
 import type { ChatTranscriptPresentation } from './ChatTranscript'
+import { useChatExchangeSources } from './chat-exchange-sources'
 
 const GeneratedUiCard = lazy(() =>
   import('../GeneratedUiCard').then((mod) => ({ default: mod.GeneratedUiCard })),
@@ -133,44 +128,12 @@ export function ChatExchange({
       [assistantVisualBlocks],
     )
     const toolChainFlags = useMemo(() => computeToolChainFlags(assistantSegments), [assistantSegments])
-    const webSources = useMemo(() => collectWebSourcesFromBlocks(assistantVisualBlocks), [assistantVisualBlocks])
-    const providerSources = useMemo<WebSourceItem[]>(() => (responseSources ?? []).flatMap((source) => (
-      source.sourceKind === 'url' && source.url
-        ? [{
-            url: source.url,
-            title: source.title || source.url,
-            origin: 'web-search' as const,
-          }]
-        : []
-    )), [responseSources])
-    /**
-     * Cited files and memories. Live replies carry the citation map in message
-     * metadata; older persisted replies only have the linkified `**Sources:**`
-     * line in the markdown, so fall back to reading it back out of the text.
-     */
-    const effectiveSourceCitations = useMemo(() => {
-      if (sourceCitations && Object.keys(sourceCitations).length > 0) return sourceCitations
-      const recovered = knowledgeCitationsFromMarkdown(assistantPlainText)
-      return Object.keys(recovered).length > 0 ? recovered : undefined
-    }, [assistantPlainText, sourceCitations])
-    const knowledgeSources = useMemo(
-      () => knowledgeSourcesFromCitations(effectiveSourceCitations),
-      [effectiveSourceCitations],
-    )
-    /**
-     * Web and knowledge sources share one Sources button and one panel. The
-     * trailing `Sources:` block is stripped from the rendered reply, so when no
-     * tool call supplied sources its external links are recovered from there.
-     */
-    const allSources = useMemo(() => {
-      const externalSources = [...providerSources, ...webSources]
-      const candidates = externalSources.length > 0
-        ? [...externalSources, ...knowledgeSources]
-        : [...externalSourcesFromMarkdown(assistantPlainText), ...knowledgeSources]
-      return candidates.filter((source, index) => candidates.findIndex((candidate) => (
-        candidate.url === source.url && candidate.internalHref === source.internalHref
-      )) === index)
-    }, [assistantPlainText, knowledgeSources, providerSources, webSources])
+    const { allSources, effectiveSourceCitations, webSources } = useChatExchangeSources({
+      assistantPlainText,
+      assistantVisualBlocks,
+      responseSources,
+      sourceCitations,
+    })
     const normalizedStatus: ChatExchangeStatus = status ?? (
       responseInProgress ? (assistantVisualBlocks.length > 0 ? 'streaming' : 'submitted') : 'completed'
     )

--- a/packages/overlay-chat-react/src/components/transcript/chat-exchange-sources.ts
+++ b/packages/overlay-chat-react/src/components/transcript/chat-exchange-sources.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react'
+import type { AssistantVisualBlock, ChatTranscriptSourceView } from '@overlay/chat-core'
+import { collectWebSourcesFromBlocks } from '@overlay/chat-core'
+import {
+  externalSourcesFromMarkdown,
+  knowledgeCitationsFromMarkdown,
+  knowledgeSourcesFromCitations,
+} from '../../lib/knowledge-sources'
+import type { SourceCitationMap } from '../../lib/source-citations'
+import type { WebSourceItem } from '../../lib/web-sources'
+
+function providerUrlSources(sources: readonly ChatTranscriptSourceView[]): WebSourceItem[] {
+  return sources.flatMap((source) => source.sourceKind === 'url' && source.url
+    ? [{ url: source.url, title: source.title || source.url, origin: 'web-search' as const }]
+    : [])
+}
+
+function uniqueSources(sources: WebSourceItem[]): WebSourceItem[] {
+  const seen = new Set<string>()
+  return sources.filter((source) => {
+    const key = `${source.url ?? ''}\n${source.internalHref ?? ''}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+export function useChatExchangeSources({
+  assistantPlainText,
+  assistantVisualBlocks,
+  responseSources,
+  sourceCitations,
+}: {
+  assistantPlainText: string
+  assistantVisualBlocks: AssistantVisualBlock[]
+  responseSources?: readonly ChatTranscriptSourceView[]
+  sourceCitations?: SourceCitationMap
+}) {
+  const webSources = useMemo(
+    () => collectWebSourcesFromBlocks(assistantVisualBlocks),
+    [assistantVisualBlocks],
+  )
+  const effectiveSourceCitations = useMemo(() => {
+    if (sourceCitations && Object.keys(sourceCitations).length > 0) return sourceCitations
+    const recovered = knowledgeCitationsFromMarkdown(assistantPlainText)
+    return Object.keys(recovered).length > 0 ? recovered : undefined
+  }, [assistantPlainText, sourceCitations])
+  const allSources = useMemo(() => {
+    const external = [...providerUrlSources(responseSources ?? []), ...webSources]
+    const knowledge = knowledgeSourcesFromCitations(effectiveSourceCitations)
+    const candidates = external.length > 0
+      ? [...external, ...knowledge]
+      : [...externalSourcesFromMarkdown(assistantPlainText), ...knowledge]
+    return uniqueSources(candidates)
+  }, [assistantPlainText, effectiveSourceCitations, responseSources, webSources])
+
+  return { allSources, effectiveSourceCitations, webSources }
+}

--- a/packages/overlay-ui/src/components/chat/GenerationModeToggle.tsx
+++ b/packages/overlay-ui/src/components/chat/GenerationModeToggle.tsx
@@ -43,9 +43,17 @@ export function GenerationModeToggle({
 
 export type PersonalChatMode = 'chat' | 'work'
 
-const PERSONAL_CHAT_MODES: { value: PersonalChatMode; label: string }[] = [
-  { value: 'chat', label: 'Chat' },
-  { value: 'work', label: 'Work' },
+const PERSONAL_CHAT_MODES: { value: PersonalChatMode; label: string; description: string }[] = [
+  {
+    value: 'chat',
+    label: 'Chat',
+    description: 'A quick conversation for questions and lightweight tool use.',
+  },
+  {
+    value: 'work',
+    label: 'Work',
+    description: 'Durable, resumable work for longer tasks with tools and approvals.',
+  },
 ]
 
 export function PersonalChatModeToggle({

--- a/packages/overlay-ui/src/components/primitives/SegmentedControl.tsx
+++ b/packages/overlay-ui/src/components/primitives/SegmentedControl.tsx
@@ -7,6 +7,8 @@ import { cn } from '../../utils/cn'
 export type SegmentedControlOption<T extends string> = {
   value: T
   label: ReactNode
+  /** Short explanation exposed on hover and to assistive technology. */
+  description?: string
   icon?: ComponentType<{ size?: number; className?: string; strokeWidth?: number }>
   disabled?: boolean
 }
@@ -54,6 +56,8 @@ export function SegmentedControl<T extends string>({
             type="button"
             role="tab"
             aria-selected={active}
+            aria-label={option.description ? `${String(option.label)}: ${option.description}` : undefined}
+            title={option.description}
             disabled={optionDisabled}
             onClick={() => {
               if (!optionDisabled) onChange(option.value)

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -292,6 +292,8 @@ export default function SettingsPage() {
             <ModelCatalogSetting
               enabledModelIds={settings.enabledChatModelIds}
               modelOrder={settings.modelOrder}
+              defaultImageModelId={settings.defaultImageModelId}
+              defaultVideoModelId={settings.defaultVideoModelId}
               disabled={busy}
               onChange={(patch) => void updateSettings(patch)}
             />

--- a/src/components/layout/sidebar/useAppSidebarActions.ts
+++ b/src/components/layout/sidebar/useAppSidebarActions.ts
@@ -8,10 +8,6 @@ import {
   type OverlaySidebarAction,
   type OverlaySidebarActionKey,
 } from '@overlay/app-core'
-import { resolveNewChatModelFields } from '@/shared/chat/chat-model-prefs'
-import { useAppSettings } from '@/components/providers/AppSettingsProvider'
-import { dispatchChatCreated } from '@/shared/chat/chat-title'
-import { markNewEmptyChat, upsertCachedChat } from '@/shared/chat/chat-list-cache'
 import { createIdempotencyKey, toRequestInit } from '@overlay/api-client'
 import { overlayAppClient } from '@/shared/app/overlay-app-client'
 import type { GateReason } from '@/components/providers/GuestGateProvider'
@@ -52,57 +48,24 @@ function isKnownActionKey(actionKey: OverlaySidebarActionKey): actionKey is
 export function useAppSidebarActions({
   user,
   pathname,
-  isFreeTier = false,
   requireAuth,
   onCloseMobileMenu,
   onChatCreated,
   onProjectCreated,
 }: UseAppSidebarActionsOptions) {
   const router = useRouter()
-  const { settings } = useAppSettings()
-
   const createChat = useCallback(async () => {
     if (!user) {
       requireAuth('send')
       return false
     }
-    const models = resolveNewChatModelFields({
-      defaultActModelId: settings.defaultActModelId,
-      defaultAskModelIds: settings.defaultAskModelIds,
-      isFreeTier,
-      onlyAllowZdrModels: settings.onlyAllowZdrModels,
-    })
-    const res = await overlayAppClient.conversations.createResponse(
-      {
-        title: 'New Chat',
-        askModelIds: models.askModelIds,
-        actModelId: models.actModelId,
-        lastMode: models.lastMode,
-      },
-      { idempotencyKey: createIdempotencyKey() },
-    )
-    if (!res.ok) return false
-    const data = await res.json() as {
-      id?: string
-      conversation?: { _id: string; title: string; lastModified: number }
-    }
-    if (!data.id) return false
-    const chat = {
-      ...(data.conversation ?? { _id: data.id, title: 'New Chat', lastModified: 0 }),
-      askModelIds: models.askModelIds,
-      actModelId: models.actModelId,
-      lastMode: models.lastMode,
-    }
-    upsertCachedChat(chat)
-    markNewEmptyChat(chat)
-    dispatchChatCreated({ chat })
     onChatCreated()
     onCloseMobileMenu()
-    const href = `/app/chat?id=${encodeURIComponent(data.id)}`
+    const href = '/app/chat'
     if (pathname === '/app/chat') {
       window.history.pushState(null, '', href)
       window.dispatchEvent(new CustomEvent('overlay:chat-route-selected', {
-        detail: { chatId: data.id },
+        detail: { chatId: null, view: 'personal' },
       }))
     } else {
       router.push(href)
@@ -114,10 +77,6 @@ export function useAppSidebarActions({
     pathname,
     requireAuth,
     router,
-    isFreeTier,
-    settings.defaultActModelId,
-    settings.defaultAskModelIds,
-    settings.onlyAllowZdrModels,
     user,
   ])
 

--- a/src/features/chat/components/ChatInlinePanel.tsx
+++ b/src/features/chat/components/ChatInlinePanel.tsx
@@ -12,7 +12,6 @@ import {
   CHAT_MODIFIED_EVENT,
   CHAT_TITLE_UPDATED_EVENT,
   dispatchChatArchived,
-  dispatchChatCreated,
   dispatchChatTitleUpdated,
   sanitizeChatTitle,
   type ChatArchivedDetail,
@@ -685,16 +684,7 @@ export function ChatInlinePanel({
         workspaceId={workspaceId}
         onOpenChange={setNewDirectMessageOpen}
         onCreated={({ id, title }) => {
-          dispatchChatCreated({
-            chat: {
-              _id: id,
-              title,
-              lastModified: Date.now(),
-              conversationType: 'dm',
-            },
-          })
-          rememberLastChatForView(workspaceId, 'dms', id)
-          router.push(`${baseHref}?${new URLSearchParams({ view: 'dms', id }).toString()}`)
+          router.push(`${baseHref}?${new URLSearchParams({ view: 'dms', id, draft: '1', title }).toString()}`)
           onNavigate?.()
         }}
       />
@@ -706,9 +696,7 @@ export function ChatInlinePanel({
         showcase={isPublicShowcase}
         onOpenChange={setNewChannelOpen}
         onCreated={({ id, title }) => {
-          dispatchChatCreated({ chat: { _id: id, title, lastModified: Date.now(), conversationType: 'channel' } })
-          rememberLastChatForView(workspaceId, 'channels', id)
-          router.push(`${baseHref}?${new URLSearchParams({ view: 'channels', id }).toString()}`)
+          router.push(`${baseHref}?${new URLSearchParams({ view: 'channels', id, draft: '1', title }).toString()}`)
           onNavigate?.()
         }}
       />

--- a/src/features/chat/components/ChatMessage.tsx
+++ b/src/features/chat/components/ChatMessage.tsx
@@ -19,7 +19,6 @@ import type {
 import { normalizeAgentAssistantText } from '@/shared/chat/agent-assistant-text'
 import {
   assistantBlocksToPlainText,
-  buildAssistantVisualSequence,
   errorLabel,
   getMessageImageAttachments,
   getMessageText,
@@ -31,6 +30,7 @@ import {
   persistedGenerationErrorMessage,
   resolveActAssistant,
   splitUserDisplayText,
+  normalizeTranscriptAssistantParts,
 } from '@overlay/chat-core'
 import { assistantSnapshotKey } from './chat/chat-runtime-helpers'
 import type { DraftModalState } from './chat-interface/types'
@@ -207,16 +207,34 @@ function TextChatMessage(props: TextChatMessageProps) {
   const responseMessageId = responseMsg && typeof (responseMsg as { id?: unknown }).id === 'string'
     ? (responseMsg as { id: string }).id
     : null
-  const assistantVisualBlocks = (() => {
+  const normalizedAssistant = (() => {
     if (persistedStatus === 'error' && looksLikeStoredGenerationError(responseText)) {
-      return []
+      return { blocks: [], sources: [] }
     }
-    const blocks = buildAssistantVisualSequence(responseParts)
+    const terminalState = persistedStatus === 'completed'
+      ? 'completed'
+      : persistedStatus === 'error'
+        ? 'error'
+        : props.status === 'completed'
+          ? 'completed'
+          : props.status === 'error'
+        ? 'error'
+        : props.status === 'cancelled'
+          ? 'cancelled'
+          : props.status === 'interrupted'
+            ? 'interrupted'
+            : undefined
+    const normalized = normalizeTranscriptAssistantParts(responseParts, terminalState ? { terminalState } : undefined)
+    const blocks = normalized.blocks
     if (blocks.length === 0 && responseText.trim()) {
-      return [{ kind: 'text' as const, text: normalizeAgentAssistantText(responseText) }]
+      return {
+        blocks: [{ kind: 'text' as const, text: normalizeAgentAssistantText(responseText) }],
+        sources: normalized.sources,
+      }
     }
-    return blocks
+    return normalized
   })()
+  const assistantVisualBlocks = normalizedAssistant.blocks
   const hasAssistantText = assistantVisualBlocks.some((block) => block.kind === 'text' && block.text.trim().length > 0)
   const hasAssistantActivity = assistantVisualBlocks.length > 0
   const isStreaming = activeHttpLoading && hasAssistantActivity
@@ -246,6 +264,7 @@ function TextChatMessage(props: TextChatMessageProps) {
       exchIdx={exchangeIndex}
       responseModelId={selectedModelId}
       assistantVisualBlocks={assistantVisualBlocks}
+      responseSources={normalizedAssistant.sources}
       isStreaming={isStreaming}
       isTextStreaming={isTextStreaming}
       errorMessage={errLabelForTurn}

--- a/src/features/chat/components/ChatToolSurface.tsx
+++ b/src/features/chat/components/ChatToolSurface.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import { ChatExchange } from '@overlay/chat-react/transcript'
+import type { ChatTranscriptSourceView } from '@overlay/chat-core'
 import type { ComponentProps } from 'react'
 
-type ChatToolSurfaceProps = ComponentProps<typeof ChatExchange>
+type ChatToolSurfaceProps = ComponentProps<typeof ChatExchange> & {
+  responseSources?: readonly ChatTranscriptSourceView[]
+}
 
 export function ChatToolSurface(props: ChatToolSurfaceProps) {
   return <ChatExchange {...props} />

--- a/src/features/chat/components/ConversationExperienceRouter.tsx
+++ b/src/features/chat/components/ConversationExperienceRouter.tsx
@@ -39,6 +39,8 @@ export function ConversationExperienceRouter(props: ComponentProps<typeof ChatEx
   const searchParams = useSearchParams()
   const searchConversationId = searchParams?.get('id') ?? null
   const searchView = searchParams?.get('view') ?? null
+  const draft = searchParams?.get('draft') === '1'
+  const draftTitle = searchParams?.get('title') ?? undefined
   // Bumped only from browser soft-nav / popstate so we re-read window.location.
   const [browserRouteVersion, setBrowserRouteVersion] = useState(0)
 
@@ -75,6 +77,8 @@ export function ConversationExperienceRouter(props: ComponentProps<typeof ChatEx
       <DirectMessageExperience
         key={`dm:${conversationId}`}
         conversationId={conversationId}
+        draft={draft}
+        draftTitle={draftTitle}
         showcase={Boolean(props.publicShowcaseSnapshots)}
       />
     )
@@ -85,6 +89,8 @@ export function ConversationExperienceRouter(props: ComponentProps<typeof ChatEx
         key={`channel:${conversationId}`}
         conversationId={conversationId}
         conversationType="channel"
+        draft={draft}
+        draftTitle={draftTitle}
         showcase={Boolean(props.publicShowcaseSnapshots)}
       />
     )

--- a/src/features/chat/components/DirectMessageExperience.tsx
+++ b/src/features/chat/components/DirectMessageExperience.tsx
@@ -45,7 +45,7 @@ import { ShareDialog } from '@/components/share/ShareDialog'
 import { AttachResourceDialog } from '@/components/share/AttachResourceDialog'
 import { resolveMentionedPrincipalIds } from '@/shared/mentions/principal-mentions'
 import { clearDraft, readDraft, writeDraft } from '@/shared/chat/conversation-drafts'
-import { dispatchChatArchived } from '@/shared/chat/chat-title'
+import { dispatchChatArchived, dispatchChatCreated } from '@/shared/chat/chat-title'
 import { useWorkspace } from '@/features/workspaces/components/WorkspaceProvider'
 import { buildWorkspaceHref } from '@/features/workspaces/lib/workspace-routing'
 import { useOverlayCapabilities } from '@/components/providers/CapabilitiesProvider'
@@ -204,10 +204,14 @@ export function DirectMessageExperience({
   conversationId,
   showcase = false,
   conversationType = 'dm',
+  draft = false,
+  draftTitle,
 }: {
   conversationId: string
   showcase?: boolean
   conversationType?: 'dm' | 'channel'
+  draft?: boolean
+  draftTitle?: string
 }) {
   const { activeWorkspace, activeWorkspaceId } = useWorkspace()
   const { appDataCapabilities, capabilities } = useOverlayCapabilities()
@@ -310,6 +314,7 @@ export function DirectMessageExperience({
   activeConversationRef.current = conversationId
   const lastTypingSentAt = useRef(0)
   const pendingCollaborationMessageSentRef = useRef(false)
+  const draftCommittedRef = useRef(!draft)
 
   // ── composer state (identical wiring to the personal chat composer) ─────────
   const [composerNotice, setComposerNotice] = useState<string | null>(null)
@@ -682,8 +687,8 @@ export function DirectMessageExperience({
 
   const otherParticipants = participants.filter((participant) => participant.principalId !== currentPrincipalId)
   const title = conversationType === 'channel'
-    ? channel?.name ?? 'Channel'
-    : conversationTitle ?? (otherParticipants.map((participant) => participant.displayName).join(', ') || 'Direct message')
+    ? channel?.name ?? draftTitle ?? 'Channel'
+    : conversationTitle ?? draftTitle ?? (otherParticipants.map((participant) => participant.displayName).join(', ') || 'Direct message')
   const HeaderIcon = conversationType === 'channel'
     ? Hash
     : otherParticipants.length === 1 && otherParticipants[0]?.principalType === 'agent'
@@ -695,6 +700,45 @@ export function DirectMessageExperience({
     row.principalId !== currentPrincipalId && row.status === 'online'
   )).length
   const currentParticipant = participants.find((participant) => participant.principalId === currentPrincipalId)
+
+  const commitDraftConversation = useCallback(() => {
+    if (!draft || draftCommittedRef.current) return
+    draftCommittedRef.current = true
+    dispatchChatCreated({
+      chat: {
+        _id: conversationId,
+        title,
+        lastModified: Date.now(),
+        conversationType,
+      },
+    })
+    const url = new URL(window.location.href)
+    url.searchParams.delete('draft')
+    url.searchParams.delete('title')
+    window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
+  }, [conversationId, conversationType, draft, title])
+
+  useEffect(() => () => {
+    if (!draft || draftCommittedRef.current || showcase || messagesRef.current.length > 0) return
+    void (async () => {
+      const removed = await overlayAppClient.conversations.deleteResponse({
+        conversationId,
+        scope: 'self',
+      })
+      if (!removed.ok) {
+        await overlayAppClient.conversations.updateParticipantState(conversationId, {
+          archived: true,
+          archiveScope: 'self',
+        }).catch(() => undefined)
+      }
+    })()
+  }, [conversationId, draft, showcase])
+
+  useEffect(() => {
+    if (draft && messages.some((message) => !message.id.startsWith('optimistic_'))) {
+      commitDraftConversation()
+    }
+  }, [commitDraftConversation, draft, messages])
   const mainMessages = messages.filter((message) => !message.threadRootMessageId)
   const threadRoot = messages.find((message) => message.id === threadRootId)
   const threadReplies = messages.filter((message) => (
@@ -921,6 +965,7 @@ export function DirectMessageExperience({
       // from here. The reply arrives in the transcript on its own, so there is
       // nothing for this client to hold open and nothing to wait for.
       if (!convexRoomSubscriptionEnabled) await loadMessages()
+      commitDraftConversation()
       void saved
     } catch {
       setMessages((current) => current.map((message) => (
@@ -1716,9 +1761,9 @@ export function DirectMessageExperience({
           addToConversationType={conversationType}
           excludedPrincipalIds={participants.map((participant) => participant.principalId)}
           onOpenChange={setAddPeopleOpen}
-          onCreated={({ id }) => {
+          onCreated={({ id, title: createdTitle }) => {
             const view = conversationType === 'channel' ? 'channels' : 'dms'
-            router.push(`/app/chat?view=${view}&id=${encodeURIComponent(id)}`)
+            router.push(`/app/chat?${new URLSearchParams({ view, id, draft: '1', title: createdTitle }).toString()}`)
           }}
           onParticipantsAdded={() => {
             setAddPeopleOpen(false)

--- a/src/features/chat/components/chat-interface/MentionInput.tsx
+++ b/src/features/chat/components/chat-interface/MentionInput.tsx
@@ -212,15 +212,15 @@ function extractMarkdownFromElement(el: HTMLDivElement): string {
   }))
 }
 
-const MENTION_SYMBOLS: Record<MentionType, string> = {
-  person: '@',
-  file: 'F',
-  knowledge: 'K',
-  connector: 'E',
-  automation: 'A',
-  skill: 'S',
-  mcp: 'M',
-  chat: '#',
+const MENTION_ICON_PATHS: Record<MentionType, string[]> = {
+  person: ['M20 21a8 8 0 0 0-16 0', 'M12 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8'],
+  file: ['M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5z', 'M14 2v6h6', 'M8 13h8', 'M8 17h8'],
+  knowledge: ['M2 6s3-2 6-2 4 2 4 2v14s-4-2-4-2-6 2-6 2z', 'M22 6s-3-2-6-2-4 2-4 2v14s4-2 4-2 6 2 6 2z'],
+  connector: ['M12 22v-5', 'M9 8V2', 'M15 8V2', 'M18 8v5a6 6 0 0 1-12 0V8z'],
+  automation: ['M3 3v5h5', 'M3.05 13A9 9 0 1 0 5.3 6.3L3 8', 'M12 7v5l4 2'],
+  skill: ['M12 3l1.9 3.9L18 8.8l-3 2.9.7 4.1-3.7-2-3.7 2 .7-4.1-3-2.9 4.1-.6z'],
+  mcp: ['M4 7V4h16v3', 'M5 20h14', 'M6 7h12v10H6z', 'M9 11h6', 'M9 14h3'],
+  chat: ['M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z'],
 }
 
 function dispatchEditorInput(el: HTMLDivElement) {
@@ -481,10 +481,20 @@ function createMentionChip(item: MentionItem): HTMLSpanElement {
   chip.setAttribute(MENTION_ID_ATTR, item.id)
   chip.className =
     'inline-flex items-center gap-1 mx-0.5 px-1.5 py-0.5 rounded-md bg-[var(--surface-muted)] border border-[var(--border)] text-xs font-medium text-[var(--foreground)] select-none align-baseline'
-  const symbol = document.createElement('span')
+  const symbol = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
   symbol.setAttribute('aria-hidden', 'true')
-  symbol.className = 'inline-flex h-3.5 w-3.5 items-center justify-center rounded bg-[var(--surface-elevated)] text-[9px] text-[var(--muted)]'
-  symbol.textContent = MENTION_SYMBOLS[item.type]
+  symbol.setAttribute('viewBox', '0 0 24 24')
+  symbol.setAttribute('fill', 'none')
+  symbol.setAttribute('stroke', 'currentColor')
+  symbol.setAttribute('stroke-width', '1.75')
+  symbol.setAttribute('stroke-linecap', 'round')
+  symbol.setAttribute('stroke-linejoin', 'round')
+  symbol.setAttribute('class', 'h-3.5 w-3.5 shrink-0 text-[var(--muted)]')
+  for (const pathData of MENTION_ICON_PATHS[item.type]) {
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    path.setAttribute('d', pathData)
+    symbol.append(path)
+  }
   const label = document.createElement('span')
   label.textContent = `@${item.name}`
   chip.append(symbol, label)

--- a/src/features/chat/components/chat-interface/MentionInput.tsx
+++ b/src/features/chat/components/chat-interface/MentionInput.tsx
@@ -12,6 +12,7 @@ import {
 import { MentionPopup } from '@/components/mentions/MentionPopup'
 import { useMentionData } from './useMentionData'
 import type { MentionCategory, MentionItem, MentionType } from '@/shared/knowledge/mention-types'
+import { joinComposerMarkdownSegments } from './composer-markdown'
 
 export type MentionInputFormatCommand =
   | 'heading1'
@@ -164,7 +165,15 @@ function inlineNodeToMarkdown(node: Node): string {
   if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? ''
   if (node.nodeType !== Node.ELEMENT_NODE) return ''
   const element = node as HTMLElement
-  if (element.getAttribute(MENTION_ATTR)) return element.textContent ?? ''
+  if (element.getAttribute(MENTION_ATTR)) {
+    try {
+      const item = JSON.parse(element.dataset.mentionData ?? '{}') as Partial<MentionItem>
+      if (typeof item.name === 'string' && item.name.trim()) return `@${item.name}`
+    } catch {
+      // Fall through to the visible label for malformed legacy chips.
+    }
+    return element.textContent ?? ''
+  }
   if (element.tagName === 'BR') return '\n'
   const content = Array.from(element.childNodes).map(inlineNodeToMarkdown).join('')
   if (element.tagName === 'STRONG' || element.tagName === 'B') return `**${content}**`
@@ -192,13 +201,26 @@ function blockNodeToMarkdown(node: Node): string {
 }
 
 function extractMarkdownFromElement(el: HTMLDivElement): string {
-  return Array.from(el.childNodes)
-    .map(blockNodeToMarkdown)
-    .join('\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/\u00A0/g, ' ')
-    .replace(/\u200B/g, '') // strip zero-width spaces used for caret placement
-    .trimEnd()
+  const blockTags = new Set(['DIV', 'P', 'H1', 'H2', 'H3', 'PRE', 'BLOCKQUOTE', 'UL', 'OL'])
+  return joinComposerMarkdownSegments(Array.from(el.childNodes).map((node) => {
+    const isBlock = node.nodeType === Node.ELEMENT_NODE
+      && blockTags.has((node as HTMLElement).tagName)
+    return {
+      markdown: isBlock ? blockNodeToMarkdown(node) : inlineNodeToMarkdown(node),
+      block: isBlock,
+    }
+  }))
+}
+
+const MENTION_SYMBOLS: Record<MentionType, string> = {
+  person: '@',
+  file: 'F',
+  knowledge: 'K',
+  connector: 'E',
+  automation: 'A',
+  skill: 'S',
+  mcp: 'M',
+  chat: '#',
 }
 
 function dispatchEditorInput(el: HTMLDivElement) {
@@ -459,7 +481,13 @@ function createMentionChip(item: MentionItem): HTMLSpanElement {
   chip.setAttribute(MENTION_ID_ATTR, item.id)
   chip.className =
     'inline-flex items-center gap-1 mx-0.5 px-1.5 py-0.5 rounded-md bg-[var(--surface-muted)] border border-[var(--border)] text-xs font-medium text-[var(--foreground)] select-none align-baseline'
-  chip.textContent = `@${item.name}`
+  const symbol = document.createElement('span')
+  symbol.setAttribute('aria-hidden', 'true')
+  symbol.className = 'inline-flex h-3.5 w-3.5 items-center justify-center rounded bg-[var(--surface-elevated)] text-[9px] text-[var(--muted)]'
+  symbol.textContent = MENTION_SYMBOLS[item.type]
+  const label = document.createElement('span')
+  label.textContent = `@${item.name}`
+  chip.append(symbol, label)
   // Store full item data
   chip.dataset.mentionData = JSON.stringify(item)
   return chip

--- a/src/features/chat/components/chat-interface/composer-markdown.test.ts
+++ b/src/features/chat/components/chat-interface/composer-markdown.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { joinComposerMarkdownSegments } from './composer-markdown'
+
+test('keeps text, links, and mention chips on the same composer line', () => {
+  assert.equal(joinComposerMarkdownSegments([
+    { markdown: 'Read ', block: false },
+    { markdown: 'tinyfish.ai', block: false },
+    { markdown: ' with ', block: false },
+    { markdown: '@Firecrawl', block: false },
+    { markdown: ' MCP', block: false },
+  ]), 'Read tinyfish.ai with @Firecrawl MCP')
+})
+
+test('preserves real block boundaries', () => {
+  assert.equal(joinComposerMarkdownSegments([
+    { markdown: 'First paragraph', block: true },
+    { markdown: '- item', block: true },
+  ]), 'First paragraph\n- item')
+})

--- a/src/features/chat/components/chat-interface/composer-markdown.ts
+++ b/src/features/chat/components/chat-interface/composer-markdown.ts
@@ -1,0 +1,19 @@
+export interface ComposerMarkdownSegment {
+  markdown: string
+  block: boolean
+}
+
+/** Join contenteditable root nodes without turning adjacent inline chips into paragraphs. */
+export function joinComposerMarkdownSegments(segments: readonly ComposerMarkdownSegment[]): string {
+  let markdown = ''
+  for (const segment of segments) {
+    if (segment.block && markdown && !markdown.endsWith('\n')) markdown += '\n'
+    markdown += segment.markdown
+    if (segment.block && !markdown.endsWith('\n')) markdown += '\n'
+  }
+  return markdown
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/\u00A0/g, ' ')
+    .replace(/\u200B/g, '')
+    .trimEnd()
+}

--- a/src/features/chat/components/chat/chat-send-create.ts
+++ b/src/features/chat/components/chat/chat-send-create.ts
@@ -14,7 +14,7 @@ import type {
 } from '../chat-interface/types'
 import { resetRuntimeState } from './conversation-runtime-utils'
 import type { EnsureConversationRuntime } from './chat-send-body-builders'
-import type { PendingFirstSendState } from './chat-send-pending-first'
+import { startPendingFirstSendRename, type PendingFirstSendState } from './chat-send-pending-first'
 
 export type CreateNewChatOptions = {
   title?: string
@@ -54,6 +54,7 @@ export async function createNewChatForSend({
   setIsTemporaryChat,
   setRuntimeHydrationVersion,
   syncStandaloneChatUrl,
+  startFirstMessageRename,
   tryActivatePendingFirstSend,
 }: {
   activeChatIdRef: MutableRefObject<string | null>
@@ -80,6 +81,7 @@ export async function createNewChatForSend({
   setIsTemporaryChat: (isTemporaryChat: boolean) => void
   setRuntimeHydrationVersion: Dispatch<SetStateAction<number>>
   syncStandaloneChatUrl: (chatId: string | null) => void
+  startFirstMessageRename: (chatId: string, seedText: string) => void
   tryActivatePendingFirstSend: () => void
 }): Promise<string | null> {
   invalidateLoadChatRequest()
@@ -126,6 +128,7 @@ export async function createNewChatForSend({
     const pending = pendingFirstSendRef.current
     if (pending && trimmedClientId && pending.conversationClientId === trimmedClientId) {
       pending.realChatId = data.id
+      startPendingFirstSendRename(pending, startFirstMessageRename)
       if (pendingScrollTurnIdRef.current && !pendingScrollChatIdRef.current) {
         pendingScrollChatIdRef.current = data.id
       }

--- a/src/features/chat/components/chat/chat-send-pending-first.test.ts
+++ b/src/features/chat/components/chat/chat-send-pending-first.test.ts
@@ -7,6 +7,7 @@ import {
   activatePendingFirstSend,
   completeSessionForPendingFirstSend,
   isStreamChatActive,
+  startPendingFirstSendRename,
   type PendingFirstSendState,
 } from './chat-send-pending-first'
 import { PENDING_FIRST_CHAT_ID, TEMPORARY_CHAT_ID } from './chat-send-body-builders'
@@ -47,6 +48,7 @@ test('checks active stream ids for temporary, pending-first, and persisted chats
       streamDone: false,
       realChatId: null,
       wasFirst: true,
+      renameStarted: false,
       renameSeed: 'hello',
       activeChatTitleSnapshot: null,
     },
@@ -88,6 +90,7 @@ test('activates pending first send once real chat and stream completion are both
       streamDone: true,
       realChatId: 'chat-real',
       wasFirst: true,
+      renameStarted: false,
       renameSeed: 'hello world',
       activeChatTitleSnapshot: 'Preview',
     },
@@ -151,6 +154,7 @@ test('completeSessionForPendingFirstSend defers chat creation until real id exis
       streamDone: false,
       realChatId: null,
       wasFirst: true,
+      renameStarted: false,
       renameSeed: 'hello',
       activeChatTitleSnapshot: null,
     },
@@ -170,4 +174,24 @@ test('completeSessionForPendingFirstSend defers chat creation until real id exis
   assert.equal(deferredClientId, 'client-1')
   assert.deepEqual(completed, [PENDING_FIRST_CHAT_ID, true])
   assert.equal(activated, 1)
+})
+
+test('starts the first-message rename as soon as the persisted id arrives and only once', () => {
+  const pending: PendingFirstSendState = {
+    conversationClientId: 'client-1',
+    previewRuntime: runtimeFor(),
+    streamDone: false,
+    realChatId: 'chat-real',
+    wasFirst: true,
+    renameStarted: false,
+    renameSeed: 'sidebar title now',
+    activeChatTitleSnapshot: null,
+  }
+  const renamed: Array<[string, string]> = []
+
+  startPendingFirstSendRename(pending, (chatId, seed) => renamed.push([chatId, seed]))
+  startPendingFirstSendRename(pending, (chatId, seed) => renamed.push([chatId, seed]))
+
+  assert.deepEqual(renamed, [['chat-real', 'sidebar title now']])
+  assert.equal(pending.renameStarted, true)
 })

--- a/src/features/chat/components/chat/chat-send-pending-first.ts
+++ b/src/features/chat/components/chat/chat-send-pending-first.ts
@@ -18,8 +18,18 @@ export type PendingFirstSendState = {
   streamDone: boolean
   realChatId: string | null
   wasFirst: boolean
+  renameStarted: boolean
   renameSeed: string
   activeChatTitleSnapshot: string | null
+}
+
+export function startPendingFirstSendRename(
+  pending: PendingFirstSendState | null,
+  startFirstMessageRename: (chatId: string, seedText: string) => void,
+) {
+  if (!pending?.realChatId || !pending.wasFirst || pending.renameStarted) return
+  pending.renameStarted = true
+  startFirstMessageRename(pending.realChatId, pending.renameSeed)
 }
 
 export function isStreamChatActive({
@@ -86,9 +96,7 @@ export function activatePendingFirstSend({
     [...preview.actChat.messages],
   )
   markChatModified(realId, pending.activeChatTitleSnapshot)
-  if (pending.wasFirst) {
-    startFirstMessageRename(realId, pending.renameSeed)
-  }
+  startPendingFirstSendRename(pending, startFirstMessageRename)
   activeChatIdRef.current = realId
   setActiveViewer(realId)
   setActiveChatId(realId)

--- a/src/features/chat/components/chat/chat-send-text.ts
+++ b/src/features/chat/components/chat/chat-send-text.ts
@@ -175,6 +175,7 @@ export function sendTextTurn({
       streamDone: false,
       realChatId: null,
       wasFirst: isFirstMessage,
+      renameStarted: false,
       renameSeed: snapshot.text || payload.indexedFileNames[0] || 'Documents',
       activeChatTitleSnapshot: snapshot.activeChatTitleSnapshot,
     }

--- a/src/features/chat/components/chat/toChatTranscriptView.ts
+++ b/src/features/chat/components/chat/toChatTranscriptView.ts
@@ -181,6 +181,15 @@ export function createWebChatTranscriptAdapter() {
           Array.isArray((response as { parts?: unknown[] }).parts)
             ? (response as { parts: unknown[] }).parts
             : undefined,
+          responseStatuses[responseIndex] === 'completed'
+            ? { terminalState: 'completed' }
+            : responseStatuses[responseIndex] === 'error'
+              ? { terminalState: 'error' }
+              : responseStatuses[responseIndex] === 'cancelled'
+                ? { terminalState: 'cancelled' }
+                : responseStatuses[responseIndex] === 'interrupted'
+                  ? { terminalState: 'interrupted' }
+                  : undefined,
         )
         const runtime = input.getResponseRuntime?.(modelId, exchangeIndex)
         const persistedStatus = (response as { status?: PersistedResponseStatus }).status

--- a/src/features/chat/components/chat/useChatSendController.ts
+++ b/src/features/chat/components/chat/useChatSendController.ts
@@ -268,6 +268,7 @@ export function useChatSendController({
       setIsTemporaryChat,
       setRuntimeHydrationVersion,
       syncStandaloneChatUrl,
+      startFirstMessageRename,
       tryActivatePendingFirstSend,
     })
   }, [
@@ -293,6 +294,7 @@ export function useChatSendController({
     setIsTemporaryChat,
     setRuntimeHydrationVersion,
     syncStandaloneChatUrl,
+    startFirstMessageRename,
     tryActivatePendingFirstSend,
   ])
 

--- a/src/features/settings/components/ModelCatalogSetting.tsx
+++ b/src/features/settings/components/ModelCatalogSetting.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { ChevronDown, ChevronUp, KeyRound, RefreshCw, Search, Sparkles, ScanEye } from 'lucide-react'
+import { Check, ChevronDown, ChevronUp, ImageIcon, KeyRound, MessageSquare, RefreshCw, Search, Sparkles, ScanEye, Video } from 'lucide-react'
 import { SettingsToggle } from '@overlay/modules-react/settings'
 import {
   AVAILABLE_MODELS,
@@ -12,6 +12,7 @@ import { useGatewayModelCatalog } from '@/components/providers/useGatewayModelCa
 import { useByokModels } from '@/components/providers/useByokModels'
 import { isByokModelId } from '@/shared/ai/gateway/byok-model-conversion'
 import { useOverlayCapabilities } from '@/components/providers/CapabilitiesProvider'
+import { gatewayCatalogModelHasSupportedPricing } from '@/shared/ai/gateway/gateway-catalog'
 
 function formatPrice(value?: number) {
   if (value === undefined) return 'Unpriced'
@@ -19,16 +20,44 @@ function formatPrice(value?: number) {
   return `$${value < 0.01 ? value.toFixed(3) : value.toFixed(2)}/1M`
 }
 
+function formatMediaPrice(model: GatewayCatalogModel): string {
+  if (model.type === 'image') {
+    const flat = Number(model.pricing.image)
+    if (Number.isFinite(flat)) return `$${flat.toFixed(flat < 0.01 ? 3 : 2)}/image`
+    if (model.inputPricePerMillion !== undefined && model.outputPricePerMillion !== undefined) {
+      return `${formatPrice(model.inputPricePerMillion)} in · ${formatPrice(model.outputPricePerMillion)} out`
+    }
+  }
+  if (model.type === 'video' && Array.isArray(model.pricing.video_duration_pricing)) {
+    const prices = model.pricing.video_duration_pricing.flatMap((row) => {
+      if (!row || typeof row !== 'object') return []
+      const value = Number((row as Record<string, unknown>).cost_per_second)
+      return Number.isFinite(value) ? [value] : []
+    })
+    if (prices.length > 0) return `from $${Math.min(...prices).toFixed(3)}/second`
+  }
+  return 'Pricing unavailable'
+}
+
 export function ModelCatalogSetting({
   enabledModelIds,
   modelOrder,
+  defaultImageModelId,
+  defaultVideoModelId,
   disabled,
   onChange,
 }: {
   enabledModelIds: readonly string[]
   modelOrder: readonly string[]
+  defaultImageModelId?: string
+  defaultVideoModelId?: string
   disabled?: boolean
-  onChange: (patch: { enabledChatModelIds?: string[]; modelOrder?: string[] }) => void
+  onChange: (patch: {
+    enabledChatModelIds?: string[]
+    modelOrder?: string[]
+    defaultImageModelId?: string
+    defaultVideoModelId?: string
+  }) => void
 }) {
   const { models, isLoading, error, refresh, revision } = useGatewayModelCatalog()
   const { appDataCapabilities } = useOverlayCapabilities()
@@ -36,6 +65,7 @@ export function ModelCatalogSetting({
     enabled: appDataCapabilities.provider === 'convex',
   })
   const [query, setQuery] = useState('')
+  const [catalogType, setCatalogType] = useState<'language' | 'image' | 'video'>('language')
 
   const effectiveIds = enabledModelIds.length > 0
     ? enabledModelIds
@@ -45,7 +75,7 @@ export function ModelCatalogSetting({
   const displayModels = useMemo(() => {
     void revision
     void byokConnections
-    const gatewayIds = new Set(models.map((model) => model.id))
+    const gatewayIds = new Set(models.filter((model) => model.type === 'language').map((model) => model.id))
     const existingDefaults: GatewayCatalogModel[] = AVAILABLE_MODELS
       .filter((model) => curatedIds.has(model.id) && !gatewayIds.has(model.id))
       .map((model) => ({
@@ -91,12 +121,13 @@ export function ModelCatalogSetting({
     })
   }, [byokConnections, curatedIds, modelOrder, models, revision])
   const filtered = useMemo(() => {
+    const byType = displayModels.filter((model) => model.type === catalogType)
     const normalized = query.trim().toLowerCase()
-    if (!normalized) return displayModels
-    return displayModels.filter((model) =>
+    if (!normalized) return byType
+    return byType.filter((model) =>
       `${model.name} ${model.id} ${model.provider}`.toLowerCase().includes(normalized),
     )
-  }, [displayModels, query])
+  }, [catalogType, displayModels, query])
 
   function toggle(modelId: string) {
     const next = new Set(effectiveIds)
@@ -130,6 +161,28 @@ export function ModelCatalogSetting({
   return (
     <div className="flex flex-col gap-4">
       <section className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)]">
+        <div className="flex items-center gap-1 border-b border-[var(--border)] p-2">
+          {([
+            ['language', 'Chat', MessageSquare],
+            ['image', 'Image', ImageIcon],
+            ['video', 'Video', Video],
+          ] as const).map(([value, label, Icon]) => (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={catalogType === value}
+              onClick={() => setCatalogType(value)}
+              className={`inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-xs font-medium transition-colors ${
+                catalogType === value
+                  ? 'bg-[var(--surface-muted)] text-[var(--foreground)]'
+                  : 'text-[var(--muted)] hover:text-[var(--foreground)]'
+              }`}
+            >
+              <Icon size={13} strokeWidth={1.75} />
+              {label}
+            </button>
+          ))}
+        </div>
         <div className="flex items-center gap-2 border-b border-[var(--border)] p-3">
           <div className="relative flex-1">
             <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--muted-light)]" />
@@ -140,29 +193,33 @@ export function ModelCatalogSetting({
               className="h-10 w-full rounded-lg border border-[var(--border)] bg-[var(--surface-subtle)] pl-9 pr-3 text-sm text-[var(--foreground)] outline-none focus:border-[var(--muted)]"
             />
           </div>
-          <button
-            type="button"
-            aria-label="Refresh models"
-            disabled={isLoading}
-            onClick={() => { void refresh(); void refreshByok() }}
-            className="flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--surface-subtle)] text-[var(--muted)] hover:text-[var(--foreground)] disabled:opacity-50"
-          >
-            <RefreshCw size={16} className={isLoading ? 'animate-spin' : ''} />
-          </button>
-          <button
-            type="button"
-            disabled={disabled}
-            onClick={() => onChange({
-              enabledChatModelIds: [...DEFAULT_CURATED_CHAT_MODEL_IDS],
-              modelOrder: [],
-            })}
-            className="hidden h-10 rounded-lg border border-[var(--border)] bg-[var(--surface-subtle)] px-3 text-xs text-[var(--foreground)] sm:block"
-          >
-            Reset defaults
-          </button>
+          {catalogType === 'language' ? <>
+            <button
+              type="button"
+              aria-label="Refresh models"
+              disabled={isLoading}
+              onClick={() => { void refresh(); void refreshByok() }}
+              className="flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--surface-subtle)] text-[var(--muted)] hover:text-[var(--foreground)] disabled:opacity-50"
+            >
+              <RefreshCw size={16} className={isLoading ? 'animate-spin' : ''} />
+            </button>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onChange({
+                enabledChatModelIds: [...DEFAULT_CURATED_CHAT_MODEL_IDS],
+                modelOrder: [],
+              })}
+              className="hidden h-10 rounded-lg border border-[var(--border)] bg-[var(--surface-subtle)] px-3 text-xs text-[var(--foreground)] sm:block"
+            >
+              Reset defaults
+            </button>
+          </> : null}
         </div>
         <div className="border-b border-[var(--border)] px-4 py-2 text-xs text-[var(--muted)]">
-          {effectiveIds.length} enabled · {displayModels.length} available models
+          {catalogType === 'language'
+            ? `${effectiveIds.length} enabled · ${filtered.length} available chat models`
+            : `${filtered.length} priced ${catalogType} models from AI Gateway`}
         </div>
         {error ? <div className="px-4 py-6 text-sm text-red-500">{error}</div> : null}
         {!error ? (
@@ -170,8 +227,14 @@ export function ModelCatalogSetting({
             {filtered.map((model: GatewayCatalogModel) => {
               const byok = isByokModelId(model.id)
               const hasUsagePricing =
-                model.inputPricePerMillion !== undefined &&
-                model.outputPricePerMillion !== undefined
+                model.type === 'language'
+                  ? model.inputPricePerMillion !== undefined && model.outputPricePerMillion !== undefined
+                  : gatewayCatalogModelHasSupportedPricing(model)
+              const mediaDefault = model.type === 'image'
+                ? defaultImageModelId === model.id
+                : model.type === 'video'
+                  ? defaultVideoModelId === model.id
+                  : false
               return (
               <div
                 key={model.id}
@@ -182,17 +245,19 @@ export function ModelCatalogSetting({
                 <div className="min-w-0 flex-1">
                   <div className="flex min-w-0 items-center gap-2">
                     <span className="truncate text-sm font-medium text-[var(--foreground)]">{model.name}</span>
-                    {model.tags.includes('vision') ? (
+                    {model.type === 'language' && model.tags.includes('vision') ? (
                       <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-[#f0f0f0] text-zinc-700">
                         <ScanEye size={11} strokeWidth={1.6} />
                       </span>
                     ) : null}
-                    {model.tags.includes('reasoning') ? (
+                    {model.type === 'language' && model.tags.includes('reasoning') ? (
                       <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-[#f0f0f0] text-zinc-700">
                         <Sparkles size={11} strokeWidth={1.6} />
                       </span>
                     ) : null}
-                    {byok ? (
+                    {model.type !== 'language' ? (
+                      <span>{formatMediaPrice(model)}</span>
+                    ) : byok ? (
                       <span className="inline-flex items-center gap-1 rounded bg-[var(--surface-subtle)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--muted)]">
                         <KeyRound size={10} /> BYOK
                       </span>
@@ -215,7 +280,7 @@ export function ModelCatalogSetting({
                     {curatedIds.has(model.id) ? <><span>·</span><span>Default</span></> : null}
                   </div>
                 </div>
-                {enabled.has(model.id) ? (
+                {model.type === 'language' && enabled.has(model.id) ? (
                   <div className="flex items-center gap-1">
                     <button
                       type="button"
@@ -237,15 +302,33 @@ export function ModelCatalogSetting({
                     </button>
                   </div>
                 ) : null}
-                <SettingsToggle
-                  checked={enabled.has(model.id)}
-                  disabled={
-                    disabled ||
-                    (!hasUsagePricing && !byok) ||
-                    (enabled.has(model.id) && enabled.size === 1)
-                  }
-                  onChange={() => toggle(model.id)}
-                />
+                {model.type === 'language' ? (
+                  <SettingsToggle
+                    checked={enabled.has(model.id)}
+                    disabled={
+                      disabled ||
+                      (!hasUsagePricing && !byok) ||
+                      (enabled.has(model.id) && enabled.size === 1)
+                    }
+                    onChange={() => toggle(model.id)}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    disabled={disabled || !hasUsagePricing}
+                    onClick={() => onChange(model.type === 'image'
+                      ? { defaultImageModelId: model.id }
+                      : { defaultVideoModelId: model.id })}
+                    className={`inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors disabled:opacity-50 ${
+                      mediaDefault
+                        ? 'border-[var(--foreground)] bg-[var(--foreground)] text-[var(--background)]'
+                        : 'border-[var(--border)] bg-[var(--surface-subtle)] text-[var(--muted)] hover:text-[var(--foreground)]'
+                    }`}
+                  >
+                    {mediaDefault ? <Check size={12} /> : null}
+                    {mediaDefault ? 'Default' : 'Set default'}
+                  </button>
+                )}
               </div>
               )
             })}

--- a/src/features/settings/components/ModelCatalogSetting.tsx
+++ b/src/features/settings/components/ModelCatalogSetting.tsx
@@ -39,6 +39,147 @@ function formatMediaPrice(model: GatewayCatalogModel): string {
   return 'Pricing unavailable'
 }
 
+type ModelSettingsPatch = {
+  enabledChatModelIds?: string[]
+  modelOrder?: string[]
+  defaultImageModelId?: string
+  defaultVideoModelId?: string
+}
+
+function ModelCatalogControls({
+  model,
+  language,
+  byok,
+  hasUsagePricing,
+  mediaDefault,
+  enabled,
+  disabled,
+  onToggle,
+  onMove,
+  onChange,
+}: {
+  model: GatewayCatalogModel
+  language: boolean
+  byok: boolean
+  hasUsagePricing: boolean
+  mediaDefault: boolean
+  enabled: ReadonlySet<string>
+  disabled?: boolean
+  onToggle: (modelId: string) => void
+  onMove: (modelId: string, direction: -1 | 1) => void
+  onChange: (patch: ModelSettingsPatch) => void
+}) {
+  if (!language) {
+    return (
+      <button
+        type="button"
+        disabled={disabled || !hasUsagePricing}
+        onClick={() => onChange(model.type === 'image' ? { defaultImageModelId: model.id } : { defaultVideoModelId: model.id })}
+        className={`inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors disabled:opacity-50 ${mediaDefault ? 'border-[var(--foreground)] bg-[var(--foreground)] text-[var(--background)]' : 'border-[var(--border)] bg-[var(--surface-subtle)] text-[var(--muted)] hover:text-[var(--foreground)]'}`}
+      >
+        {mediaDefault ? <Check size={12} /> : null}
+        {mediaDefault ? 'Default' : 'Set default'}
+      </button>
+    )
+  }
+
+  const isEnabled = enabled.has(model.id)
+  return (
+    <>
+      {isEnabled ? (
+        <div className="flex items-center gap-1">
+          <button type="button" aria-label={`Move ${model.name} up`} disabled={disabled} onClick={() => onMove(model.id, -1)} className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--muted)] hover:bg-[var(--surface-subtle)] disabled:opacity-40">
+            <ChevronUp size={14} />
+          </button>
+          <button type="button" aria-label={`Move ${model.name} down`} disabled={disabled} onClick={() => onMove(model.id, 1)} className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--muted)] hover:bg-[var(--surface-subtle)] disabled:opacity-40">
+            <ChevronDown size={14} />
+          </button>
+        </div>
+      ) : null}
+      <SettingsToggle
+        checked={isEnabled}
+        disabled={disabled || (!hasUsagePricing && !byok) || (isEnabled && enabled.size === 1)}
+        onChange={() => onToggle(model.id)}
+      />
+    </>
+  )
+}
+
+function ModelCatalogRow({
+  model,
+  curated,
+  enabled,
+  defaultImageModelId,
+  defaultVideoModelId,
+  disabled,
+  onToggle,
+  onMove,
+  onChange,
+}: {
+  model: GatewayCatalogModel
+  curated: boolean
+  enabled: ReadonlySet<string>
+  defaultImageModelId?: string
+  defaultVideoModelId?: string
+  disabled?: boolean
+  onToggle: (modelId: string) => void
+  onMove: (modelId: string, direction: -1 | 1) => void
+  onChange: (patch: ModelSettingsPatch) => void
+}) {
+  const byok = isByokModelId(model.id)
+  const language = model.type === 'language'
+  const hasUsagePricing = language
+    ? model.inputPricePerMillion !== undefined && model.outputPricePerMillion !== undefined
+    : gatewayCatalogModelHasSupportedPricing(model)
+  const mediaDefault = model.type === 'image'
+    ? defaultImageModelId === model.id
+    : model.type === 'video' && defaultVideoModelId === model.id
+
+  return (
+    <div className={`flex items-center gap-4 px-4 py-3 transition-colors ${hasUsagePricing || byok ? 'hover:bg-[var(--surface-muted)]' : 'opacity-55'}`}>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm font-medium text-[var(--foreground)]">{model.name}</span>
+          {language && model.tags.includes('vision') ? (
+            <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-[#f0f0f0] text-zinc-700">
+              <ScanEye size={11} strokeWidth={1.6} />
+            </span>
+          ) : null}
+          {language && model.tags.includes('reasoning') ? (
+            <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-[#f0f0f0] text-zinc-700">
+              <Sparkles size={11} strokeWidth={1.6} />
+            </span>
+          ) : null}
+          {!language ? <span>{formatMediaPrice(model)}</span> : byok ? (
+            <span className="inline-flex items-center gap-1 rounded bg-[var(--surface-subtle)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--muted)]">
+              <KeyRound size={10} /> BYOK
+            </span>
+          ) : null}
+        </div>
+        <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[var(--muted)]">
+          <span className="capitalize">{model.provider}</span><span>·</span>
+          {byok ? <span>Billed directly by provider</span> : hasUsagePricing && language ? (
+            <><span>{formatPrice(model.inputPricePerMillion)} in</span><span>·</span><span>{formatPrice(model.outputPricePerMillion)} out</span></>
+          ) : !hasUsagePricing ? <span>Pricing unavailable</span> : null}
+          {curated ? <><span>·</span><span>Default</span></> : null}
+        </div>
+      </div>
+      <ModelCatalogControls
+        model={model}
+        language={language}
+        byok={byok}
+        hasUsagePricing={hasUsagePricing}
+        mediaDefault={mediaDefault}
+        enabled={enabled}
+        disabled={disabled}
+        onToggle={onToggle}
+        onMove={onMove}
+        onChange={onChange}
+      />
+    </div>
+  )
+}
+
 export function ModelCatalogSetting({
   enabledModelIds,
   modelOrder,
@@ -52,12 +193,7 @@ export function ModelCatalogSetting({
   defaultImageModelId?: string
   defaultVideoModelId?: string
   disabled?: boolean
-  onChange: (patch: {
-    enabledChatModelIds?: string[]
-    modelOrder?: string[]
-    defaultImageModelId?: string
-    defaultVideoModelId?: string
-  }) => void
+  onChange: (patch: ModelSettingsPatch) => void
 }) {
   const { models, isLoading, error, refresh, revision } = useGatewayModelCatalog()
   const { appDataCapabilities } = useOverlayCapabilities()
@@ -224,114 +360,20 @@ export function ModelCatalogSetting({
         {error ? <div className="px-4 py-6 text-sm text-red-500">{error}</div> : null}
         {!error ? (
           <div className="max-h-[34rem] divide-y divide-[var(--border)] overflow-y-auto">
-            {filtered.map((model: GatewayCatalogModel) => {
-              const byok = isByokModelId(model.id)
-              const hasUsagePricing =
-                model.type === 'language'
-                  ? model.inputPricePerMillion !== undefined && model.outputPricePerMillion !== undefined
-                  : gatewayCatalogModelHasSupportedPricing(model)
-              const mediaDefault = model.type === 'image'
-                ? defaultImageModelId === model.id
-                : model.type === 'video'
-                  ? defaultVideoModelId === model.id
-                  : false
-              return (
-              <div
+            {filtered.map((model) => (
+              <ModelCatalogRow
                 key={model.id}
-                className={`flex items-center gap-4 px-4 py-3 transition-colors ${
-                  hasUsagePricing || byok ? 'hover:bg-[var(--surface-muted)]' : 'opacity-55'
-                }`}
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span className="truncate text-sm font-medium text-[var(--foreground)]">{model.name}</span>
-                    {model.type === 'language' && model.tags.includes('vision') ? (
-                      <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-[#f0f0f0] text-zinc-700">
-                        <ScanEye size={11} strokeWidth={1.6} />
-                      </span>
-                    ) : null}
-                    {model.type === 'language' && model.tags.includes('reasoning') ? (
-                      <span className="inline-flex h-4 w-4 items-center justify-center rounded bg-[#f0f0f0] text-zinc-700">
-                        <Sparkles size={11} strokeWidth={1.6} />
-                      </span>
-                    ) : null}
-                    {model.type !== 'language' ? (
-                      <span>{formatMediaPrice(model)}</span>
-                    ) : byok ? (
-                      <span className="inline-flex items-center gap-1 rounded bg-[var(--surface-subtle)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--muted)]">
-                        <KeyRound size={10} /> BYOK
-                      </span>
-                    ) : null}
-                  </div>
-                  <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[var(--muted)]">
-                    <span className="capitalize">{model.provider}</span>
-                    <span>·</span>
-                    {byok ? (
-                      <span>Billed directly by provider</span>
-                    ) : hasUsagePricing ? (
-                      <>
-                        <span>{formatPrice(model.inputPricePerMillion)} in</span>
-                        <span>·</span>
-                        <span>{formatPrice(model.outputPricePerMillion)} out</span>
-                      </>
-                    ) : (
-                      <span>Pricing unavailable</span>
-                    )}
-                    {curatedIds.has(model.id) ? <><span>·</span><span>Default</span></> : null}
-                  </div>
-                </div>
-                {model.type === 'language' && enabled.has(model.id) ? (
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      aria-label={`Move ${model.name} up`}
-                      disabled={disabled}
-                      onClick={() => moveEnabledModel(model.id, -1)}
-                      className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--muted)] hover:bg-[var(--surface-subtle)] disabled:opacity-40"
-                    >
-                      <ChevronUp size={14} />
-                    </button>
-                    <button
-                      type="button"
-                      aria-label={`Move ${model.name} down`}
-                      disabled={disabled}
-                      onClick={() => moveEnabledModel(model.id, 1)}
-                      className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--muted)] hover:bg-[var(--surface-subtle)] disabled:opacity-40"
-                    >
-                      <ChevronDown size={14} />
-                    </button>
-                  </div>
-                ) : null}
-                {model.type === 'language' ? (
-                  <SettingsToggle
-                    checked={enabled.has(model.id)}
-                    disabled={
-                      disabled ||
-                      (!hasUsagePricing && !byok) ||
-                      (enabled.has(model.id) && enabled.size === 1)
-                    }
-                    onChange={() => toggle(model.id)}
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    disabled={disabled || !hasUsagePricing}
-                    onClick={() => onChange(model.type === 'image'
-                      ? { defaultImageModelId: model.id }
-                      : { defaultVideoModelId: model.id })}
-                    className={`inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors disabled:opacity-50 ${
-                      mediaDefault
-                        ? 'border-[var(--foreground)] bg-[var(--foreground)] text-[var(--background)]'
-                        : 'border-[var(--border)] bg-[var(--surface-subtle)] text-[var(--muted)] hover:text-[var(--foreground)]'
-                    }`}
-                  >
-                    {mediaDefault ? <Check size={12} /> : null}
-                    {mediaDefault ? 'Default' : 'Set default'}
-                  </button>
-                )}
-              </div>
-              )
-            })}
+                model={model}
+                curated={curatedIds.has(model.id)}
+                enabled={enabled}
+                defaultImageModelId={defaultImageModelId}
+                defaultVideoModelId={defaultVideoModelId}
+                disabled={disabled}
+                onToggle={toggle}
+                onMove={moveEnabledModel}
+                onChange={onChange}
+              />
+            ))}
             {!isLoading && filtered.length === 0 ? (
               <div className="px-4 py-10 text-center text-sm text-[var(--muted)]">No models match your search.</div>
             ) : null}

--- a/src/server/ai/model-policy-authority.ts
+++ b/src/server/ai/model-policy-authority.ts
@@ -53,8 +53,8 @@ export async function resolveAuthorizedModelIds(args: {
   // Populate AVAILABLE_MODELS from the full AI Gateway catalog before reading it.
   // Fail soft to curated fallbacks if the catalog is unreachable.
   try {
-    const { getGatewayLanguageCatalog } = await import('@/server/ai/gateway/gateway-catalog')
-    await getGatewayLanguageCatalog(args.forceCatalogRefresh ?? false)
+    const { getGatewayCatalog } = await import('@/server/ai/gateway/gateway-catalog')
+    await getGatewayCatalog(args.forceCatalogRefresh ?? false)
   } catch (error) {
     logger.warn('[model-policy] Gateway catalog unavailable; authorizing curated fallback models only', {
       error: error instanceof Error ? error.message : String(error),

--- a/src/server/app-api/v1/bootstrap/route.ts
+++ b/src/server/app-api/v1/bootstrap/route.ts
@@ -24,7 +24,7 @@ import {
   VIDEO_MODELS,
   registerGatewayCatalogModels,
 } from '@/shared/ai/gateway/model-data'
-import { getGatewayLanguageCatalog } from '@/server/ai/gateway/gateway-catalog'
+import { getGatewayCatalog } from '@/server/ai/gateway/gateway-catalog'
 import {
   formatOverlayConfigError,
   getOverlayRuntimeConfig,
@@ -102,8 +102,8 @@ export async function GET(request: NextRequest, context: AppApiRouteContext) {
           },
           { throwOnError: true },
         ).catch((_error) => DEFAULT_APP_SETTINGS),
-      getGatewayLanguageCatalog().catch((error) => {
-        logger.warn('[app/bootstrap] gateway language catalog unavailable; using curated fallback', error)
+      getGatewayCatalog().catch((error) => {
+        logger.warn('[app/bootstrap] gateway model catalog unavailable; using curated fallback', error)
         return null
       }),
     ])

--- a/src/server/app-api/v1/conversations/act/route.ts
+++ b/src/server/app-api/v1/conversations/act/route.ts
@@ -1059,6 +1059,7 @@ export async function POST(
     const _uiStream = toUIMessageStream({
       stream: result.stream,
       originalMessages: uiMessages,
+      sendSources: true,
       onError: (error: unknown) => {
         logger.error('[conversations/act] stream error', {
           requestId,

--- a/src/server/app-api/v1/model-catalog/route.ts
+++ b/src/server/app-api/v1/model-catalog/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import type { AppApiRouteContext } from '@/server/app-api/bff-context'
-import { getGatewayLanguageCatalog } from '@/server/ai/gateway/gateway-catalog'
+import { getGatewayCatalog } from '@/server/ai/gateway/gateway-catalog'
 import { getOverlayServerContext } from '@/server/bootstrap'
 import { resolveAuthorizedModelIds } from '@/server/ai/model-policy-authority'
 
@@ -18,7 +18,10 @@ export async function GET(request: NextRequest, context: AppApiRouteContext) {
     forceCatalogRefresh: force,
   })
   // Catalog is already warm from authorization; force was applied there when requested.
-  const models = (await getGatewayLanguageCatalog(false))
-    .filter((model) => authorized.chat.has(model.id))
+  const models = (await getGatewayCatalog(false)).filter((model) => (
+    (model.type === 'language' && authorized.chat.has(model.id))
+    || (model.type === 'image' && authorized.image.has(model.id))
+    || (model.type === 'video' && authorized.video.has(model.id))
+  ))
   return NextResponse.json({ models })
 }

--- a/src/shared/ai/gateway/gateway-catalog.ts
+++ b/src/shared/ai/gateway/gateway-catalog.ts
@@ -1,4 +1,4 @@
-import type { ChatModel } from '@/shared/ai/gateway/model-types'
+import type { ChatModel, ImageModel, VideoModel, VideoSubMode } from '@/shared/ai/gateway/model-types'
 
 export interface GatewayCatalogModel {
   id: string
@@ -32,5 +32,64 @@ export function gatewayCatalogModelToChatModel(model: GatewayCatalogModel): Chat
     supportsSearch: model.tags.includes('web-search'),
     supportsZeroDataRetention: false,
     pricePer1mTokens: blendedPrice,
+  }
+}
+
+function positivePrice(value: unknown): boolean {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN
+  return Number.isFinite(parsed) && parsed >= 0
+}
+
+export function gatewayCatalogModelHasSupportedPricing(model: GatewayCatalogModel): boolean {
+  if (model.type === 'language') {
+    return model.inputPricePerMillion !== undefined && model.outputPricePerMillion !== undefined
+  }
+  if (model.type === 'image') {
+    return positivePrice(model.pricing.image) || (
+      model.inputPricePerMillion !== undefined && model.outputPricePerMillion !== undefined
+    )
+  }
+  if (model.type === 'video') {
+    return Array.isArray(model.pricing.video_duration_pricing)
+      && model.pricing.video_duration_pricing.some((row) => (
+        !!row && typeof row === 'object' && positivePrice((row as Record<string, unknown>).cost_per_second)
+      ))
+  }
+  return false
+}
+
+export function gatewayCatalogModelToImageModel(model: GatewayCatalogModel): ImageModel {
+  return {
+    id: model.id,
+    name: model.name,
+    provider: model.provider,
+    description: model.description,
+    defaultAspectRatio: '1:1',
+  }
+}
+
+function inferVideoSubModes(model: GatewayCatalogModel): VideoSubMode[] {
+  const haystack = `${model.id} ${model.name}`.toLowerCase()
+  if (haystack.includes('motion-control')) return ['motion-control']
+  if (haystack.includes('r2v') || haystack.includes('reference-to-video')) return ['reference-to-video']
+  if (haystack.includes('i2v') || haystack.includes('image-to-video')) return ['image-to-video']
+  if (haystack.includes('t2v') || haystack.includes('text-to-video')) return ['text-to-video']
+  if (haystack.includes('grok-imagine-video')) return ['text-to-video', 'image-to-video', 'video-editing']
+  if (haystack.includes('veo')) return ['text-to-video', 'image-to-video']
+  return model.tags.includes('video-input')
+    ? ['text-to-video', 'image-to-video', 'video-editing']
+    : ['text-to-video']
+}
+
+export function gatewayCatalogModelToVideoModel(model: GatewayCatalogModel): VideoModel {
+  return {
+    id: model.id,
+    name: model.name,
+    provider: model.provider,
+    description: model.description,
+    billingUnit: Array.isArray(model.pricing.video_duration_pricing) ? 'per_second' : 'per_video',
+    defaultDuration: 8,
+    defaultAspectRatio: '16:9',
+    subModes: inferVideoSubModes(model),
   }
 }

--- a/src/shared/ai/gateway/model-data.test.ts
+++ b/src/shared/ai/gateway/model-data.test.ts
@@ -4,6 +4,8 @@ import test from 'node:test'
 import {
   getEnabledChatModels,
   getGatewayCatalogRevision,
+  IMAGE_MODELS,
+  VIDEO_MODELS,
   registerByokModels,
   registerGatewayCatalogModels,
 } from './model-data'
@@ -25,6 +27,16 @@ test('new gateway models appear before the free section for paid users', () => {
     },
     inputPricePerMillion: 0.3,
     outputPricePerMillion: 1.2,
+  }, {
+    id: UNKNOWN_ENABLED_ID,
+    gatewayId: UNKNOWN_ENABLED_ID,
+    name: 'Not Yet In Static Catalog',
+    type: 'language',
+    provider: 'vendor',
+    tags: ['vision', 'reasoning'],
+    pricing: { input: '0', output: '0' },
+    inputPricePerMillion: 0,
+    outputPricePerMillion: 0,
   }])
 
   const models = getEnabledChatModels([
@@ -36,6 +48,42 @@ test('new gateway models appear before the free section for paid users', () => {
     DYNAMIC_MODEL_ID,
     'openrouter/free',
   ])
+})
+
+test('registers only priced live image and video models', () => {
+  registerGatewayCatalogModels([
+    {
+      id: 'vendor/priced-image',
+      gatewayId: 'vendor/priced-image',
+      name: 'Priced Image',
+      type: 'image',
+      provider: 'vendor',
+      tags: ['image-generation'],
+      pricing: { image: '0.04' },
+    },
+    {
+      id: 'vendor/unpriced-image',
+      gatewayId: 'vendor/unpriced-image',
+      name: 'Unpriced Image',
+      type: 'image',
+      provider: 'vendor',
+      tags: ['image-generation'],
+      pricing: {},
+    },
+    {
+      id: 'vendor/priced-video-i2v',
+      gatewayId: 'vendor/priced-video-i2v',
+      name: 'Priced Video I2V',
+      type: 'video',
+      provider: 'vendor',
+      tags: ['video-input'],
+      pricing: { video_duration_pricing: [{ cost_per_second: '0.08' }] },
+    },
+  ])
+
+  assert.deepEqual(IMAGE_MODELS.map((model) => model.id), ['vendor/priced-image'])
+  assert.deepEqual(VIDEO_MODELS.map((model) => model.id), ['vendor/priced-video-i2v'])
+  assert.deepEqual(VIDEO_MODELS[0]?.subModes, ['image-to-video'])
 })
 
 test('free models remain first for free-tier users', () => {
@@ -50,7 +98,7 @@ test('free models remain first for free-tier users', () => {
   ])
 })
 
-test('enabled ids missing from the static catalog still appear (provisional)', () => {
+test('enabled ids registered from the gateway remain visible outside the static catalog', () => {
   const before = getGatewayCatalogRevision()
   const models = getEnabledChatModels(
     ['moonshotai/kimi-k2.6', UNKNOWN_ENABLED_ID, 'openrouter/free'],
@@ -59,7 +107,7 @@ test('enabled ids missing from the static catalog still appear (provisional)', (
   assert.ok(models.some((model) => model.id === UNKNOWN_ENABLED_ID))
   assert.ok(models.some((model) => model.id === 'moonshotai/kimi-k2.6'))
   assert.equal(models.length, 3)
-  // Registering the catalog should bump revision so React can refresh metadata.
+  // Re-registering the catalog should bump revision so React can refresh metadata.
   registerGatewayCatalogModels([{
     id: UNKNOWN_ENABLED_ID,
     gatewayId: UNKNOWN_ENABLED_ID,

--- a/src/shared/ai/gateway/model-data.ts
+++ b/src/shared/ai/gateway/model-data.ts
@@ -7,6 +7,9 @@ import {
 } from '@/shared/ai/gateway/model-types'
 import {
   gatewayCatalogModelToChatModel,
+  gatewayCatalogModelHasSupportedPricing,
+  gatewayCatalogModelToImageModel,
+  gatewayCatalogModelToVideoModel,
   type GatewayCatalogModel,
 } from '@/shared/ai/gateway/gateway-catalog'
 import {
@@ -164,6 +167,14 @@ export function registerGatewayCatalogModels(models: readonly GatewayCatalogMode
     registered.push(chatModel)
   }
   rebuildAvailableModels(registered, registeredIds)
+  const liveImageModels = models
+    .filter((model) => model.type === 'image' && gatewayCatalogModelHasSupportedPricing(model))
+    .map(gatewayCatalogModelToImageModel)
+  const liveVideoModels = models
+    .filter((model) => model.type === 'video' && gatewayCatalogModelHasSupportedPricing(model))
+    .map(gatewayCatalogModelToVideoModel)
+  if (liveImageModels.length > 0) IMAGE_MODELS.splice(0, IMAGE_MODELS.length, ...liveImageModels)
+  if (liveVideoModels.length > 0) VIDEO_MODELS.splice(0, VIDEO_MODELS.length, ...liveVideoModels)
   gatewayCatalogRegistered = true
 }
 
@@ -414,10 +425,8 @@ export function getEnabledChatModels(
 
 export const IMAGE_MODELS: ImageModel[] = [
   { id: 'openai/gpt-image-1.5', name: 'GPT Image 1.5', provider: 'openai', description: 'High quality, detailed', defaultAspectRatio: '1:1' },
-  { id: 'xai/grok-imagine-image-pro', name: 'Grok Image Pro', provider: 'xai', description: 'Photorealistic', defaultAspectRatio: '1:1' },
-  { id: 'xai/grok-imagine-image', name: 'Grok Image', provider: 'xai', description: 'Fast & creative', defaultAspectRatio: '1:1' },
-  { id: 'bfl/flux-2-max', name: 'FLUX 2 Max', provider: 'bfl', description: 'Premium quality', defaultAspectRatio: '1:1' },
-  { id: 'prodia/flux-fast-schnell', name: 'FLUX Schnell', provider: 'prodia', description: 'Ultra-fast, low cost', defaultAspectRatio: '1:1' },
+  { id: 'spacexai/grok-imagine-image-2.0', name: 'Grok Imagine Image 2.0', provider: 'spacexai', description: 'Photorealistic', defaultAspectRatio: '1:1' },
+  { id: 'spacexai/grok-imagine-image', name: 'Grok Imagine Image', provider: 'spacexai', description: 'Fast & creative', defaultAspectRatio: '1:1' },
   { id: 'bytedance/seedream-5.0-lite', name: 'Seedream 5.0 Lite', provider: 'bytedance', description: 'Fast generation', defaultAspectRatio: '1:1' },
   { id: 'bytedance/seedream-4.5', name: 'Seedream 4.5', provider: 'bytedance', description: 'Balanced quality', defaultAspectRatio: '1:1' },
 ]
@@ -433,7 +442,7 @@ export const VIDEO_MODELS: VideoModel[] = [
   { id: 'google/veo-3.1-generate-001', name: 'Veo 3.1', provider: 'google', description: 'Highest quality', billingUnit: 'per_video', defaultDuration: 8, defaultAspectRatio: '16:9', subModes: ['text-to-video', 'image-to-video'] },
   { id: 'google/veo-3.1-fast-generate-001', name: 'Veo 3.1 Fast', provider: 'google', description: 'Fast generation', billingUnit: 'per_video', defaultDuration: 8, defaultAspectRatio: '16:9', subModes: ['text-to-video', 'image-to-video'] },
   { id: 'bytedance/seedance-v1.5-pro', name: 'Seedance v1.5 Pro', provider: 'bytedance', description: 'Cinematic quality', billingUnit: 'per_second', defaultDuration: 10, defaultAspectRatio: '16:9', subModes: ['text-to-video', 'image-to-video'] },
-  { id: 'xai/grok-imagine-video', name: 'Grok Video', provider: 'xai', description: 'Creative & fast', billingUnit: 'per_video', defaultDuration: 8, defaultAspectRatio: '16:9', subModes: ['text-to-video', 'image-to-video', 'video-editing'] },
+  { id: 'spacexai/grok-imagine-video', name: 'Grok Video', provider: 'spacexai', description: 'Creative & fast', billingUnit: 'per_second', defaultDuration: 8, defaultAspectRatio: '16:9', subModes: ['text-to-video', 'image-to-video', 'video-editing'] },
   // Text-to-video only
   { id: 'alibaba/wan-v2.6-t2v', name: 'Wan v2.6', provider: 'alibaba', description: 'Versatile', billingUnit: 'per_second', defaultDuration: 8, defaultAspectRatio: '16:9', subModes: ['text-to-video'] },
   { id: 'klingai/kling-v2.6-t2v', name: 'Kling v2.6', provider: 'klingai', description: 'Cinematic motion', billingUnit: 'per_video', defaultDuration: 5, defaultAspectRatio: '16:9', subModes: ['text-to-video'] },


### PR DESCRIPTION
## Summary
- defer personal chat creation until the first message, and keep new DM/channel drafts out of the sidebar until they contain a message
- start first-message title generation as soon as the persisted conversation id exists
- normalize AI SDK source parts and settle stale tool/reasoning states when responses become terminal
- keep composer mentions inline and add distinct mention-type symbols
- explain Chat vs Work on hover
- register priced live Vercel AI Gateway image/video models and expose Chat, Image, and Video settings tabs
- replace four CodeQL-reported polynomial regular expressions with linear scanners and adversarial regression coverage

## Verification
- `npm --prefix packages/overlay-chat-core test` (33 passed)
- `npm --prefix packages/overlay-chat-react test` (16 passed)
- targeted chat/composer/model tests (11 passed)
- `npm run test:pricing` (6 passed)
- `npm run test:gateway-contracts` (22 passed)
- `npm run check:shared-isomorphic` (146 modules passed)
- `npm run check:web-complexity`
- `npm exec tsc -- --noEmit --incremental false`
- changed-file ESLint (0 errors; 3 pre-existing warnings)
- CI: required quality/security, CodeQL, Semgrep, secrets, dependency review, docs, schema/routing, and JS/TS analysis pass
- Vercel `overlay-web-postgres` preview production build (193 routes, Ready)
- remote Playwright parity gallery smoke, including completed tool, Sources control, image, and video states

## Known external limitation
The repository's `Vercel – overlay-landing` integration reports `Deployment was blocked`. The same exact head SHA builds successfully in CI and on the requested `overlay-web-postgres` Vercel project. No production deployment was performed.

No local Postgres or Docker work was run.
