### PR TITLE
Fix sent-message links, mentions, copy, and MCP lifecycle

### DIFF
--- a/packages/overlay-chat-core/src/tool-labels.test.ts
+++ b/packages/overlay-chat-core/src/tool-labels.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getDescriptiveToolLabel } from './tool-labels'
+
+test('MCP tool labels reflect running and terminal lifecycle states', () => {
+  const input = { toolName: 'read_tweet' }
+  assert.equal(getDescriptiveToolLabel('call_mcp_tool', input), 'Calling MCP tool · read_tweet')
+  assert.equal(getDescriptiveToolLabel('call_mcp_tool', input, 'complete'), 'Called MCP tool · read_tweet')
+  assert.equal(getDescriptiveToolLabel('call_mcp_tool', input, 'error'), 'MCP tool failed · read_tweet')
+  assert.equal(getDescriptiveToolLabel('call_mcp_tool', input, 'denied'), 'MCP tool denied · read_tweet')
+})
+
+test('MCP search labels settle after their result is available', () => {
+  const input = { query: 'read an exact tweet' }
+  assert.equal(
+    getDescriptiveToolLabel('search_mcp_tools', input, 'complete'),
+    'Searched MCP integrations for “read an exact tweet”',
+  )
+})

--- a/packages/overlay-chat-core/src/tool-labels.ts
+++ b/packages/overlay-chat-core/src/tool-labels.ts
@@ -117,37 +117,53 @@ function describeComposioIntegrationTool(toolName: string, input?: Record<string
 
 export type ToolLabelPhase = 'running' | 'complete' | 'error' | 'denied'
 
+const MCP_CALL_LABEL_BY_PHASE: Record<ToolLabelPhase, string> = {
+  running: 'Calling MCP tool',
+  complete: 'Called MCP tool',
+  error: 'MCP tool failed',
+  denied: 'MCP tool denied',
+}
+
+const MCP_SEARCH_LABEL_BY_PHASE: Record<ToolLabelPhase, string> = {
+  running: 'Searching MCP integrations',
+  complete: 'Searched MCP integrations',
+  error: 'MCP search failed',
+  denied: 'MCP search denied',
+}
+
+function clippedInputValue(
+  input: Record<string, unknown> | undefined,
+  key: string,
+  maxLength: number,
+): string | null {
+  const value = pickFirstStringFromInput(input, [key])
+  if (!value) return null
+  return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value
+}
+
+function describeMcpToolCall(input: Record<string, unknown> | undefined, phase: ToolLabelPhase): string {
+  const prefix = MCP_CALL_LABEL_BY_PHASE[phase]
+  const toolName = clippedInputValue(input, 'toolName', 48)
+  return toolName ? `${prefix} · ${toolName}` : prefix
+}
+
+function describeMcpToolSearch(input: Record<string, unknown> | undefined, phase: ToolLabelPhase): string {
+  const prefix = MCP_SEARCH_LABEL_BY_PHASE[phase]
+  const query = clippedInputValue(input, 'query', 56)
+  return query ? `${prefix} for “${query}”` : prefix
+}
+
 export function getDescriptiveToolLabel(
   toolName: string,
   toolInput?: Record<string, unknown>,
   phase: ToolLabelPhase = 'running',
 ): string {
   if (toolName === 'call_mcp_tool') {
-    const toolNameArg = pickFirstStringFromInput(toolInput, ['toolName'])
-    const clipped = toolNameArg
-      ? toolNameArg.length > 48 ? `${toolNameArg.slice(0, 48)}…` : toolNameArg
-      : null
-    const prefix = phase === 'complete'
-      ? 'Called MCP tool'
-      : phase === 'error'
-        ? 'MCP tool failed'
-        : phase === 'denied'
-          ? 'MCP tool denied'
-          : 'Calling MCP tool'
-    return clipped ? `${prefix} · ${clipped}` : prefix
+    return describeMcpToolCall(toolInput, phase)
   }
 
   if (toolName === 'search_mcp_tools') {
-    const q = pickFirstStringFromInput(toolInput, ['query'])
-    const clipped = q ? q.length > 56 ? `${q.slice(0, 56)}…` : q : null
-    const prefix = phase === 'complete'
-      ? 'Searched MCP integrations'
-      : phase === 'error'
-        ? 'MCP search failed'
-        : phase === 'denied'
-          ? 'MCP search denied'
-          : 'Searching MCP integrations'
-    return clipped ? `${prefix} for “${clipped}”` : prefix
+    return describeMcpToolSearch(toolInput, phase)
   }
 
   const map: Record<string, string> = {

--- a/packages/overlay-chat-core/src/tool-labels.ts
+++ b/packages/overlay-chat-core/src/tool-labels.ts
@@ -115,7 +115,41 @@ function describeComposioIntegrationTool(toolName: string, input?: Record<string
   return titleCaseUnderscore(toolName.replace(/^composio_/i, ''))
 }
 
-export function getDescriptiveToolLabel(toolName: string, toolInput?: Record<string, unknown>): string {
+export type ToolLabelPhase = 'running' | 'complete' | 'error' | 'denied'
+
+export function getDescriptiveToolLabel(
+  toolName: string,
+  toolInput?: Record<string, unknown>,
+  phase: ToolLabelPhase = 'running',
+): string {
+  if (toolName === 'call_mcp_tool') {
+    const toolNameArg = pickFirstStringFromInput(toolInput, ['toolName'])
+    const clipped = toolNameArg
+      ? toolNameArg.length > 48 ? `${toolNameArg.slice(0, 48)}…` : toolNameArg
+      : null
+    const prefix = phase === 'complete'
+      ? 'Called MCP tool'
+      : phase === 'error'
+        ? 'MCP tool failed'
+        : phase === 'denied'
+          ? 'MCP tool denied'
+          : 'Calling MCP tool'
+    return clipped ? `${prefix} · ${clipped}` : prefix
+  }
+
+  if (toolName === 'search_mcp_tools') {
+    const q = pickFirstStringFromInput(toolInput, ['query'])
+    const clipped = q ? q.length > 56 ? `${q.slice(0, 56)}…` : q : null
+    const prefix = phase === 'complete'
+      ? 'Searched MCP integrations'
+      : phase === 'error'
+        ? 'MCP search failed'
+        : phase === 'denied'
+          ? 'MCP search denied'
+          : 'Searching MCP integrations'
+    return clipped ? `${prefix} for “${clipped}”` : prefix
+  }
+
   const map: Record<string, string> = {
     browser_run_task: 'Browsing the web',
     interactive_browser_session: 'Browsing the web',
@@ -134,8 +168,6 @@ export function getDescriptiveToolLabel(toolName: string, toolInput?: Record<str
     generate_image: 'Generating an image',
     generate_video: 'Generating a video',
     run_daytona_sandbox: 'Running your workspace',
-    search_mcp_tools: 'Searching MCP integrations',
-    call_mcp_tool: 'Calling MCP tool',
   }
   if (map[toolName]) return map[toolName]!
 
@@ -160,22 +192,6 @@ export function getDescriptiveToolLabel(toolName: string, toolInput?: Record<str
     if (o) {
       const clipped = o.length > 72 ? `${o.slice(0, 72)}…` : o
       return `Researching: “${clipped}”`
-    }
-  }
-
-  if (toolName === 'call_mcp_tool' && toolInput) {
-    const toolNameArg = pickFirstStringFromInput(toolInput, ['toolName'])
-    if (toolNameArg) {
-      const clipped = toolNameArg.length > 48 ? `${toolNameArg.slice(0, 48)}…` : toolNameArg
-      return `MCP: ${clipped}`
-    }
-  }
-
-  if (toolName === 'search_mcp_tools' && toolInput) {
-    const q = pickFirstStringFromInput(toolInput, ['query'])
-    if (q) {
-      const clipped = q.length > 56 ? `${q.slice(0, 56)}…` : q
-      return `Searching MCP for “${clipped}”`
     }
   }
 

--- a/packages/overlay-chat-react/src/components/exchange/tool-call-rows.tsx
+++ b/packages/overlay-chat-react/src/components/exchange/tool-call-rows.tsx
@@ -22,9 +22,19 @@ export function ToolCallRowWithReasoning({
   connectBottom?: boolean
 }) {
   const toolDone = TOOL_UI_DONE_STATES.has(block.state)
-  const err = block.state === 'output-error' || block.state === 'output-denied'
+  const err = block.state === 'input-error' || block.state === 'output-error' || block.state === 'output-denied'
   const running = !toolDone && !err
-  const label = getDescriptiveToolLabel(block.name, block.toolInput)
+  const label = getDescriptiveToolLabel(
+    block.name,
+    block.toolInput,
+    block.state === 'output-denied'
+      ? 'denied'
+      : block.state === 'output-error' || block.state === 'input-error'
+        ? 'error'
+        : toolDone
+          ? 'complete'
+          : 'running',
+  )
 
   const pad = variant === 'nested' ? 'py-0.5' : 'py-1'
 
@@ -105,7 +115,9 @@ export function ToolCallsCollapsedGroup({
   const anyRunning =
     tools.some((t) => !TOOL_UI_DONE_STATES.has(t.state)) ||
     items.some((it) => it.kind === 'reasoning' && it.state !== 'done')
-  const anyErr = tools.some((t) => t.state === 'output-error' || t.state === 'output-denied')
+  const anyErr = tools.some(
+    (t) => t.state === 'input-error' || t.state === 'output-error' || t.state === 'output-denied',
+  )
   const summary =
     anyErr
       ? `${n} tools called`

--- a/packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx
+++ b/packages/overlay-chat-react/src/components/transcript/ChatExchange.tsx
@@ -34,6 +34,7 @@ import type { GeneratedUiData } from '@overlay/chat-core/generated-ui'
 import { UsageExhaustedNotice } from '../UsageExhaustedNotice'
 import { ExchangeActions } from './ExchangeActions'
 import { ExchangeLoadingState, exchangeLoadingPresentation } from './ExchangeLoadingState'
+import { UserMessageActions } from './UserMessageActions'
 import type { ChatTranscriptPresentation } from './ChatTranscript'
 import { useChatExchangeSources } from './chat-exchange-sources'
 
@@ -223,9 +224,12 @@ export function ChatExchange({
               </div>
             )}
             {showTextBubble && (
-              <UserMessageBubble className="ml-auto max-w-full" contentClassName="whitespace-normal">
-                <MarkdownMessage text={userBodyText} isStreaming={false} mentions={userMentions} />
-              </UserMessageBubble>
+              <>
+                <UserMessageBubble className="ml-auto max-w-full" contentClassName="whitespace-normal">
+                  <MarkdownMessage text={userBodyText} isStreaming={false} mentions={userMentions} />
+                </UserMessageBubble>
+                <UserMessageActions markdown={userBodyText} disabled={isExiting} />
+              </>
             )}
           </div>
         </div>

--- a/packages/overlay-chat-react/src/components/transcript/ChatTranscript.test.tsx
+++ b/packages/overlay-chat-react/src/components/transcript/ChatTranscript.test.tsx
@@ -6,6 +6,7 @@ import type { ChatTranscriptView } from '@overlay/chat-core'
 import { ChatTranscript } from './ChatTranscript'
 import { ExchangeActions } from './ExchangeActions'
 import { MediaExchange } from './MediaExchange'
+import { UserMessageActions } from './UserMessageActions'
 
 test('ChatTranscript renders normalized exchanges in contract order without wrapper markup', () => {
   const view: ChatTranscriptView = {
@@ -234,4 +235,12 @@ test('exchange actions keep branch and sources immediately after reply', () => {
   assert.ok(replyIndex >= 0)
   assert.ok(replyIndex < branchIndex)
   assert.ok(branchIndex < sourcesIndex)
+})
+
+test('sent-message actions copy the original Markdown payload', () => {
+  const markdown = '[x.com](<https://x.com/todaywasawesome/status/1961234567890123456>)'
+  const markup = renderToStaticMarkup(<UserMessageActions markdown={markdown} />)
+
+  assert.match(markup, /aria-label="Copy sent message as Markdown"/)
+  assert.doesNotMatch(markup, /disabled=""/)
 })

--- a/packages/overlay-chat-react/src/components/transcript/ChatTranscript.test.tsx
+++ b/packages/overlay-chat-react/src/components/transcript/ChatTranscript.test.tsx
@@ -68,6 +68,13 @@ test('ChatTranscript renders normalized exchanges in contract order without wrap
   assert.equal(markup, '<span data-turn="turn-1">One</span><span data-turn="turn-2">Two</span>')
 })
 
+test('sent-message copy actions use the shared touch visibility class', () => {
+  const markup = renderToStaticMarkup(<UserMessageActions markdown="Hello **world**" />)
+
+  assert.match(markup, /chat-exchange-actions--hover/)
+  assert.match(markup, /aria-label="Copy sent message as Markdown"/)
+})
+
 test('ChatTranscript inserts day dividers when consecutive exchanges fall on different days', () => {
   const view: ChatTranscriptView = {
     version: 1,

--- a/packages/overlay-chat-react/src/components/transcript/UserMessageActions.tsx
+++ b/packages/overlay-chat-react/src/components/transcript/UserMessageActions.tsx
@@ -10,7 +10,7 @@ export function UserMessageActions({
   if (!markdown.trim()) return null
 
   return (
-    <div className="flex items-center justify-end pr-1 opacity-0 transition-opacity group-hover/exchange:opacity-100 focus-within:opacity-100">
+    <div className="chat-exchange-actions--hover flex items-center justify-end pr-1 opacity-0 transition-opacity group-hover/exchange:opacity-100 focus-within:opacity-100">
       <FlashCopyIconButton
         copyText={markdown}
         disabled={disabled}

--- a/packages/overlay-chat-react/src/components/transcript/UserMessageActions.tsx
+++ b/packages/overlay-chat-react/src/components/transcript/UserMessageActions.tsx
@@ -1,0 +1,21 @@
+import { FlashCopyIconButton } from '../DraftReviewModal'
+
+export function UserMessageActions({
+  markdown,
+  disabled = false,
+}: {
+  markdown: string
+  disabled?: boolean
+}) {
+  if (!markdown.trim()) return null
+
+  return (
+    <div className="flex items-center justify-end pr-1 opacity-0 transition-opacity group-hover/exchange:opacity-100 focus-within:opacity-100">
+      <FlashCopyIconButton
+        copyText={markdown}
+        disabled={disabled}
+        ariaLabel="Copy sent message as Markdown"
+      />
+    </div>
+  )
+}

--- a/src/components/mentions/MentionPopup.test.tsx
+++ b/src/components/mentions/MentionPopup.test.tsx
@@ -34,3 +34,33 @@ test('the mention menu calls the people and agent directory Members', () => {
     Object.defineProperty(globalThis, 'window', { configurable: true, value: originalWindow })
   }
 })
+
+test('a top-level mention query shows loading instead of a false empty result', () => {
+  const originalWindow = globalThis.window
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { innerWidth: 1280, innerHeight: 800 },
+  })
+
+  try {
+    const html = renderToStaticMarkup(
+      <MentionPopup
+        categories={[]}
+        loading
+        position={{ x: 24, y: 24 }}
+        onSelect={() => undefined}
+        onUploadFile={() => undefined}
+        onClose={() => undefined}
+        query="fire"
+        availableTypes={['mcp']}
+        selectedCategory={null}
+        onSelectedCategoryChange={() => undefined}
+      />,
+    )
+    assert.match(html, /role="status"/)
+    assert.match(html, /Loading mentions/)
+    assert.doesNotMatch(html, /No results/)
+  } finally {
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: originalWindow })
+  }
+})

--- a/src/components/mentions/MentionPopup.tsx
+++ b/src/components/mentions/MentionPopup.tsx
@@ -232,9 +232,10 @@ export function MentionPopup({
       )}
 
       <div className="overflow-y-auto" role="listbox" id="mention-listbox" aria-label="Mention suggestions">
-        {loading && categories.length === 0 && selectedCategory !== null ? (
-          <div className="flex items-center justify-center py-6">
+        {loading && isEmptyResults ? (
+          <div className="flex items-center justify-center gap-2 py-6 text-xs text-[var(--muted-light)]" role="status" aria-live="polite">
             <div className="h-4 w-4 animate-spin rounded-full border-2 border-[var(--muted)] border-t-transparent" />
+            <span>Loading mentions...</span>
           </div>
         ) : isEmptyResults && (query.trim() !== '' || selectedCategory !== null) ? (
           <>

--- a/src/features/chat/components/chat-interface/MentionInput.tsx
+++ b/src/features/chat/components/chat-interface/MentionInput.tsx
@@ -12,7 +12,7 @@ import {
 import { MentionPopup } from '@/components/mentions/MentionPopup'
 import { useMentionData } from './useMentionData'
 import type { MentionCategory, MentionItem, MentionType } from '@/shared/knowledge/mention-types'
-import { joinComposerMarkdownSegments } from './composer-markdown'
+import { composerAnchorToMarkdown, joinComposerMarkdownSegments } from './composer-markdown'
 
 export type MentionInputFormatCommand =
   | 'heading1'
@@ -176,6 +176,9 @@ function inlineNodeToMarkdown(node: Node): string {
   }
   if (element.tagName === 'BR') return '\n'
   const content = Array.from(element.childNodes).map(inlineNodeToMarkdown).join('')
+  if (element.tagName === 'A') {
+    return composerAnchorToMarkdown(content, element.getAttribute('href') ?? '')
+  }
   if (element.tagName === 'STRONG' || element.tagName === 'B') return `**${content}**`
   if (element.tagName === 'EM' || element.tagName === 'I') return `*${content}*`
   if (element.tagName === 'S' || element.tagName === 'DEL' || element.tagName === 'STRIKE') return `~~${content}~~`
@@ -623,6 +626,7 @@ export const MentionInput = forwardRef<MentionInputHandle, MentionInputProps>(
     const [mentionQuery, setMentionQuery] = useState('')
     const [popupPosition, setPopupPosition] = useState<{ x: number; y: number } | null>(null)
     const [categories, setCategories] = useState<MentionCategory[]>([])
+    const [mentionSearching, setMentionSearching] = useState(false)
     const [selectedCategory, setSelectedCategory] = useState<MentionType | null>(null)
     const [activeOptionId, setActiveOptionId] = useState<string | null>(null)
     const triggerOffsetRef = useRef<number>(0)
@@ -631,6 +635,7 @@ export const MentionInput = forwardRef<MentionInputHandle, MentionInputProps>(
     const lastValueRef = useRef(value)
     /** Guards against recursive handleInput calls from dispatchEditorInput in live markdown formatting. */
     const formattingAppliedRef = useRef(false)
+    const searchRequestRef = useRef(0)
     /** True when the @ that opened the current popup was inserted by the @ button rather
      * than typed by the user; on close-without-select we strip that orphan @. */
     const buttonInsertedAtRef = useRef(false)
@@ -640,6 +645,7 @@ export const MentionInput = forwardRef<MentionInputHandle, MentionInputProps>(
       availableTypes: defaultAvailableTypes,
       search: searchDefaultCategories,
       loading,
+      fetchAllData,
     } = useMentionData()
     const availableTypes = useMemo(() => Array.from(new Set([
       ...defaultAvailableTypes,
@@ -658,6 +664,19 @@ export const MentionInput = forwardRef<MentionInputHandle, MentionInputProps>(
       for (const category of extraCategories) byType.set(category.type, category)
       return Array.from(byType.values())
     }, [mentionCategories, searchDefaultCategories])
+
+    const runMentionSearch = useCallback((query: string) => {
+      const requestId = ++searchRequestRef.current
+      setCategories([])
+      setMentionSearching(true)
+      void search(query)
+        .then((nextCategories) => {
+          if (searchRequestRef.current === requestId) setCategories(nextCategories)
+        })
+        .finally(() => {
+          if (searchRequestRef.current === requestId) setMentionSearching(false)
+        })
+    }, [search])
 
     // Sync explicit external value commands into the editor (clear on send,
     // populate restored draft after hydration). Normal typing stays local to
@@ -803,13 +822,13 @@ export const MentionInput = forwardRef<MentionInputHandle, MentionInputProps>(
           if (coords) {
             setPopupPosition(coords)
             setShowPopup(true)
-            void search(mentionState.query).then(setCategories)
+            runMentionSearch(mentionState.query)
           }
         } else {
           setShowPopup(false)
         }
       }
-    }, [onChange, onMentionsChange, search])
+    }, [onChange, onMentionsChange, runMentionSearch])
 
     const syncEditorEmptyState = useCallback(() => {
       const el = editorRef.current
@@ -1137,6 +1156,42 @@ function exitBlockToParagraph(block: HTMLElement, sel: Selection, el: HTMLDivEle
           return
         }
 
+        // Rich clipboards often expose a shortened label (for example `x.com`)
+        // in text/plain while keeping the exact tweet/article URL only in the
+        // anchor href. Preserve that destination in the editor DOM so extraction
+        // serializes portable Markdown instead of permanently storing the host.
+        const richHtml = e.clipboardData.getData('text/html')
+        if (richHtml) {
+          const template = document.createElement('template')
+          template.innerHTML = richHtml
+          const anchors = template.content.querySelectorAll('a[href]')
+          const anchor = anchors.length === 1 ? anchors[0] : null
+          const anchorLabel = anchor?.textContent?.trim() ?? ''
+          const richText = template.content.textContent?.trim() ?? ''
+          const safeHref = anchor
+            ? composerAnchorToMarkdown('', anchor.getAttribute('href') ?? '')
+            : ''
+          if (anchor && safeHref && anchorLabel && richText === anchorLabel) {
+            const link = document.createElement('a')
+            link.href = safeHref
+            link.textContent = anchorLabel
+            link.className = 'text-[#2563eb] underline underline-offset-2'
+            const sel = window.getSelection()
+            if (sel && sel.rangeCount > 0) {
+              const range = sel.getRangeAt(0)
+              range.deleteContents()
+              range.insertNode(link)
+              range.setStartAfter(link)
+              range.collapse(true)
+              sel.removeAllRanges()
+              sel.addRange(range)
+              resizeEditorElement(el)
+              dispatchEditorInput(el)
+              return
+            }
+          }
+        }
+
         // If the pasted text contains markdown syntax, parse and insert as
         // formatted HTML so the composer renders it visually.
         const hasMarkdown = /(^|\n)(#{1,3}\s|>\s|[-*]\s|\d+\.\s|```)|\*\*[^*]+\*\*|`[^`]+`|~~[^~]+~~|(^|[\s(])\*[^*\n]+\*(?=$|[\s).,!?:;])/m.test(text)
@@ -1178,7 +1233,9 @@ function exitBlockToParagraph(block: HTMLElement, sel: Selection, el: HTMLDivEle
     )
 
     const closePopup = useCallback(() => {
+      searchRequestRef.current += 1
       setShowPopup(false)
+      setMentionSearching(false)
       setMentionQuery('')
       setSelectedCategory(null)
       // If the @ was inserted by the button and no item was selected, strip the
@@ -1222,7 +1279,10 @@ function exitBlockToParagraph(block: HTMLElement, sel: Selection, el: HTMLDivEle
           contentEditable={!disabled}
           suppressContentEditableWarning
           onInput={handleInput}
-          onFocus={syncEditorEmptyState}
+          onFocus={() => {
+            syncEditorEmptyState()
+            void fetchAllData()
+          }}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           onCompositionStart={() => { isComposingRef.current = true }}
@@ -1242,7 +1302,7 @@ function exitBlockToParagraph(block: HTMLElement, sel: Selection, el: HTMLDivEle
         {showPopup && (
           <MentionPopup
             categories={categories}
-            loading={loading}
+            loading={mentionSearching || loading}
             position={popupPosition}
             onSelect={handleSelect}
             onUploadFile={() => {

--- a/src/features/chat/components/chat-interface/MentionInput.tsx
+++ b/src/features/chat/components/chat-interface/MentionInput.tsx
@@ -215,6 +215,85 @@ function extractMarkdownFromElement(el: HTMLDivElement): string {
   }))
 }
 
+const RICH_PASTE_ALLOWED_TAGS = new Set([
+  'A',
+  'B',
+  'BLOCKQUOTE',
+  'BR',
+  'CODE',
+  'DEL',
+  'DIV',
+  'EM',
+  'H1',
+  'H2',
+  'H3',
+  'I',
+  'LI',
+  'OL',
+  'P',
+  'PRE',
+  'S',
+  'STRIKE',
+  'STRONG',
+  'UL',
+])
+
+const RICH_PASTE_IGNORED_TAGS = new Set([
+  'IFRAME',
+  'NOSCRIPT',
+  'OBJECT',
+  'SCRIPT',
+  'STYLE',
+  'TEMPLATE',
+])
+
+function buildSafeRichPasteFragment(html: string): DocumentFragment | null {
+  const source = document.createElement('template')
+  source.innerHTML = html
+  const fragment = document.createDocumentFragment()
+  let preservedLinkCount = 0
+
+  const appendSafeNode = (node: Node, parent: Node): void => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      parent.appendChild(document.createTextNode(node.textContent ?? ''))
+      return
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return
+
+    const element = node as HTMLElement
+    if (RICH_PASTE_IGNORED_TAGS.has(element.tagName)) return
+
+    if (element.tagName === 'A') {
+      const safeHref = composerAnchorToMarkdown('', element.getAttribute('href') ?? '')
+      if (!safeHref) {
+        for (const child of Array.from(element.childNodes)) appendSafeNode(child, parent)
+        return
+      }
+
+      const link = document.createElement('a')
+      link.href = safeHref
+      link.className = 'text-[#2563eb] underline underline-offset-2'
+      for (const child of Array.from(element.childNodes)) appendSafeNode(child, link)
+      if (!link.textContent?.trim()) link.textContent = safeHref
+      parent.appendChild(link)
+      preservedLinkCount += 1
+      return
+    }
+
+    if (!RICH_PASTE_ALLOWED_TAGS.has(element.tagName)) {
+      for (const child of Array.from(element.childNodes)) appendSafeNode(child, parent)
+      return
+    }
+
+    const safeElement = document.createElement(element.tagName.toLowerCase())
+    for (const child of Array.from(element.childNodes)) appendSafeNode(child, safeElement)
+    parent.appendChild(safeElement)
+  }
+
+  for (const child of Array.from(source.content.childNodes)) appendSafeNode(child, fragment)
+  return preservedLinkCount > 0 ? fragment : null
+}
+
 const MENTION_ICON_PATHS: Record<MentionType, string[]> = {
   person: ['M20 21a8 8 0 0 0-16 0', 'M12 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8'],
   file: ['M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5z', 'M14 2v6h6', 'M8 13h8', 'M8 17h8'],
@@ -1162,26 +1241,15 @@ function exitBlockToParagraph(block: HTMLElement, sel: Selection, el: HTMLDivEle
         // serializes portable Markdown instead of permanently storing the host.
         const richHtml = e.clipboardData.getData('text/html')
         if (richHtml) {
-          const template = document.createElement('template')
-          template.innerHTML = richHtml
-          const anchors = template.content.querySelectorAll('a[href]')
-          const anchor = anchors.length === 1 ? anchors[0] : null
-          const anchorLabel = anchor?.textContent?.trim() ?? ''
-          const richText = template.content.textContent?.trim() ?? ''
-          const safeHref = anchor
-            ? composerAnchorToMarkdown('', anchor.getAttribute('href') ?? '')
-            : ''
-          if (anchor && safeHref && anchorLabel && richText === anchorLabel) {
-            const link = document.createElement('a')
-            link.href = safeHref
-            link.textContent = anchorLabel
-            link.className = 'text-[#2563eb] underline underline-offset-2'
+          const fragment = buildSafeRichPasteFragment(richHtml)
+          if (fragment) {
             const sel = window.getSelection()
             if (sel && sel.rangeCount > 0) {
               const range = sel.getRangeAt(0)
               range.deleteContents()
-              range.insertNode(link)
-              range.setStartAfter(link)
+              const lastNode = fragment.lastChild
+              range.insertNode(fragment)
+              if (lastNode) range.setStartAfter(lastNode)
               range.collapse(true)
               sel.removeAllRanges()
               sel.addRange(range)

--- a/src/features/chat/components/chat-interface/composer-markdown.test.ts
+++ b/src/features/chat/components/chat-interface/composer-markdown.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { joinComposerMarkdownSegments } from './composer-markdown'
+import { composerAnchorToMarkdown, joinComposerMarkdownSegments } from './composer-markdown'
 
 test('keeps text, links, and mention chips on the same composer line', () => {
   assert.equal(joinComposerMarkdownSegments([
@@ -17,4 +17,18 @@ test('preserves real block boundaries', () => {
     { markdown: 'First paragraph', block: true },
     { markdown: '- item', block: true },
   ]), 'First paragraph\n- item')
+})
+
+test('preserves a shortened anchor label and its full destination in Markdown', () => {
+  assert.equal(
+    composerAnchorToMarkdown(
+      'x.com',
+      'https://x.com/todaywasawesome/status/1961234567890123456?s=20&t=overlay',
+    ),
+    '[x.com](<https://x.com/todaywasawesome/status/1961234567890123456?s=20&t=overlay>)',
+  )
+})
+
+test('does not serialize unsafe anchor protocols', () => {
+  assert.equal(composerAnchorToMarkdown('click me', 'javascript:alert(1)'), 'click me')
 })

--- a/src/features/chat/components/chat-interface/composer-markdown.ts
+++ b/src/features/chat/components/chat-interface/composer-markdown.ts
@@ -3,6 +3,32 @@ export interface ComposerMarkdownSegment {
   block: boolean
 }
 
+function safeComposerLinkHref(rawHref: string): string | null {
+  try {
+    const url = new URL(rawHref)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null
+  } catch {
+    return null
+  }
+}
+
+function escapeMarkdownLinkLabel(label: string): string {
+  return label.replace(/([\\\[\]])/g, '\\$1')
+}
+
+/**
+ * Preserve an anchor's destination when the contenteditable exposes only its
+ * shortened visible label. Returning Markdown keeps the copied/sent payload
+ * portable while the composer and transcript remain free to truncate display.
+ */
+export function composerAnchorToMarkdown(label: string, rawHref: string): string {
+  const href = safeComposerLinkHref(rawHref)
+  const visibleLabel = label.trim()
+  if (!href) return visibleLabel
+  if (!visibleLabel || visibleLabel === rawHref || visibleLabel === href) return href
+  return `[${escapeMarkdownLinkLabel(visibleLabel)}](<${href.replace(/>/g, '%3E')}>)`
+}
+
 /** Join contenteditable root nodes without turning adjacent inline chips into paragraphs. */
 export function joinComposerMarkdownSegments(segments: readonly ComposerMarkdownSegment[]): string {
   let markdown = ''

--- a/src/features/chat/components/chat-interface/useMentionData.ts
+++ b/src/features/chat/components/chat-interface/useMentionData.ts
@@ -1,8 +1,10 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useOverlayCapabilities } from '@/components/providers/CapabilitiesProvider'
 import { overlayAppClient } from '@/shared/app/overlay-app-client'
 import { unwrapPaginatedData } from '@/shared/api/pagination'
+import { getActiveChatListWorkspace } from '@/shared/chat/chat-list-cache'
 import type { MentionCategory, MentionItem, MentionType } from '@/shared/knowledge/mention-types'
+import { ACTIVE_WORKSPACE_HEADER } from '@/shared/workspaces/constants'
 
 interface CachedData {
   cacheKey: string
@@ -26,6 +28,17 @@ const CATEGORY_META: Array<{ type: MentionType; label: string; icon: string }> =
   { type: 'mcp', label: 'MCP Servers', icon: 'Server' },
   { type: 'chat', label: 'Chats', icon: 'MessageSquare' },
 ]
+
+const MENTION_CACHE_TTL_MS = 60_000
+const mentionCache = new Map<string, { data: CachedData; cachedAt: number }>()
+const mentionRequests = new Map<string, Promise<CachedData>>()
+
+function workspaceInit(workspaceId: string | null, init: RequestInit = {}): RequestInit {
+  if (!workspaceId) return init
+  const headers = new Headers(init.headers)
+  headers.set(ACTIVE_WORKSPACE_HEADER, workspaceId)
+  return { ...init, headers }
+}
 
 function supportedMentionTypes(capabilities: ReturnType<typeof useOverlayCapabilities>['capabilities']): MentionType[] {
   return CATEGORY_META
@@ -75,145 +88,149 @@ export function useMentionData() {
   const availableTypes = useMemo(() => supportedMentionTypes(capabilities), [capabilities])
   const cacheKey = useMemo(() => mentionCapabilityCacheKey(capabilities), [capabilities])
   const [loading, setLoading] = useState(false)
-  const cacheRef = useRef<CachedData | null>(null)
-  const fetchingRef = useRef(false)
 
   const fetchAllData = useCallback(async (): Promise<CachedData> => {
-    if (cacheRef.current?.cacheKey === cacheKey) return cacheRef.current
+    const workspaceId = getActiveChatListWorkspace()
+    const requestKey = `${workspaceId ?? 'personal'}:${cacheKey}`
+    const cached = mentionCache.get(requestKey)
+    if (cached && Date.now() - cached.cachedAt < MENTION_CACHE_TTL_MS) return cached.data
 
-    if (fetchingRef.current) {
-      // Wait for in-flight fetch
-      await new Promise<void>((resolve) => {
-        const check = () => {
-          if (!fetchingRef.current) { resolve(); return }
-          setTimeout(check, 50)
-        }
-        check()
-      })
-      return cacheRef.current!
+    setLoading(true)
+    const existingRequest = mentionRequests.get(requestKey)
+    if (existingRequest) {
+      try {
+        return await existingRequest
+      } finally {
+        setLoading(false)
+      }
     }
 
-    fetchingRef.current = true
-    setLoading(true)
+    const init = workspaceInit(workspaceId)
+    const request = (async () => {
+      try {
+        const [filesRes, knowledgeRes, connectorsRes, automationsRes, skillsRes, mcpsRes, chatsRes] =
+          await Promise.allSettled([
+            capabilities.files
+              ? overlayAppClient.files.getResponse({ limit: 100, summary: true }, init).then((r) => r.ok ? r.json() : [])
+              : Promise.resolve([]),
+            capabilities.knowledge
+              ? overlayAppClient.knowledgeBases.list(init)
+              : Promise.resolve({ knowledgeBases: [] }),
+            capabilities.integrations
+              ? overlayAppClient.integrations.getResponse(undefined, init).then((r) => r.ok ? r.json() : { items: [] })
+              : Promise.resolve({ items: [] }),
+            capabilities.automations
+              ? overlayAppClient.automations.getResponse({ limit: 100 }, init).then((r) => r.ok ? r.json() : [])
+              : Promise.resolve([]),
+            capabilities.skills
+              ? overlayAppClient.skills.getResponse({ limit: 100 }, init).then((r) => r.ok ? r.json() : [])
+              : Promise.resolve([]),
+            capabilities.mcpServers
+              ? overlayAppClient.mcpServers.getResponse({ limit: 100 }, init).then((r) => r.ok ? r.json() : [])
+              : Promise.resolve([]),
+            capabilities.chat
+              ? overlayAppClient.conversations.getResponse({ limit: 100 }, init).then((r) => r.ok ? r.json() : [])
+              : Promise.resolve([]),
+          ])
 
-    try {
-      const [filesRes, knowledgeRes, connectorsRes, automationsRes, skillsRes, mcpsRes, chatsRes] =
-        await Promise.allSettled([
-          capabilities.files
-            ? overlayAppClient.files.getResponse({ limit: 100, summary: true }).then((r) => r.ok ? r.json() : [])
-            : Promise.resolve([]),
-          capabilities.knowledge
-            ? overlayAppClient.knowledgeBases.list()
-            : Promise.resolve({ knowledgeBases: [] }),
-          capabilities.integrations
-            ? overlayAppClient.integrations.getResponse().then((r) => r.ok ? r.json() : { items: [] })
-            : Promise.resolve({ items: [] }),
-          capabilities.automations
-            ? overlayAppClient.automations.getResponse({ limit: 100 }).then((r) => r.ok ? r.json() : [])
-            : Promise.resolve([]),
-          capabilities.skills
-            ? overlayAppClient.skills.getResponse({ limit: 100 }).then((r) => r.ok ? r.json() : [])
-            : Promise.resolve([]),
-          capabilities.mcpServers
-            ? overlayAppClient.mcpServers.getResponse({ limit: 100 }).then((r) => r.ok ? r.json() : [])
-            : Promise.resolve([]),
-          capabilities.chat
-            ? overlayAppClient.conversations.getResponse({ limit: 100 }).then((r) => r.ok ? r.json() : [])
-            : Promise.resolve([]),
-        ])
-
-      const files: MentionItem[] = (
-        filesRes.status === 'fulfilled'
-          ? unwrapPaginatedData<{ _id: string; name?: string; kind?: string; mimeType?: string }>(filesRes.value)
-          : []
-      ).map((f: { _id: string; name?: string; kind?: string; mimeType?: string }) => ({
-        type: 'file' as const,
-        id: f._id,
-        name: f.name || 'Untitled',
-        description: f.kind || f.mimeType || 'file',
-        icon: 'FileText',
-      }))
-
-      const knowledgeRaw = knowledgeRes.status === 'fulfilled' ? knowledgeRes.value : { knowledgeBases: [] }
-      const knowledge: MentionItem[] = (knowledgeRaw.knowledgeBases || []).map(
-        (base: { id: string; title: string; description?: string; kind?: string }) => ({
-          type: 'knowledge' as const,
-          id: base.id,
-          name: base.title,
-          description: base.description || base.kind || 'Knowledge base',
-          icon: 'BookOpen',
-        }),
-      )
-
-      const connectorsRaw = connectorsRes.status === 'fulfilled' ? connectorsRes.value : { items: [] }
-      const connectors: MentionItem[] = (connectorsRaw.items || []).map(
-        (c: { slug: string; name: string; description?: string; logoUrl?: string }) => ({
-          type: 'connector' as const,
-          id: c.slug,
-          name: c.name,
-          description: c.description || '',
-          icon: 'Plug',
-          logoUrl: c.logoUrl,
-        })
-      )
-
-      const automations: MentionItem[] = capabilities.automations ? (
-        automationsRes.status === 'fulfilled'
-          ? unwrapPaginatedData<{ _id: string; name?: string; description?: string; deletedAt?: number }>(automationsRes.value)
-          : []
-      )
-        .filter((a: { deletedAt?: number }) => !a.deletedAt)
-        .map((a: { _id: string; name?: string; description?: string }) => ({
-          type: 'automation' as const,
-          id: a._id,
-          name: a.name || 'Untitled automation',
-          description: a.description || '',
-          icon: 'Zap',
-        })) : []
-
-      const skills: MentionItem[] = (
-        skillsRes.status === 'fulfilled'
-          ? unwrapPaginatedData<{ _id: string; name: string; description?: string; enabled?: boolean }>(skillsRes.value)
-          : []
-      )
-        .filter((s: { enabled?: boolean }) => s.enabled !== false)
-        .map((s: { _id: string; name: string; description?: string }) => ({
-          type: 'skill' as const,
-          id: s._id,
-          name: s.name,
-          description: s.description || '',
-          icon: 'Sparkles',
+        const files: MentionItem[] = (
+          filesRes.status === 'fulfilled'
+            ? unwrapPaginatedData<{ _id: string; name?: string; kind?: string; mimeType?: string }>(filesRes.value)
+            : []
+        ).map((f: { _id: string; name?: string; kind?: string; mimeType?: string }) => ({
+          type: 'file' as const,
+          id: f._id,
+          name: f.name || 'Untitled',
+          description: f.kind || f.mimeType || 'file',
+          icon: 'FileText',
         }))
 
-      const mcps: MentionItem[] = (
-        mcpsRes.status === 'fulfilled'
-          ? unwrapPaginatedData<{ _id: string; name: string; description?: string; url?: string }>(mcpsRes.value)
-          : []
-      ).map((m: { _id: string; name: string; description?: string; url?: string }) => ({
-        type: 'mcp' as const,
-        id: m._id,
-        name: m.name,
-        description: m.description || m.url || '',
-        icon: 'Server',
-      }))
+        const knowledgeRaw = knowledgeRes.status === 'fulfilled' ? knowledgeRes.value : { knowledgeBases: [] }
+        const knowledge: MentionItem[] = (knowledgeRaw.knowledgeBases || []).map(
+          (base: { id: string; title: string; description?: string; kind?: string }) => ({
+            type: 'knowledge' as const,
+            id: base.id,
+            name: base.title,
+            description: base.description || base.kind || 'Knowledge base',
+            icon: 'BookOpen',
+          }),
+        )
 
-      const chats: MentionItem[] = (
-        chatsRes.status === 'fulfilled'
-          ? unwrapPaginatedData<{ _id: string; title: string }>(chatsRes.value)
-          : []
-      ).map((c: { _id: string; title: string }) => ({
-        type: 'chat' as const,
-        id: c._id,
-        name: c.title || 'Untitled chat',
-        icon: 'MessageSquare',
-      }))
+        const connectorsRaw = connectorsRes.status === 'fulfilled' ? connectorsRes.value : { items: [] }
+        const connectors: MentionItem[] = (connectorsRaw.items || []).map(
+          (c: { slug: string; name: string; description?: string; logoUrl?: string }) => ({
+            type: 'connector' as const,
+            id: c.slug,
+            name: c.name,
+            description: c.description || '',
+            icon: 'Plug',
+            logoUrl: c.logoUrl,
+          }),
+        )
 
-      const data: CachedData = { cacheKey, files, knowledge, connectors, automations, skills, mcps, chats }
-      cacheRef.current = data
-      return data
+        const automations: MentionItem[] = capabilities.automations ? (
+          automationsRes.status === 'fulfilled'
+            ? unwrapPaginatedData<{ _id: string; name?: string; description?: string; deletedAt?: number }>(automationsRes.value)
+            : []
+        )
+          .filter((a: { deletedAt?: number }) => !a.deletedAt)
+          .map((a: { _id: string; name?: string; description?: string }) => ({
+            type: 'automation' as const,
+            id: a._id,
+            name: a.name || 'Untitled automation',
+            description: a.description || '',
+            icon: 'Zap',
+          })) : []
+
+        const skills: MentionItem[] = (
+          skillsRes.status === 'fulfilled'
+            ? unwrapPaginatedData<{ _id: string; name: string; description?: string; enabled?: boolean }>(skillsRes.value)
+            : []
+        )
+          .filter((s: { enabled?: boolean }) => s.enabled !== false)
+          .map((s: { _id: string; name: string; description?: string }) => ({
+            type: 'skill' as const,
+            id: s._id,
+            name: s.name,
+            description: s.description || '',
+            icon: 'Sparkles',
+          }))
+
+        const mcps: MentionItem[] = (
+          mcpsRes.status === 'fulfilled'
+            ? unwrapPaginatedData<{ _id: string; name: string; description?: string; url?: string }>(mcpsRes.value)
+            : []
+        ).map((m: { _id: string; name: string; description?: string; url?: string }) => ({
+          type: 'mcp' as const,
+          id: m._id,
+          name: m.name,
+          description: m.description || m.url || '',
+          icon: 'Server',
+        }))
+
+        const chats: MentionItem[] = (
+          chatsRes.status === 'fulfilled'
+            ? unwrapPaginatedData<{ _id: string; title: string }>(chatsRes.value)
+            : []
+        ).map((c: { _id: string; title: string }) => ({
+          type: 'chat' as const,
+          id: c._id,
+          name: c.title || 'Untitled chat',
+          icon: 'MessageSquare',
+        }))
+
+        const data: CachedData = { cacheKey: requestKey, files, knowledge, connectors, automations, skills, mcps, chats }
+        mentionCache.set(requestKey, { data, cachedAt: Date.now() })
+        return data
+      } finally {
+        mentionRequests.delete(requestKey)
+      }
+    })()
+    mentionRequests.set(requestKey, request)
+    try {
+      return await request
     } finally {
       setLoading(false)
-      fetchingRef.current = false
     }
   }, [
     cacheKey,
@@ -250,7 +267,7 @@ export function useMentionData() {
   )
 
   const invalidateCache = useCallback(() => {
-    cacheRef.current = null
+    mentionCache.clear()
   }, [])
 
   return { availableTypes, search, loading, invalidateCache, fetchAllData }


### PR DESCRIPTION
## Summary
- preserve full external-link destinations while keeping sent-message link chips visually shortened
- add Markdown copy actions below sent messages
- show an honest first-load mention state and warm/cache mention data per workspace
- settle MCP tool labels across completed, failed, and denied lifecycle states

## Staging QA
- merged feature commit `d0bbe096b72f6438e1efbc388245b0fb44149c8e` into staging commit `f4d59404059cf908bf19364ed5e8ed773e357133`
- Vercel staging deployment completed successfully
- verified rich X link kept full tweet path/query behind shortened `x.com` label
- verified first mention query showed `Loading mentions...`, then warm-cache reopen displayed categories immediately
- verified sent-message copy wrote the original message text
- verified completed tool group settled to `1 tool called`
- verified no browser console warnings/errors during authenticated staging checks

No Convex files changed, so no Convex deployment was run.