### PR TITLE
feat: add Hermes connected-agent support

### DIFF
--- a/docs/develop/bring-your-own-agents.md
+++ b/docs/develop/bring-your-own-agents.md
@@ -112,8 +112,12 @@ records an explicitly granted default working directory. Creating an environment
 same dialog and returns directly to the binding step after phrase and root approval. A failed
 binding retry edits the already-durable agent identity rather than creating a duplicate. The host
 ships data-only manifests for Codex (`@agentclientprotocol/codex-acp@1.7.0`) and Claude Code
-(`@agentclientprotocol/claude-agent-acp@0.70.0`); adding another ACP target extends the manifest and
-conformance fixtures, not conversation orchestration. The built-in user-owned adapter IDs live in
+(`@agentclientprotocol/claude-agent-acp@0.70.0`). Hermes 0.20.6 or newer is a third built-in target
+through the official `hermes acp` stdio server. It uses the unchanged ACP lifecycle for session
+creation/loading, streamed message and tool updates, permissions, cancellation, and authentication;
+the host does not translate Hermes through a private protocol. Adding another ACP target extends the
+manifest and conformance fixtures, not conversation orchestration. The built-in user-owned adapter
+IDs live in
 `@overlay/workspace-contracts`; they are deliberately separate from the managed-sandbox adapter
 allowlist so enabling a local or VPS adapter never makes Overlay Cloud eligible.
 PostgreSQL migration 0066 repairs older databases whose recorded migration history omitted the
@@ -191,8 +195,9 @@ a remote or headless flow. Overlay never copies, mounts, uploads, or imports a u
 Claude, or equivalent authentication directory into a managed sandbox.
 
 Phase 7 makes `@overlay/agent-host` and `@overlay/agent-bridge-protocol` publishable packages and
-requires Node.js 24. The first production package line is `0.1.0`; the application copies an exact
-`npx --yes @overlay/agent-host@0.1.0 ...` command rather than following npm `latest`. The host and
+requires Node.js 24. The first production package line is `0.1.0`; Hermes support is released in
+the lockstep `0.2.0` package line. The application copies an exact
+`npx --yes @overlay/agent-host@0.2.0 ...` command rather than following npm `latest`. The host and
 protocol packages release together, the host depends on the exact protocol version, and the npm
 release workflow publishes compiled ESM plus declarations for both packages with provenance after
 the compatibility, package-content, and clean Node.js installation gates. Published package entry
@@ -214,8 +219,8 @@ be publicly reachable. Eve connection
 authorization (`authorization.required`) is not bridged by the current host contract, so the
 adapter fails that run closed instead of leaving an OAuth pause unobservable. Use static or
 app-scoped Eve connection auth until a dedicated authorization capability is added.
-Hermes, OpenClaw, and other native adapters remain ineligible unless ACP is unavailable and the
-unchanged host conformance suite passes.
+Hermes uses its official ACP server. OpenClaw and other native adapters remain ineligible unless ACP
+is unavailable and the unchanged host conformance suite passes.
 
 Phase 8 uses one entitlement-derived policy for both persistence providers. Environment redemption
 rechecks the enrollment-time environment ceiling atomically; remote dispatch atomically enforces

--- a/package-lock.json
+++ b/package-lock.json
@@ -34735,7 +34735,7 @@
     },
     "packages/overlay-agent-bridge-protocol": {
       "name": "@overlay/agent-bridge-protocol",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^3.25.76"
@@ -34747,11 +34747,11 @@
     },
     "packages/overlay-agent-host": {
       "name": "@overlay/agent-host",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
-        "@overlay/agent-bridge-protocol": "0.1.0",
+        "@overlay/agent-bridge-protocol": "0.2.0",
         "ai": "7.0.65",
         "eve": "0.44.4",
         "tsx": "^4.8.1",

--- a/packages/overlay-agent-bridge-protocol/README.md
+++ b/packages/overlay-agent-bridge-protocol/README.md
@@ -7,7 +7,7 @@ signature payloads, protocol limits, and TypeScript types; it does not start an 
 Install the matching protocol and host versions together:
 
 ```sh
-npm install @overlay/agent-bridge-protocol@0.1.0 @overlay/agent-host@0.1.0
+npm install @overlay/agent-bridge-protocol@0.2.0 @overlay/agent-host@0.2.0
 ```
 
 Protocol version 1 fails closed on unknown versions, invalid event sequences, oversized payloads,

--- a/packages/overlay-agent-bridge-protocol/package.json
+++ b/packages/overlay-agent-bridge-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overlay/agent-bridge-protocol",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Versioned command and event contracts for Overlay Agent Host.",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/packages/overlay-agent-host/README.md
+++ b/packages/overlay-agent-host/README.md
@@ -7,7 +7,7 @@ unacknowledged events in SQLite, so restarting the host does not duplicate accep
 Node.js 24 or newer is required. Run it in the foreground with the one-copy command from Overlay:
 
 ```sh
-npx --yes @overlay/agent-host@0.1.0 connect <enrollment-code> \
+npx --yes @overlay/agent-host@0.2.0 connect <enrollment-code> \
   --server https://getoverlay.io \
   --kind vps \
   --run
@@ -32,14 +32,18 @@ Keep credentials out of the JSON file:
   },
   "adapters": [
     { "manifest": "codex" },
-    { "manifest": "claude-code" }
+    { "manifest": "claude-code" },
+    { "manifest": "hermes" }
   ]
 }
 ```
 
 The built-in manifests resolve to the exact, release-tested
 `@agentclientprotocol/codex-acp@1.7.0` and
-`@agentclientprotocol/claude-agent-acp@0.70.0` packages. A custom
+`@agentclientprotocol/claude-agent-acp@0.70.0` packages. Hermes uses its official
+`hermes acp` stdio server and requires Hermes Agent 0.20.6 or newer. Install Hermes from the
+official Nous Research distribution, then verify it before enrollment with
+`hermes acp --check`. A custom
 ACP process can still use the explicit `id`, `displayName`, `protocol`, `command`, and `args`
 shape.
 
@@ -62,7 +66,7 @@ network URL:
 The equivalent enrollment form is:
 
 ```sh
-npx --yes @overlay/agent-host@0.1.0 connect <enrollment-code> \
+npx --yes @overlay/agent-host@0.2.0 connect <enrollment-code> \
   --server https://getoverlay.io \
   --kind vps \
   --adapter eve \
@@ -110,6 +114,6 @@ directory and ACP workspace roots; they are not an operating-system sandbox. For
 isolation, run the host and harness under a restricted OS account, container, VM, or managed
 sandbox.
 
-Native adapters such as Hermes or OpenClaw are added only when the harness cannot expose ACP and
-only after the unchanged Agent Host conformance suite passes. MCP remains a tool/resource protocol;
-it is not used as the execution lifecycle transport.
+Native adapters such as OpenClaw are added only when the harness cannot expose ACP and only after
+the unchanged Agent Host conformance suite passes. Hermes uses its official ACP server. MCP remains
+a tool/resource protocol; it is not used as the execution lifecycle transport.

--- a/packages/overlay-agent-host/docker-compose.example.yml
+++ b/packages/overlay-agent-host/docker-compose.example.yml
@@ -1,6 +1,6 @@
 services:
   agent-host:
-    image: ghcr.io/layernorm/overlay-agent-host:0.1.0
+    image: ghcr.io/layernorm/overlay-agent-host:0.2.0
     restart: unless-stopped
     init: true
     # No ports: the host and its harnesses connect to Overlay over outbound HTTPS.

--- a/packages/overlay-agent-host/package.json
+++ b/packages/overlay-agent-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overlay/agent-host",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Outbound-only host for connecting user-owned and managed agents to Overlay.",
   "license": "AGPL-3.0-only",
   "repository": {
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.4.0",
-    "@overlay/agent-bridge-protocol": "0.1.0",
+    "@overlay/agent-bridge-protocol": "0.2.0",
     "ai": "7.0.65",
     "eve": "0.44.4",
     "tsx": "^4.8.1",

--- a/packages/overlay-agent-host/src/acp-adapter.test.ts
+++ b/packages/overlay-agent-host/src/acp-adapter.test.ts
@@ -43,6 +43,22 @@ test('official ACP SDK adapter streams supervised updates and bridges approval a
   }
 })
 
+test('ACP adapter discovery enforces its readiness verifier', async () => {
+  let checks = 0
+  const ready = new AcpAgentAdapter({
+    id: 'ready', displayName: 'Ready', command: process.execPath,
+    verify: async () => { checks += 1 },
+  })
+  assert.equal((await ready.discover()).id, 'ready')
+  assert.equal(checks, 1)
+
+  const unavailable = new AcpAgentAdapter({
+    id: 'unavailable', displayName: 'Unavailable', command: process.execPath,
+    verify: async () => { throw new Error('adapter is not ready') },
+  })
+  await assert.rejects(unavailable.discover(), /adapter is not ready/)
+})
+
 async function waitFor(predicate: () => boolean): Promise<void> {
   for (let attempt = 0; attempt < 200; attempt += 1) {
     if (predicate()) return

--- a/packages/overlay-agent-host/src/acp-adapter.test.ts
+++ b/packages/overlay-agent-host/src/acp-adapter.test.ts
@@ -39,7 +39,7 @@ test('official ACP SDK adapter streams supervised updates and bridges approval a
     assert.ok(events.some((event) => event.type === 'completed'))
   } finally {
     await session?.stop()
-    await rm(directory, { recursive: true, force: true })
+    await rm(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
   }
 })
 

--- a/packages/overlay-agent-host/src/acp-adapter.ts
+++ b/packages/overlay-agent-host/src/acp-adapter.ts
@@ -10,6 +10,7 @@ export type AcpAdapterOptions = {
   command: string
   args?: string[]
   env?: Record<string, string>
+  verify?: () => Promise<void>
 }
 
 type Deferred<T> = { promise: Promise<T>; resolve(value: T): void; reject(error: unknown): void }
@@ -24,7 +25,10 @@ export class AcpAgentAdapter implements AgentAdapter {
     }
   }
 
-  async discover() { return this.capability }
+  async discover() {
+    await this.options.verify?.()
+    return this.capability
+  }
 
   async start(input: StartAdapterSessionInput, emit: EmitAgentEvent): Promise<AgentAdapterSession> {
     const ready = deferred<{ sessionId: string; context: acp.ClientContext }>()

--- a/packages/overlay-agent-host/src/adapter-manifests.test.ts
+++ b/packages/overlay-agent-host/src/adapter-manifests.test.ts
@@ -1,9 +1,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { ACP_ADAPTER_MANIFESTS, resolveAcpAdapterManifest } from './adapter-manifests'
+import {
+  ACP_ADAPTER_MANIFESTS,
+  HERMES_AGENT_MINIMUM_VERSION,
+  resolveAcpAdapterManifest,
+} from './adapter-manifests'
 
 test('first native ACP targets are data-only manifests', () => {
-  assert.deepEqual(Object.keys(ACP_ADAPTER_MANIFESTS), ['codex', 'claude-code'])
+  assert.deepEqual(Object.keys(ACP_ADAPTER_MANIFESTS), ['codex', 'claude-code', 'hermes'])
   assert.deepEqual(resolveAcpAdapterManifest('codex'), {
     id: 'codex',
     displayName: 'Codex',
@@ -17,6 +21,14 @@ test('first native ACP targets are data-only manifests', () => {
     protocol: 'acp',
     command: 'npx',
     args: ['-y', '@agentclientprotocol/claude-agent-acp@0.70.0'],
+  })
+  assert.equal(HERMES_AGENT_MINIMUM_VERSION, '0.20.6')
+  assert.deepEqual(resolveAcpAdapterManifest('hermes'), {
+    id: 'hermes',
+    displayName: 'Hermes',
+    protocol: 'acp',
+    command: 'hermes',
+    args: ['acp'],
   })
 })
 

--- a/packages/overlay-agent-host/src/adapter-manifests.ts
+++ b/packages/overlay-agent-host/src/adapter-manifests.ts
@@ -1,5 +1,6 @@
 export const CODEX_ACP_PACKAGE_VERSION = '1.7.0'
 export const CLAUDE_AGENT_ACP_PACKAGE_VERSION = '0.70.0'
+export const HERMES_AGENT_MINIMUM_VERSION = '0.20.6'
 
 export const ACP_ADAPTER_MANIFESTS = {
   codex: {
@@ -15,6 +16,13 @@ export const ACP_ADAPTER_MANIFESTS = {
     protocol: 'acp' as const,
     command: 'npx',
     args: ['-y', `@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_PACKAGE_VERSION}`],
+  },
+  hermes: {
+    id: 'hermes',
+    displayName: 'Hermes',
+    protocol: 'acp' as const,
+    command: 'hermes',
+    args: ['acp'],
   },
 } as const
 

--- a/packages/overlay-agent-host/src/cli.ts
+++ b/packages/overlay-agent-host/src/cli.ts
@@ -126,8 +126,17 @@ function buildAdapters(configs: AgentHostConfigAdapter[]): AgentAdapter[] {
     return new AcpAgentAdapter({
       id: adapter.id, displayName: adapter.displayName, command: adapter.command,
       ...(adapter.args ? { args: adapter.args } : {}), ...(adapter.env ? { env: adapter.env } : {}),
+      ...(isHermesManifestAdapter(adapter) ? { verify: verifyHermesAcpReadiness } : {}),
     })
   })
+}
+
+function isHermesManifestAdapter(adapter: AgentHostConfigAdapter): boolean {
+  return adapter.protocol === 'acp'
+    && adapter.id === 'hermes'
+    && adapter.command === 'hermes'
+    && adapter.args?.length === 1
+    && adapter.args[0] === 'acp'
 }
 
 type AgentHostConfigAdapter = Awaited<ReturnType<typeof loadAgentHostConfig>>['adapters'][number]

--- a/packages/overlay-agent-host/src/cli.ts
+++ b/packages/overlay-agent-host/src/cli.ts
@@ -15,6 +15,7 @@ import { loadOrCreateDeviceKeyPair } from './device-key.js'
 import { loadStoredConnection, saveStoredConnection } from './connection.js'
 import { resolveAcpAdapterManifest } from './adapter-manifests.js'
 import { EveAgentAdapter } from './eve-adapter.js'
+import { verifyHermesAcpReadiness } from './hermes-readiness.js'
 
 const [command, ...args] = process.argv.slice(2)
 const configPath = option(args, '--config')
@@ -35,6 +36,7 @@ if (command === 'connect') {
     if (!manifest) throw new Error(`unknown ACP adapter manifest: ${id}`)
     return { ...manifest, args: [...manifest.args] }
   })
+  if (adapterIds.includes('hermes')) await verifyHermesAcpReadiness()
   const connection = await connectAgentHost({
     code,
     serverUrl,
@@ -140,6 +142,6 @@ function options(args: string[], name: string): string[] {
 }
 
 function usage(): never {
-  process.stderr.write('Usage:\n  overlay-agent-host connect <code> --server https://getoverlay.io [--state-dir path] [--name name] [--kind local|vps|overlay_cloud|external] [--run] [--adapter codex] [--adapter eve --eve-url http://127.0.0.1:3000 --eve-auth-env EVE_AGENT_TOKEN]\n  overlay-agent-host <run|doctor> --config /absolute/path/config.json\n')
+  process.stderr.write('Usage:\n  overlay-agent-host connect <code> --server https://getoverlay.io [--state-dir path] [--name name] [--kind local|vps|overlay_cloud|external] [--run] [--adapter codex|claude-code|hermes] [--adapter eve --eve-url http://127.0.0.1:3000 --eve-auth-env EVE_AGENT_TOKEN]\n  overlay-agent-host <run|doctor> --config /absolute/path/config.json\n')
   process.exit(2)
 }

--- a/packages/overlay-agent-host/src/hermes-acp.integration.test.ts
+++ b/packages/overlay-agent-host/src/hermes-acp.integration.test.ts
@@ -51,6 +51,6 @@ test('Hermes ACP streams and resumes a complete turn through the production adap
     assert.equal(resumedCheckpoint?.payload.text, 'OVERLAY_HERMES_OKOVERLAY_HERMES_RESUMED')
   } finally {
     await session?.stop()
-    await rm(workingDirectory, { recursive: true, force: true })
+    await rm(workingDirectory, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
   }
 })

--- a/packages/overlay-agent-host/src/hermes-acp.integration.test.ts
+++ b/packages/overlay-agent-host/src/hermes-acp.integration.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { AcpAgentAdapter } from './acp-adapter'
+import type { NormalizedAgentEvent } from './adapter'
+
+const hermesCommand = process.env.OVERLAY_HERMES_ACP_COMMAND?.trim()
+
+test('Hermes ACP streams and resumes a complete turn through the production adapter', {
+  skip: hermesCommand ? false : 'Set OVERLAY_HERMES_ACP_COMMAND to run the live Hermes conformance test.',
+  timeout: 120_000,
+}, async () => {
+  const workingDirectory = await mkdtemp(join(tmpdir(), 'overlay-hermes-acp-'))
+  const events: NormalizedAgentEvent[] = []
+  const createAdapter = () => new AcpAgentAdapter({
+    id: 'hermes',
+    displayName: 'Hermes',
+    command: hermesCommand!,
+    args: ['acp'],
+  })
+  const adapter = createAdapter()
+  let session: Awaited<ReturnType<typeof adapter.start>> | undefined
+  try {
+    session = await adapter.start({
+      runId: 'hermes-live-conformance',
+      workingDirectory,
+      additionalDirectories: [],
+      prompt: '',
+      metadata: {},
+    }, async (event) => { events.push(event) })
+    await session.prompt('Reply with exactly OVERLAY_HERMES_OK and do not use tools.')
+    const checkpoint = events.filter((event) => event.type === 'text_checkpoint').at(-1)
+    assert.equal(checkpoint?.payload.text, 'OVERLAY_HERMES_OK')
+    assert.ok(events.some((event) => event.type === 'completed'))
+
+    const remoteSessionId = session.remoteSessionId
+    await session.stop()
+    session = await createAdapter().start({
+      runId: 'hermes-live-conformance-resume',
+      workingDirectory,
+      additionalDirectories: [],
+      remoteSessionId,
+      prompt: '',
+      metadata: {},
+    }, async (event) => { events.push(event) })
+    assert.equal(session.remoteSessionId, remoteSessionId)
+    await session.prompt('Reply with exactly OVERLAY_HERMES_RESUMED and do not use tools.')
+    const resumedCheckpoint = events.filter((event) => event.type === 'text_checkpoint').at(-1)
+    assert.equal(resumedCheckpoint?.payload.text, 'OVERLAY_HERMES_OKOVERLAY_HERMES_RESUMED')
+  } finally {
+    await session?.stop()
+    await rm(workingDirectory, { recursive: true, force: true })
+  }
+})

--- a/packages/overlay-agent-host/src/hermes-readiness.test.ts
+++ b/packages/overlay-agent-host/src/hermes-readiness.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { verifyHermesAcpReadiness } from './hermes-readiness'
+
+test('Hermes readiness accepts the official ACP sentinel', async () => {
+  await verifyHermesAcpReadiness(async () => ({ stdout: 'Hermes ACP check OK\n' }))
+})
+
+test('Hermes readiness fails with a setup path when ACP is missing or stale', async () => {
+  await assert.rejects(
+    verifyHermesAcpReadiness(async () => { throw new Error('command not found') }),
+    /Install Hermes Agent 0\.20\.6 or newer.*hermes acp --setup.*hermes acp --check/,
+  )
+})

--- a/packages/overlay-agent-host/src/hermes-readiness.ts
+++ b/packages/overlay-agent-host/src/hermes-readiness.ts
@@ -1,0 +1,24 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+type CheckRunner = () => Promise<{ stdout: string }>
+
+export async function verifyHermesAcpReadiness(run: CheckRunner = async () => {
+  const result = await execFileAsync('hermes', ['acp', '--check'], {
+    timeout: 15_000,
+    maxBuffer: 64 * 1024,
+    windowsHide: true,
+  })
+  return { stdout: result.stdout }
+}) {
+  try {
+    const result = await run()
+    if (!result.stdout.includes('Hermes ACP check OK')) throw new Error('unexpected readiness response')
+  } catch (error) {
+    throw new Error(
+      'Hermes ACP is not ready. Install Hermes Agent 0.20.6 or newer, run `hermes acp --setup`, then verify it with `hermes acp --check` before reconnecting.',
+      { cause: error },
+    )
+  }
+}

--- a/packages/overlay-agent-host/src/index.ts
+++ b/packages/overlay-agent-host/src/index.ts
@@ -1,6 +1,7 @@
 export * from './acp-adapter.js'
 export * from './adapter.js'
 export * from './adapter-manifests.js'
+export * from './hermes-readiness.js'
 export * from './config.js'
 export * from './connection.js'
 export * from './device-key.js'

--- a/packages/overlay-workspace-contracts/src/connected-agents.ts
+++ b/packages/overlay-workspace-contracts/src/connected-agents.ts
@@ -35,7 +35,7 @@ export type AgentProtocolAdapter = (typeof AGENT_PROTOCOL_ADAPTERS)[number]
  * Keep this separate from the managed-sandbox allowlist: being built in must never imply
  * that Overlay Cloud is released for the same harness.
  */
-export const BUILT_IN_USER_OWNED_ACP_ADAPTER_IDS = ['codex', 'claude-code'] as const
+export const BUILT_IN_USER_OWNED_ACP_ADAPTER_IDS = ['codex', 'claude-code', 'hermes'] as const
 export type BuiltInUserOwnedAcpAdapterId = (typeof BUILT_IN_USER_OWNED_ACP_ADAPTER_IDS)[number]
 
 export function isBuiltInUserOwnedAcpAdapterId(value: unknown): value is BuiltInUserOwnedAcpAdapterId {

--- a/scripts/smoke-agent-host-package-install.mjs
+++ b/scripts/smoke-agent-host-package-install.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -8,6 +8,8 @@ import { fileURLToPath } from 'node:url'
 const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const smokeDirectory = mkdtempSync(join(tmpdir(), 'overlay-agent-host-release-'))
 const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const hostPackage = JSON.parse(readFileSync(join(repositoryRoot, 'packages/overlay-agent-host/package.json'), 'utf8'))
+const protocolPackage = JSON.parse(readFileSync(join(repositoryRoot, 'packages/overlay-agent-bridge-protocol/package.json'), 'utf8'))
 
 try {
   execFileSync(npmCommand, [
@@ -20,8 +22,8 @@ try {
   execFileSync(npmCommand, [
     'install', '--ignore-scripts', '--no-audit', '--no-fund',
     '--min-release-age=0',
-    './overlay-agent-bridge-protocol-0.1.0.tgz',
-    './overlay-agent-host-0.1.0.tgz',
+    `./overlay-agent-bridge-protocol-${protocolPackage.version}.tgz`,
+    `./overlay-agent-host-${hostPackage.version}.tgz`,
   ], { cwd: smokeDirectory, stdio: 'pipe' })
 
   execFileSync(process.execPath, [

--- a/scripts/verify-agent-host-release.mjs
+++ b/scripts/verify-agent-host-release.mjs
@@ -23,5 +23,8 @@ assert.match(
 )
 assert.match(adapterManifests, /CODEX_ACP_PACKAGE_VERSION = '1\.7\.0'/)
 assert.match(adapterManifests, /CLAUDE_AGENT_ACP_PACKAGE_VERSION = '0\.70\.0'/)
+assert.match(adapterManifests, /HERMES_AGENT_MINIMUM_VERSION = '0\.20\.6'/)
+assert.match(adapterManifests, /command: 'hermes'/)
+assert.match(adapterManifests, /args: \['acp'\]/)
 
 console.log(`Agent Host release ${hostPackage.version} is internally pinned and consistent.`)

--- a/src/features/agents/lib/byo-agent-setup.test.ts
+++ b/src/features/agents/lib/byo-agent-setup.test.ts
@@ -16,6 +16,7 @@ const environment = {
   capabilities: {
     adapters: [
       { id: 'codex', displayName: 'Codex', protocol: 'acp' },
+      { id: 'hermes', displayName: 'Hermes', protocol: 'acp' },
       { id: 'custom-acp', displayName: 'Custom ACP', protocol: 'acp' },
       { id: 'eve', displayName: 'Eve', protocol: 'eve' },
     ],
@@ -26,7 +27,7 @@ const environment = {
 
 test('BYO harness discovery keeps built-in targets and adds advertised ACP adapters', () => {
   assert.deepEqual(availableByoHarnesses([environment]).map((harness) => harness.id), [
-    'codex', 'claude-code', 'custom-acp',
+    'codex', 'claude-code', 'hermes', 'custom-acp',
   ])
   assert.equal(environmentSupportsHarness(environment, 'custom-acp'), true)
   assert.equal(environmentSupportsHarness(environment, 'eve'), false)
@@ -37,11 +38,13 @@ test('BYO defaults preserve explicit filesystem and workspace harness boundaries
   assert.equal(defaultWorkingDirectory(environment), '/repo')
   assert.equal(workspaceHarnessForByo('claude-code'), 'claude-code')
   assert.equal(workspaceHarnessForByo('codex'), 'overlay')
+  assert.equal(workspaceHarnessForByo('hermes'), 'overlay')
   assert.match(generatedByoInstructions('Codex'), /connected environment/)
 })
 
 test('existing BYO identity is recognized without a binding request', () => {
   assert.equal(workspaceAgentUsesByo({ harness: 'overlay', modelId: 'byo/codex' }), true)
   assert.equal(workspaceAgentUsesByo({ harness: 'claude-code', modelId: 'byo/claude-code' }), true)
+  assert.equal(workspaceAgentUsesByo({ harness: 'overlay', modelId: 'byo/hermes' }), true)
   assert.equal(workspaceAgentUsesByo({ harness: 'overlay', modelId: 'openrouter/free' }), false)
 })

--- a/src/features/agents/lib/byo-agent-setup.ts
+++ b/src/features/agents/lib/byo-agent-setup.ts
@@ -17,6 +17,11 @@ export const BUILT_IN_BYO_HARNESSES = [
     label: 'Claude Code',
     description: 'Run Anthropic Claude Code through the Agent Client Protocol.',
   },
+  {
+    id: 'hermes',
+    label: 'Hermes',
+    description: 'Run Hermes 0.20.6 or newer through its official Agent Client Protocol server.',
+  },
 ] as const satisfies ReadonlyArray<{
   id: BuiltInUserOwnedAcpAdapterId
   label: string

--- a/src/server/agents/agent-enrollment-command.test.ts
+++ b/src/server/agents/agent-enrollment-command.test.ts
@@ -9,14 +9,25 @@ test('the copyable enrollment command starts the selected harness in one step', 
       origin: 'https://getoverlay.io',
       adapterId: 'claude-code',
     }),
-    'npx --yes @overlay/agent-host@0.1.0 connect single-use-code --server https://getoverlay.io --adapter claude-code --run',
+    'npx --yes @overlay/agent-host@0.2.0 connect single-use-code --server https://getoverlay.io --adapter claude-code --run',
   )
 })
 
 test('the compatibility command still starts the host when no harness is selected', () => {
   assert.equal(
     buildAgentHostEnrollmentCommand({ code: 'single-use-code', origin: 'https://getoverlay.io' }),
-    'npx --yes @overlay/agent-host@0.1.0 connect single-use-code --server https://getoverlay.io --run',
+    'npx --yes @overlay/agent-host@0.2.0 connect single-use-code --server https://getoverlay.io --run',
+  )
+})
+
+test('the copyable enrollment command starts Hermes through its official ACP server', () => {
+  assert.equal(
+    buildAgentHostEnrollmentCommand({
+      code: 'single-use-code',
+      origin: 'https://getoverlay.io',
+      adapterId: 'hermes',
+    }),
+    'npx --yes @overlay/agent-host@0.2.0 connect single-use-code --server https://getoverlay.io --adapter hermes --run',
   )
 })
 

--- a/src/server/agents/agent-enrollment-command.ts
+++ b/src/server/agents/agent-enrollment-command.ts
@@ -1,6 +1,6 @@
 import type { BuiltInUserOwnedAcpAdapterId } from '@overlay/workspace-contracts'
 
-export const OVERLAY_AGENT_HOST_PACKAGE_VERSION = '0.1.0'
+export const OVERLAY_AGENT_HOST_PACKAGE_VERSION = '0.2.0'
 export const OVERLAY_AGENT_HOST_PACKAGE_SPEC = `@overlay/agent-host@${OVERLAY_AGENT_HOST_PACKAGE_VERSION}`
 
 export function buildAgentHostEnrollmentCommand(input: {


### PR DESCRIPTION
## Summary

- add Hermes 0.20.6+ as a first-party user-owned ACP harness
- fail before enrollment when `hermes acp --check` is unavailable or stale
- release Agent Host and bridge protocol together as `0.2.0`
- expose Hermes in the BYO agent editor without widening Overlay Cloud eligibility
- add opt-in live Hermes ACP stream and resume conformance coverage

## Verification

- `npm run check:byo-agents:release`
- `HERMES_HOME=<isolated-home> OVERLAY_HERMES_ACP_COMMAND=<official-0.20.6-hermes> npm --prefix packages/overlay-agent-host test`
- `npx tsc --noEmit`
- `npm run build`
- targeted ESLint on all changed TypeScript files
- `npx --yes node@24 scripts/smoke-agent-host-package-install.mjs`

The repository-wide `npm run typecheck` wrapper is currently blocked by the existing sibling desktop checkout failing `desktop shared-chat.css must import the canonical chat stylesheet`; direct TypeScript and the production build both pass for this branch.
