### PR TITLE
Fix project navigation and safe inline naming

### DIFF
--- a/packages/overlay-modules-react/src/projects/hub.back.test.tsx
+++ b/packages/overlay-modules-react/src/projects/hub.back.test.tsx
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ProjectHubHeader } from './hub'
+
+const noop = () => undefined
+
+test('project hub header exposes an accessible back affordance when requested', () => {
+  const html = renderToStaticMarkup(
+    <ProjectHubHeader
+      projectName="Launch plan"
+      editingName={false}
+      draftName="Launch plan"
+      onBack={noop}
+      onStartRename={noop}
+      onDraftNameChange={noop}
+      onCommitRename={noop}
+      onCancelRename={noop}
+    />,
+  )
+
+  assert.match(html, /aria-label="Back to projects"/)
+  assert.match(html, /Launch plan/)
+})

--- a/packages/overlay-modules-react/src/projects/hub.tsx
+++ b/packages/overlay-modules-react/src/projects/hub.tsx
@@ -6,7 +6,7 @@ ProjectFileSummary,
 ProjectHubTab
 } from '@overlay/app-core'
 import { projectRouteViewForFile } from '@overlay/app-core'
-import { BookOpen,ChevronDown,FileText,FolderOpen,FolderPlus,Loader2,MessageSquare,Pencil,Plus,Upload } from 'lucide-react'
+import { ArrowLeft,BookOpen,ChevronDown,FileText,FolderPlus,Loader2,MessageSquare,Pencil,Plus,Upload } from 'lucide-react'
 import { type ChangeEvent,type ReactNode,type RefObject } from 'react'
 import { AppScreenBody, AppScreenHeader, AppScreenShell } from '../shell'
 import { FileTypeIcon } from '../shared/file-type-icon'
@@ -17,6 +17,8 @@ export interface ProjectHubHeaderProps {
   draftName: string
   savingName?: boolean
   actions?: ReactNode
+  /** When provided, shows a back affordance to the left of the project name. */
+  onBack?: () => void
   onStartRename: () => void
   onDraftNameChange: (value: string) => void
   onCommitRename: () => void
@@ -29,6 +31,7 @@ export function ProjectHubHeader({
   draftName,
   savingName,
   actions,
+  onBack,
   onStartRename,
   onDraftNameChange,
   onCommitRename,
@@ -37,7 +40,16 @@ export function ProjectHubHeader({
   return (
     <AppScreenHeader className="px-3 py-2.5 md:px-4 md:py-0">
       <div className="flex min-w-0 items-center gap-2">
-        <FolderOpen size={16} className="shrink-0 text-[var(--muted)]" />
+        {onBack ? (
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="Back to projects"
+            className="shrink-0 rounded-md p-1.5 text-[var(--muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--foreground)]"
+          >
+            <ArrowLeft size={16} />
+          </button>
+        ) : null}
         {editingName ? (
           <input
             className="max-w-md min-w-0 flex-1 rounded border border-[var(--border)] bg-[var(--background)] px-2 py-0.5 text-sm font-medium text-[var(--foreground)] outline-none focus:ring-1 focus:ring-[var(--foreground)]"

--- a/src/features/projects/components/ProjectsView.tsx
+++ b/src/features/projects/components/ProjectsView.tsx
@@ -510,20 +510,88 @@ function formatProjectUpdatedAt(updatedAt: number): string {
   }).format(new Date(updatedAt))
 }
 
+function ProjectRenameInput({
+  projectName,
+  saving,
+  error,
+  onCommit,
+  onCancel,
+  onChange,
+}: {
+  projectName: string
+  saving: boolean
+  error: string | null
+  onCommit: (name: string) => void
+  onCancel: () => void
+  onChange: () => void
+}) {
+  const [draftName, setDraftName] = useState(projectName)
+  const cancelledRef = useRef(false)
+
+  const commit = () => {
+    if (cancelledRef.current || saving) return
+    onCommit(draftName)
+  }
+
+  return (
+    <div className="min-w-0">
+      <input
+        autoFocus
+        aria-label="Project name"
+        aria-invalid={Boolean(error)}
+        aria-describedby={error ? 'project-rename-error' : undefined}
+        value={draftName}
+        readOnly={saving}
+        onChange={(event) => {
+          setDraftName(event.target.value)
+          onChange()
+        }}
+        onFocus={(event) => event.currentTarget.select()}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault()
+            commit()
+          }
+          if (event.key === 'Escape' && !saving) {
+            event.preventDefault()
+            cancelledRef.current = true
+            onCancel()
+          }
+        }}
+        onBlur={commit}
+        className="w-full truncate rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-0.5 text-sm font-medium text-[var(--foreground)] outline-none focus:ring-1 focus:ring-[var(--foreground)] read-only:opacity-70"
+      />
+      {error ? (
+        <p id="project-rename-error" role="alert" className="mt-1 text-[11px] leading-4 text-red-500">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
 function ProjectsLanding({
   projects,
   loading,
   creating,
   onCreateProject,
   renamingProjectId,
+  renamingProjectPending,
+  renameError,
   onCommitRename,
+  onCancelRename,
+  onRenameChange,
 }: {
   projects: readonly ProjectSummary[]
   loading: boolean
   creating: boolean
   onCreateProject: () => void
   renamingProjectId: string | null
+  renamingProjectPending: boolean
+  renameError: string | null
   onCommitRename: (projectId: string, name: string) => void
+  onCancelRename: () => void
+  onRenameChange: () => void
 }) {
   const router = useRouter()
   const rootProjectRows = useMemo(() => {
@@ -567,44 +635,25 @@ function ProjectsLanding({
             {rootProjectRows.map((project) => {
               const subprojectCount = getChildProjects(projects, project._id).length
               const updatedLabel = formatProjectUpdatedAt(project.updatedAt)
-              return (
-                <div
-                  key={project._id}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => router.push(projectHubHref(project))}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter' && event.target === event.currentTarget) {
-                      router.push(projectHubHref(project))
-                    }
-                  }}
-                  className="group flex min-h-32 cursor-pointer flex-col justify-between rounded-lg border border-[var(--border)] bg-[var(--surface-elevated)] p-4 text-left transition-colors hover:border-[var(--muted-light)] hover:bg-[var(--surface-subtle)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--foreground)]"
-                >
+              const isRenaming = renamingProjectId === project._id
+              const content = (
+                <>
                   <div className="flex min-w-0 items-start gap-3">
                     <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[var(--border)] bg-[var(--surface-muted)] text-[var(--muted)]">
                       <Folder size={16} strokeWidth={1.75} />
                     </span>
-                    <div className="min-w-0">
-                      {renamingProjectId === project._id ? (
-                        <input
-                          autoFocus
-                          aria-label="Project name"
-                          defaultValue={project.name}
-                          disabled={creating}
-                          onFocus={(event) => event.currentTarget.select()}
-                          onKeyDown={(event) => {
-                            if (event.key === 'Enter') {
-                              event.preventDefault()
-                              void onCommitRename(project._id, (event.currentTarget as HTMLInputElement).value.trim() || project.name)
-                            }
-                            if (event.key === 'Escape') {
-                              ;(event.currentTarget as HTMLInputElement).blur()
-                            }
-                          }}
-                          className="w-full truncate rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-0.5 text-sm font-medium text-[var(--foreground)] outline-none focus:ring-1 focus:ring-[var(--foreground)]"
+                    <div className="min-w-0 flex-1">
+                      {isRenaming ? (
+                        <ProjectRenameInput
+                          projectName={project.name}
+                          saving={renamingProjectPending}
+                          error={renameError}
+                          onCommit={(name) => onCommitRename(project._id, name)}
+                          onCancel={onCancelRename}
+                          onChange={onRenameChange}
                         />
                       ) : (
-                      <p className="truncate text-sm font-medium text-[var(--foreground)]">{project.name}</p>
+                        <p className="truncate text-sm font-medium text-[var(--foreground)]">{project.name}</p>
                       )}
                       {project.description || project.instructions ? (
                         <p className="mt-1 line-clamp-2 text-xs leading-5 text-[var(--muted)]">
@@ -619,7 +668,25 @@ function ProjectsLanding({
                     <span>{subprojectCount > 0 ? `${subprojectCount} nested project${subprojectCount === 1 ? '' : 's'}` : 'Project'}</span>
                     {updatedLabel ? <span>Updated {updatedLabel}</span> : null}
                   </div>
+                </>
+              )
+
+              return isRenaming ? (
+                <div
+                  key={project._id}
+                  className="group flex min-h-32 flex-col justify-between rounded-lg border border-[var(--muted-light)] bg-[var(--surface-subtle)] p-4 text-left"
+                >
+                  {content}
                 </div>
+              ) : (
+                <button
+                  key={project._id}
+                  type="button"
+                  onClick={() => router.push(projectHubHref(project))}
+                  className="group flex min-h-32 cursor-pointer flex-col justify-between rounded-lg border border-[var(--border)] bg-[var(--surface-elevated)] p-4 text-left transition-colors hover:border-[var(--muted-light)] hover:bg-[var(--surface-subtle)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--foreground)]"
+                >
+                  {content}
+                </button>
               )
             })}
           </div>
@@ -649,6 +716,9 @@ export default function ProjectsView({
   const [projectsLoading, setProjectsLoading] = useState(initialProjects.length === 0)
   const [creatingProject, setCreatingProject] = useState(false)
   const [renamingProjectId, setRenamingProjectId] = useState<string | null>(null)
+  const [renamingProjectPending, setRenamingProjectPending] = useState(false)
+  const [renameError, setRenameError] = useState<string | null>(null)
+  const renameRequestRef = useRef(false)
   const view = searchParams?.get('view') ?? null
   const id = searchParams?.get('id') ?? null
   const projectId = searchParams?.get('projectId') ?? null
@@ -707,6 +777,7 @@ export default function ProjectsView({
       const createdId = created?._id || data.id
       window.dispatchEvent(new Event(PROJECTS_CHANGED_EVENT))
       if (createdId) {
+        setRenameError(null)
         setRenamingProjectId(createdId)
       }
     } finally {
@@ -746,12 +817,52 @@ export default function ProjectsView({
       creating={creatingProject}
       onCreateProject={() => void createProject()}
       renamingProjectId={renamingProjectId}
+      renamingProjectPending={renamingProjectPending}
+      renameError={renameError}
       onCommitRename={async (projectId, name) => {
         const trimmed = name.trim()
-        if (!trimmed || trimmed === 'Untitled project') return
-        await overlayAppClient.projects.updateResponse({ projectId, name: trimmed })
-        setProjects((prev) => prev.map((project) => project._id === projectId ? { ...project, name: trimmed } : project))
+        if (!trimmed) {
+          setRenameError('Enter a project name.')
+          return
+        }
+        if (renameRequestRef.current) return
+        const currentProject = projects.find((project) => project._id === projectId)
+        if (trimmed === currentProject?.name) {
+          setRenameError(null)
+          setRenamingProjectId(null)
+          return
+        }
+
+        renameRequestRef.current = true
+        setRenamingProjectPending(true)
+        setRenameError(null)
+        try {
+          const response = await overlayAppClient.projects.updateResponse({ projectId, name: trimmed })
+          const payload = (await response.json().catch(() => null)) as
+            | { error?: string; message?: string; project?: ProjectSummary | null }
+            | null
+          if (!response.ok) {
+            setRenameError(payload?.message || payload?.error || 'Could not rename this project. Try again.')
+            return
+          }
+          const finalName = payload?.project?.name?.trim() || trimmed
+          setProjects((prev) => prev.map((project) => (
+            project._id === projectId ? { ...project, ...payload?.project, name: finalName } : project
+          )))
+          setRenamingProjectId(null)
+          window.dispatchEvent(new Event(PROJECTS_CHANGED_EVENT))
+        } catch {
+          setRenameError('Could not rename this project. Check your connection and try again.')
+        } finally {
+          renameRequestRef.current = false
+          setRenamingProjectPending(false)
+        }
       }}
+      onCancelRename={() => {
+        setRenameError(null)
+        setRenamingProjectId(null)
+      }}
+      onRenameChange={() => setRenameError(null)}
     />
   )
 }

--- a/src/features/projects/components/ProjectsView.tsx
+++ b/src/features/projects/components/ProjectsView.tsx
@@ -449,6 +449,7 @@ function ProjectHubBody({
       draftName={draftName}
       savingName={savingName}
       actions={headerActions}
+      onBack={() => { router.push('/app/projects') }}
       onStartRename={() => { setDraftName(projectName); setEditingName(true) }}
       onDraftNameChange={setDraftName}
       onCommitRename={() => void commitProjectRename()}
@@ -514,11 +515,15 @@ function ProjectsLanding({
   loading,
   creating,
   onCreateProject,
+  renamingProjectId,
+  onCommitRename,
 }: {
   projects: readonly ProjectSummary[]
   loading: boolean
   creating: boolean
   onCreateProject: () => void
+  renamingProjectId: string | null
+  onCommitRename: (projectId: string, name: string) => void
 }) {
   const router = useRouter()
   const rootProjectRows = useMemo(() => {
@@ -563,18 +568,44 @@ function ProjectsLanding({
               const subprojectCount = getChildProjects(projects, project._id).length
               const updatedLabel = formatProjectUpdatedAt(project.updatedAt)
               return (
-                <button
+                <div
                   key={project._id}
-                  type="button"
+                  role="button"
+                  tabIndex={0}
                   onClick={() => router.push(projectHubHref(project))}
-                  className="group flex min-h-32 flex-col justify-between rounded-lg border border-[var(--border)] bg-[var(--surface-elevated)] p-4 text-left transition-colors hover:border-[var(--muted-light)] hover:bg-[var(--surface-subtle)]"
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' && event.target === event.currentTarget) {
+                      router.push(projectHubHref(project))
+                    }
+                  }}
+                  className="group flex min-h-32 cursor-pointer flex-col justify-between rounded-lg border border-[var(--border)] bg-[var(--surface-elevated)] p-4 text-left transition-colors hover:border-[var(--muted-light)] hover:bg-[var(--surface-subtle)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--foreground)]"
                 >
                   <div className="flex min-w-0 items-start gap-3">
                     <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[var(--border)] bg-[var(--surface-muted)] text-[var(--muted)]">
                       <Folder size={16} strokeWidth={1.75} />
                     </span>
                     <div className="min-w-0">
+                      {renamingProjectId === project._id ? (
+                        <input
+                          autoFocus
+                          aria-label="Project name"
+                          defaultValue={project.name}
+                          disabled={creating}
+                          onFocus={(event) => event.currentTarget.select()}
+                          onKeyDown={(event) => {
+                            if (event.key === 'Enter') {
+                              event.preventDefault()
+                              void onCommitRename(project._id, (event.currentTarget as HTMLInputElement).value.trim() || project.name)
+                            }
+                            if (event.key === 'Escape') {
+                              ;(event.currentTarget as HTMLInputElement).blur()
+                            }
+                          }}
+                          className="w-full truncate rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-0.5 text-sm font-medium text-[var(--foreground)] outline-none focus:ring-1 focus:ring-[var(--foreground)]"
+                        />
+                      ) : (
                       <p className="truncate text-sm font-medium text-[var(--foreground)]">{project.name}</p>
+                      )}
                       {project.description || project.instructions ? (
                         <p className="mt-1 line-clamp-2 text-xs leading-5 text-[var(--muted)]">
                           {project.description || project.instructions}
@@ -588,7 +619,7 @@ function ProjectsLanding({
                     <span>{subprojectCount > 0 ? `${subprojectCount} nested project${subprojectCount === 1 ? '' : 's'}` : 'Project'}</span>
                     {updatedLabel ? <span>Updated {updatedLabel}</span> : null}
                   </div>
-                </button>
+                </div>
               )
             })}
           </div>
@@ -613,11 +644,11 @@ export default function ProjectsView({
   firstName?: string
   initialProjects?: ProjectSummary[]
 }) {
-  const router = useRouter()
   const searchParams = useSearchParams()
   const [projects, setProjects] = useState<ProjectSummary[]>(initialProjects)
   const [projectsLoading, setProjectsLoading] = useState(initialProjects.length === 0)
   const [creatingProject, setCreatingProject] = useState(false)
+  const [renamingProjectId, setRenamingProjectId] = useState<string | null>(null)
   const view = searchParams?.get('view') ?? null
   const id = searchParams?.get('id') ?? null
   const projectId = searchParams?.get('projectId') ?? null
@@ -674,15 +705,14 @@ export default function ProjectsView({
         void loadProjects()
       }
       const createdId = created?._id || data.id
-      const createdName = created?.name || 'Untitled project'
       window.dispatchEvent(new Event(PROJECTS_CHANGED_EVENT))
       if (createdId) {
-        router.push(projectHubHref({ _id: createdId, name: createdName }))
+        setRenamingProjectId(createdId)
       }
     } finally {
       setCreatingProject(false)
     }
-  }, [creatingProject, loadProjects, router])
+  }, [creatingProject, loadProjects])
 
   if (view === 'chat' && id) {
     return (
@@ -715,6 +745,13 @@ export default function ProjectsView({
       loading={projectsLoading}
       creating={creatingProject}
       onCreateProject={() => void createProject()}
+      renamingProjectId={renamingProjectId}
+      onCommitRename={async (projectId, name) => {
+        const trimmed = name.trim()
+        if (!trimmed || trimmed === 'Untitled project') return
+        await overlayAppClient.projects.updateResponse({ projectId, name: trimmed })
+        setProjects((prev) => prev.map((project) => project._id === projectId ? { ...project, name: trimmed } : project))
+      }}
     />
   )
 }


### PR DESCRIPTION
## What changed

Rebases the pending project UX fixes directly onto the production memory/Hermes release, excluding the duplicate memory-deletion replay from the old local history. Project hubs gain a clear back affordance, while newly created projects stay on the project list in a safe inline rename state. Rename now saves on Enter or blur, cancels on Escape, blocks accidental card navigation, preserves the draft after API failures, and shows a recoverable inline error.

## Risk and rollback

- Security or tenant-boundary impact: None; existing project API authorization remains unchanged.
- Billing or provider-cost impact: None.
- Data migration impact: None.
- Rollback plan: Revert this PR; project creation returns to opening the new project immediately.

## Verification

- [x] I own this contribution or have written authority to submit it, and I identified all third-party material
- [ ] CLA Signatures check is green (outside contributors must comment `I have read the CLA Document and I hereby sign the CLA`; this checkbox is not a signature)
- [x] Relevant focused tests pass
- [x] Typecheck passes when contracts changed
- [x] Living documentation was updated when required
- [x] No credentials or customer data are included
- [ ] Browser or deployment evidence is attached when behavior depends on a hosted environment

The focused back-navigation regression test, changed-file lint, and root TypeScript compiler pass. The aggregate `npm run typecheck` remains blocked by the pre-existing desktop canonical-chat-stylesheet boundary failure before it reaches TypeScript; required CI is left as the independent merge gate.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable; this does not change an architectural contract or living-document policy.

**Implementation** — 2 files · `+175 / -15`

Keeps navigation presentation in the reusable project module and the web-only mutation/error behavior in the existing project host.

**Tests** — 1 file · `+25 / -0`

Adds focused regression coverage for the optional accessible project-hub back affordance.
