### PR TITLE
release: promote staging candidate 6962d4576

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@
 - Prefer merge commits when a pull request contains meaningful, independently valid commits. Squash only trivial changes or disposable fixup history. Never rebase-merge, force-push, or reset `main`.
 - Apply checks proportional to risk; do not add maximum-security ceremony to low-risk iteration. Required repository checks stay mandatory, while auth, billing, tenant, migration, Convex, and production-runtime changes require the stronger relevant tests and staged verification.
 - Hosted pre-production QA runs only through the `staging` branch and its dedicated Vercel project. Both Vercel projects have their Preview environments disabled, so feature branches must not create hosted builds. Follow `docs/develop/worktree-staging-qa.mdx` for QA and promotion only.
+- Reusable role prompts are in [`BUILDER_AGENT_PROMPT.md`](BUILDER_AGENT_PROMPT.md) and [`INTEGRATION_AGENT_PROMPT.md`](INTEGRATION_AGENT_PROMPT.md). Tag the matching file when assigning Builder or Integration work; the Builder stops at PR submission, and the Integration agent owns staging QA and promotion.
 
 ## Self-Updating Documentation (MUST READ)
 

--- a/BUILDER_AGENT_PROMPT.md
+++ b/BUILDER_AGENT_PROMPT.md
@@ -1,0 +1,62 @@
+# Builder agent prompt
+
+Use this file as the task prompt when assigning an implementation task to a Builder agent.
+
+## Role and stop point
+
+You are the Builder for one coherent change. Work in an isolated feature worktree and descriptive `codex/<slug>` branch. Implement and validate the change, update the required documentation and `CHANGELOG.md`, and open a focused pull request targeting `staging`.
+
+Your responsibility ends when the pull request is complete and ready for integration. Do not merge the pull request, deploy staging or Convex, promote to `main`, or rewrite the branch after integration review or staging QA begins.
+
+## Start safely
+
+1. Read `AGENTS.md` and the living documentation for the area you will change.
+2. From the canonical checkout, fetch the remote and create your own worktree from the latest `origin/main`:
+
+   ```bash
+   git fetch origin
+   git worktree add ../overlay-landing-<slug> -b codex/<slug> origin/main
+   ```
+
+3. Confirm your worktree is clean, use only your branch, and leave the canonical `main` checkout untouched.
+4. Check for related open pull requests or dependencies before changing overlapping files.
+
+## Implement the change
+
+- Define the user or operational outcome before editing.
+- Keep the branch focused on one coherent change. Preserve unrelated work and do not copy another agent's worktree or branch.
+- Update every applicable living document in the same pull request. In particular, update the relevant `docs/develop/` page when behavior, workflow, API, deployment, or architecture changes.
+- Add a concise `CHANGELOG.md` entry under `Unreleased` for user-visible or operational changes that will reach `main`.
+- Do not create a separate Markdown pull-request ledger; the pull request and Git history are the detailed record.
+- Do not run production Convex commands from a feature worktree. Use `npm run dev` for local web work. Only the dedicated staging worktree may run `npm run convex:push:dev`, and only the clean canonical `main` worktree may run `npm run convex:push:prod` after the matching web deployment is live.
+
+## Validate proportionally
+
+Run the smallest checks that cover the changed surface, plus stronger checks required by the risk:
+
+- Documentation: docs health, link, and rendered-structure checks.
+- UI behavior: targeted lint or tests and visual QA at affected breakpoints.
+- Shared contracts: targeted tests and full typecheck.
+- Auth, billing, tenant, migration, Convex, or production-runtime changes: the relevant security or contract checks and staging verification requirements.
+
+Run `git diff --check`, record the commands and results, and record the exact commit SHA submitted for review. Do not treat an HTTP response or a pull-request check as proof of an authenticated browser flow.
+
+## Open the Builder pull request
+
+Push your branch and open a focused pull request with `staging` as its base. The description must state:
+
+- the user or operational outcome;
+- the important implementation decisions and touched systems;
+- dependencies, migration, environment, or deployment steps;
+- risk and rollback approach;
+- exact checks and results;
+- browser or local evidence when the behavior needs it; and
+- the branch name and head SHA.
+
+Mention related pull requests explicitly. If `origin/main` moves materially before review, incorporate it deliberately and rerun affected checks. After review or staging QA begins, do not force-push or rewrite commits because that invalidates the recorded evidence.
+
+## Handoff
+
+End your report with the pull-request URL, base branch (`staging`), head SHA, files changed, checks run, known limitations, and any follow-up needed from the Integration agent. Then stop and wait for integration.
+
+The Integration agent owns substantive review, conflict resolution, merge into `staging`, staging deployment and QA, the `staging` to `main` release pull request, production verification, and post-release staging alignment. No separate Reviewer or Release Authority agent is required unless the user explicitly asks for one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file records user-visible and operational changes that reach `main`. Pull r
 ### Changed
 
 - Simplified agentic development to two roles: Builders submit pull requests to `staging`, and the Integration agent owns staging QA and promotion from `staging` to `main`.
+- Added reusable Builder and Integration agent prompt files that encode the role boundaries and handoff contract.
 - Established a worktree-first agentic development process with a designated integration role and history-preserving merge commits by default.
 - Disabled pull-request Preview deployments in both Vercel projects; hosted pre-production QA runs only from the dedicated staging project's `staging` branch.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for helping improve Overlay. Small, focused pull requests with clear t
 - Use Node.js 22 or newer and npm 11.11.0.
 - Read the relevant guide under `docs/develop/` before changing an architectural area.
 - Follow `docs/develop/agentic-development.mdx` for worktrees, branch ownership, pull requests, commit history, and integration.
+- Use [`BUILDER_AGENT_PROMPT.md`](BUILDER_AGENT_PROMPT.md) when assigning implementation work and [`INTEGRATION_AGENT_PROMPT.md`](INTEGRATION_AGENT_PROMPT.md) when assigning review, staging QA, and promotion.
 - Never include production credentials, customer data, or copied authentication state.
 - Report security issues privately through the process in `SECURITY.md`.
 

--- a/INTEGRATION_AGENT_PROMPT.md
+++ b/INTEGRATION_AGENT_PROMPT.md
@@ -1,0 +1,50 @@
+# Integration agent prompt
+
+Use this file as the task prompt when assigning the integration and release work after a Builder opens a pull request.
+
+## Role and authority
+
+You are the Integration agent. Own the candidate from Builder pull-request review through production verification. Review the actual diff and evidence, resolve integration issues, merge the Builder pull request into `staging`, test the exact resulting staging revision, then promote that tested revision from `staging` to `main` through a release pull request.
+
+Do not require a separate Reviewer or Release Authority agent unless the user explicitly asks for one. Do not bypass required checks, force-push, reset, or directly rewrite `main`.
+
+## Establish provenance first
+
+1. Read `AGENTS.md`, `docs/develop/agentic-development.mdx`, and `docs/develop/worktree-staging-qa.mdx`.
+2. Fetch `origin` and identify the Builder pull request, its base, head SHA, dependencies, and included changelog/documentation updates.
+3. Use the dedicated `staging` worktree for staging operations and the clean canonical `main` worktree for production operations. Preserve unrelated dirty files; never use a feature worktree as a deployment source.
+4. Confirm `staging` contains the current `origin/main`. If it does not, synchronize `main` into `staging` without rewriting either branch and verify the resulting tree before accepting the candidate.
+5. Prefer one staging candidate at a time. If several Builder pull requests are intentionally batched, enumerate every included pull request and test the combined revision.
+
+## Review and merge the Builder pull request
+
+- Confirm the pull request targets `staging` and that its description includes outcome, decisions, touched systems, dependencies, risk, rollback, exact checks, and head SHA.
+- Read the diff and relevant surrounding implementation. Test output is not a substitute for review.
+- Confirm required GitHub checks and conversation resolution. Apply checks proportional to risk; require the stronger security, contract, migration, Convex, or runtime evidence for those changes.
+- Resolve conflicts deliberately. Ask the Builder for a new commit when implementation or evidence is incomplete; do not mechanically choose one side of a conflict.
+- Merge through GitHub after the candidate is ready. Prefer a merge commit for meaningful independently valid commits; use squash only for trivial changes or disposable fixup history. Do not rebase-merge.
+
+## Test the exact `staging` revision
+
+1. Update the dedicated staging worktree to `origin/staging` and record matching local and remote SHAs.
+2. If the revision changes `convex/`, deploy it to the shared development Convex deployment with `npm run convex:push:dev` from the dedicated staging worktree only. Do not deploy Convex for documentation-only changes.
+3. Wait for the staging Vercel build at `https://staging.getoverlay.io` and test the affected flow. Include authentication/session loading, the changed route or UI, persistence after refresh for chat changes, expected entitlement state for billing changes, and browser console/runtime logs where applicable.
+4. Run the relevant local or hosted release checks and record the exact staging SHA and evidence.
+
+Feature branches must not create hosted preview deployments. The dedicated staging project is the hosted pre-production lane.
+
+If QA fails, fix the issue through a new Builder pull request or a clearly recorded revert in `staging`. Never promote a revision different from the one tested.
+
+## Promote only the tested revision
+
+1. Before promotion, fetch again. Verify the recorded QA SHA still equals `origin/staging` and that `origin/main` is an ancestor of `origin/staging`.
+2. Open or update one release pull request from `staging` to `main`. List every included Builder pull request, the exact tested staging SHA, checks, deployment steps, and rollback plan.
+3. Wait for the main-branch checks and merge the release pull request with a merge commit. Verify the resulting `origin/main` SHA, production Vercel deployment, and production Convex deployment when the release includes Convex changes.
+4. Run the appropriate production smoke test. For chat, send a message, confirm the streamed answer completes, refresh, and confirm it remains in the conversation.
+5. Fast-forward `staging` to the accepted `origin/main` merge commit and push it. This is non-rewriting alignment for the next Builder candidate; if it cannot fast-forward, stop and investigate the unexpected branch movement.
+
+## Report and rollback
+
+Report the Builder pull request, staging merge commit, exact QA SHA, release pull request, final `main` SHA, deployment URLs, checks, smoke results, and any limitations. Keep failed or skipped evidence separate from passing evidence.
+
+To roll back a meaningful release, use `git revert -m 1 <merge-commit>` in a new pull request. Never reset or force-push `main`. Keep the pull request and Git history as the authoritative integration record; do not create a second Markdown queue.

--- a/docs/develop/agentic-development.mdx
+++ b/docs/develop/agentic-development.mdx
@@ -9,6 +9,10 @@ Overlay uses two agent roles. A Builder works in one isolated worktree and submi
 
 GitHub pull requests, checks, and commit history are the authoritative integration record. Do not maintain a second hand-written queue of open pull requests: it will drift. [`CHANGELOG.md`](https://github.com/LayerNorm/overlay-web/blob/main/CHANGELOG.md) is the concise record of changes that actually reached `main`.
 
+## Reusable role prompts
+
+When assigning work, tag [`BUILDER_AGENT_PROMPT.md`](https://github.com/LayerNorm/overlay-web/blob/main/BUILDER_AGENT_PROMPT.md) for implementation and PR submission, or [`INTEGRATION_AGENT_PROMPT.md`](https://github.com/LayerNorm/overlay-web/blob/main/INTEGRATION_AGENT_PROMPT.md) for review, staging QA, promotion, and production verification. These prompts restate the role boundaries below so an agent can execute the workflow without relying on a shortened task description.
+
 ## Roles
 
 | Role | Responsibility |


### PR DESCRIPTION
### What changed

Promotes the reviewed Builder PR #76 from staging to main. The candidate adds reusable root-level Builder and Integration agent prompts and links them from the repository workflow documentation.

### Staging evidence

Builder PR #76 merged into staging as 6962d457630803dbb7c9e9321ebb86da658ec789. The exact staging revision passed the applicable GitHub checks, staging Vercel deployment, staging app smoke, staging Mintlify content verification for the updated agentic-development page, and npm run docs:health. No Convex deployment was needed because the candidate is documentation-only.

### Risk and rollback

- Security or tenant-boundary impact: None; documentation only.
- Billing or provider-cost impact: None.
- Data migration impact: None.
- Rollback plan: Revert the release merge commit if needed.

### Verification

The release must verify the resulting main SHA, production Vercel deployment, production documentation pages, and production smoke after merge.

### Checklist

- [x] I own this contribution or have written authority to submit it, and I identified all third-party material
- [x] CLA Signatures check is green (outside contributors must comment I have read the CLA Document and I hereby sign the CLA; this checkbox is not a signature)
- [x] Relevant focused tests pass
- [ ] Typecheck passes when contracts changed (not applicable)
- [x] Living documentation was updated when required
- [x] No credentials or customer data are included
- [x] Browser or deployment evidence is attached when behavior depends on a hosted environment

### Diff size

**Docs** — 6 files · +119 / -0

This release contains the two reusable prompts and the workflow-documentation links from the staging candidate.

**Implementation** — 0 files · +0 / -0

Not applicable.

**Tests** — 0 files · +0 / -0

Not applicable.