### PR TITLE
Fix: project tiles fill their grid cell so the per-tile menu lands inside

### DIFF
--- a/packages/overlay-ui/src/components/primitives/Tile.tsx
+++ b/packages/overlay-ui/src/components/primitives/Tile.tsx
@@ -64,7 +64,7 @@ export function Tile({
       disabled={Component === 'button' ? disabled : undefined}
       aria-disabled={disabled || undefined}
       className={cn(
-        'group relative flex min-h-32 flex-col rounded-lg border p-4 text-left transition-colors',
+        'group relative flex min-h-32 w-full flex-col rounded-lg border p-4 text-left transition-colors',
         interactive
           ? 'cursor-pointer border-[var(--border)] bg-[var(--surface-elevated)] hover:border-[var(--muted-light)] hover:bg-[var(--surface-subtle)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--foreground)] disabled:pointer-events-none disabled:opacity-60'
           : null,


### PR DESCRIPTION
## Summary
Tile renders as a button, which shrink-wraps content; inside a grid cell the button was narrower than the cell, so the absolutely positioned per-tile menu anchored to the cell's right edge — the three-dot button floated outside the tile border on the Projects page (and any other shrink-wrapped Tile). Tiles now fill their cell (w-full).

## QA
- tsc --noEmit and targeted eslint clean.
- Staging deploy ag1cvst0k Ready; Projects page shows the menu button inside each tile's top-right corner.

Generated with [Claude Code](https://claude.com/claude-code)
