### PR TITLE
Release: Agent Host 0.3.5 with ACP slash-command pass-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file records user-visible and operational changes that reach `main`. Pull r
 
 ### Changed
 
+- Released the Agent Host and bridge protocol together at `0.3.5`, which forwards agents' advertised ACP slash commands (`available_commands_update`) to the transcript; production DM slash menus and the composer slash button activate once connected hosts are restarted on `0.3.5`.
 - Unified the list-page UI system: added shared `Tile`, `TileGrid`, `TileIcon`, `TileSkeleton`, `CreateTile`, `ListRow`, and `HeaderSearch` primitives to `@overlay/ui` and migrated the Projects, Knowledge, Agents, and Extensions (Connectors, Skills, MCP Servers) list pages plus the Files/Knowledge header onto them, so tiles, list rows, and page headers share one spacing, radius, hover, and dark-mode language.
 - Projects can now be archived and restored from a three-dot menu on each project tile, and the projects sidebar gained All/Archived subpages that list active and archived projects respectively.
 - Newly created projects now open straight into inline rename with the title text pre-selected, whether created from the projects page or the sidebar, so the name can be typed immediately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34755,7 +34755,7 @@
     },
     "packages/overlay-agent-bridge-protocol": {
       "name": "@layernorm/overlay-agent-bridge-protocol",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^3.25.76"
@@ -34767,11 +34767,11 @@
     },
     "packages/overlay-agent-host": {
       "name": "@layernorm/overlay-agent-host",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
-        "@layernorm/overlay-agent-bridge-protocol": "0.3.4",
+        "@layernorm/overlay-agent-bridge-protocol": "0.3.5",
         "ai": "7.0.65",
         "eve": "0.44.4",
         "tsx": "^4.8.1",

--- a/packages/overlay-agent-bridge-protocol/package.json
+++ b/packages/overlay-agent-bridge-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layernorm/overlay-agent-bridge-protocol",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Versioned command and event contracts for Overlay Agent Host.",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/packages/overlay-agent-host/package.json
+++ b/packages/overlay-agent-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layernorm/overlay-agent-host",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Outbound-only host for connecting user-owned and managed agents to Overlay.",
   "license": "AGPL-3.0-only",
   "repository": {
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.4.0",
-    "@layernorm/overlay-agent-bridge-protocol": "0.3.4",
+    "@layernorm/overlay-agent-bridge-protocol": "0.3.5",
     "ai": "7.0.65",
     "eve": "0.44.4",
     "tsx": "^4.8.1",

--- a/src/server/agents/agent-enrollment-command.test.ts
+++ b/src/server/agents/agent-enrollment-command.test.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { buildAgentHostEnrollmentCommand } from './agent-enrollment-command'
+import { OVERLAY_AGENT_HOST_PACKAGE_VERSION, buildAgentHostEnrollmentCommand } from './agent-enrollment-command'
+
+/** The pinned host version must track the release constant, not a copied literal. */
+function expectedCommand(params: { code: string; origin: string; adapterId?: string }): string {
+  const adapter = params.adapterId ? ` --adapter ${params.adapterId}` : ''
+  return `npx --yes --package node@24 --package @layernorm/overlay-agent-host@${OVERLAY_AGENT_HOST_PACKAGE_VERSION} overlay-agent-host connect ${params.code} --server ${params.origin}${adapter} --run`
+}
 
 test('the copyable enrollment command starts the selected harness in one step', () => {
   assert.equal(
@@ -9,14 +15,14 @@ test('the copyable enrollment command starts the selected harness in one step', 
       origin: 'https://getoverlay.io',
       adapterId: 'claude-code',
     }),
-    'npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.2 overlay-agent-host connect single-use-code --server https://getoverlay.io --adapter claude-code --run',
+    expectedCommand({ code: 'single-use-code', origin: 'https://getoverlay.io', adapterId: 'claude-code' }),
   )
 })
 
 test('the compatibility command still starts the host when no harness is selected', () => {
   assert.equal(
     buildAgentHostEnrollmentCommand({ code: 'single-use-code', origin: 'https://getoverlay.io' }),
-    'npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.2 overlay-agent-host connect single-use-code --server https://getoverlay.io --run',
+    expectedCommand({ code: 'single-use-code', origin: 'https://getoverlay.io' }),
   )
 })
 
@@ -27,7 +33,7 @@ test('the copyable enrollment command starts Hermes through its official ACP ser
       origin: 'https://getoverlay.io',
       adapterId: 'hermes',
     }),
-    'npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.2 overlay-agent-host connect single-use-code --server https://getoverlay.io --adapter hermes --run',
+    expectedCommand({ code: 'single-use-code', origin: 'https://getoverlay.io', adapterId: 'hermes' }),
   )
 })
 

--- a/src/server/agents/agent-enrollment-command.ts
+++ b/src/server/agents/agent-enrollment-command.ts
@@ -1,6 +1,6 @@
 import type { BuiltInUserOwnedAcpAdapterId } from '@overlay/workspace-contracts'
 
-export const OVERLAY_AGENT_HOST_PACKAGE_VERSION = '0.3.4'
+export const OVERLAY_AGENT_HOST_PACKAGE_VERSION = '0.3.5'
 export const OVERLAY_AGENT_HOST_PACKAGE_SPEC = `@layernorm/overlay-agent-host@${OVERLAY_AGENT_HOST_PACKAGE_VERSION}`
 export const OVERLAY_AGENT_HOST_NODE_SPEC = 'node@24'
 


### PR DESCRIPTION
## Summary
Bumps @layernorm/overlay-agent-host and @layernorm/overlay-agent-bridge-protocol to 0.3.5 so published hosts forward agents' advertised ACP slash commands (available_commands_update). 0.3.4 predated the pass-through, so production DM slash menus and the composer slash button had nothing to render — this unblocks them once connected hosts restart on 0.3.5.

Also pins the enrollment command constant to the released version and derives the enrollment test expectations from the constant (they had drifted to 0.3.2).

## Checks
- verify:agent-host-release: internally pinned and consistent at 0.3.5
- pack + smoke (clean package install and runtime import on Node 24+): pass
- agent-enrollment-command + connected-agent-rollout tests: pass
- tsc --noEmit clean

Generated with [Claude Code](https://claude.com/claude-code)
