### PR TITLE
Agents roster follows recency; offline BYO environments explain recovery

### DIFF
--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -73,6 +73,8 @@ Slack, Microsoft Teams, Telegram, and similar products are interaction endpoints
 
 This is the first implemented slice. It establishes the product hierarchy, but it does not yet deliver the complete control plane.
 
+The roster now defaults to the most recently used agent per workspace and orders the sidebar by recency (client-side open history; server-side last-run timestamps are a future refinement). A failed conversation open retries and then surfaces an explicit error with a manual retry instead of sticking on the blank state.
+
 ### Step 2 — Create agents from conversation
 
 - Add a first-class `create_agent` tool callable from chat.
@@ -85,6 +87,7 @@ This is the first implemented slice. It establishes the product hierarchy, but i
 - Add current work, routines, knowledge, tools, runtime status, activity, artifacts, cost, and approvals around the conversation.
 - Make failures and blocked access obvious and actionable.
 - Let operators pause, resume, reassign, inspect, and improve an agent without changing its identity.
+- Decide reconnect semantics for customer-controlled runtimes: hosts are outbound-only, so Overlay cannot wake a sleeping machine. Queued work is claimed automatically when a host returns, but interrupted runs need an explicit Resume — consider auto-resuming host-offline recoveries on heartbeat return once the duplicate-work and Eve-cursor risks are resolved.
 
 ### Step 4 — Make successful work repeatable
 

--- a/AGENT_PLAN.md
+++ b/AGENT_PLAN.md
@@ -1,0 +1,106 @@
+# Agent-first product plan
+
+This is a good first step, not a finished product specification. A lot will change as we put real agents to work, observe where they fail, and learn which controls people and organizations actually need.
+
+> **Overlay is the control plane for your AI workforce—create or connect agents, give them everything they need to work, and manage them from anywhere.**
+
+## Direction
+
+Overlay is the control plane for an organization's AI workforce. Agents are the primary unit of productivity: durable workers with identities, outcomes, tools, knowledge, permissions, routines, runtime access, activity, and accountable histories.
+
+Chat and collaboration remain important, but they are supporting interaction surfaces. A user should be able to manage an agent in Overlay and work with it from Overlay, Slack, Microsoft Teams, Telegram, or another existing surface without migrating the organization into a new chat product.
+
+The product should optimize for measurable return: useful outcomes completed, time saved, operating cost, reliability, approval burden, and how often an agent can repeat the work successfully.
+
+## Product model
+
+Each agent should have:
+
+- An identity: name, role, owner, team, visibility, and organizational purpose.
+- An outcome: a plain-language job it is responsible for completing.
+- Conversations: the threads where people direct it, review work, and resolve exceptions.
+- Tools and access: software, APIs, browser, terminal, computers, credentials, and approval rules.
+- Knowledge: workspace context, connected sources, memories, and agent-specific instructions.
+- Routines: scheduled, event-driven, and recurring work owned by the agent.
+- Runtime: Overlay-managed or customer-controlled execution, with health and availability.
+- Activity: current work, completed runs, artifacts, decisions, failures, cost, and audit history.
+
+Agent identity must remain stable when its model, harness, or runtime changes. Overlay owns the control plane; execution can happen wherever the organization requires.
+
+## Creation should feel effortless
+
+Creating an agent should be a tool call away from any chat. A person describes an outcome in ordinary language, and Overlay can call an agent-creation tool instead of making them start with a configuration form.
+
+The creation conversation should feel like creating a Grok bot: the agent chats with the user, progressively shapes the job, and asks for tool access in context instead of presenting a wall of configuration. The flow should:
+
+1. Ask what outcome the agent should own.
+2. Propose a name, instructions, and working cadence.
+3. Discover the minimum tools, knowledge, credentials, and runtime access required.
+4. Ask for access at the moment it is needed, with a clear explanation of why.
+5. Present sensitive grants and consequential actions for explicit approval.
+6. Create the agent, open its conversation, and help it complete a first real task.
+7. Offer to make successful work recurring only after the first outcome is verified.
+
+The structured editor remains useful for inspection, administration, and precise changes. It should not be the only way to create an agent.
+
+## Product surfaces
+
+### Agents
+
+Agents are the primary navigation item and the default authenticated home. The left sidebar is the workforce roster. Selecting an agent opens its conversation directly instead of navigating to a directory of cards.
+
+The conversation header opens the selected agent's settings in the shared right-side panel. The same panel becomes an overlay dialog on smaller screens. Creating a new agent uses this editor surface for now, while conversational creation is built.
+
+Over time, the selected agent surface should expand beyond one conversation to include its active work, routines, knowledge, access, runtime health, activity, cost, and outcomes without losing the conversation as the fastest way to direct it.
+
+### Chat and collaboration
+
+Chats, direct messages, channels, files, and projects remain available, but below Agents in the hierarchy. They are places where humans and agents coordinate, not the core positioning of the product.
+
+### External surfaces
+
+Slack, Microsoft Teams, Telegram, and similar products are interaction endpoints. Start with narrow, explicit conversation bridges and bot interactions. Do not import an entire external workspace or turn Overlay into a wrapper around another collaboration product.
+
+## Delivery sequence
+
+### Step 1 — Make agents the front door
+
+- Put Agents above Chats in primary navigation.
+- Make Agents the default authenticated destination.
+- Replace the authenticated agent directory with the selected agent's conversation.
+- Open create and edit controls in the shared right-side panel or its small-screen dialog presentation.
+- Preserve existing full-page editor URLs as compatibility paths while the new surface settles.
+
+This is the first implemented slice. It establishes the product hierarchy, but it does not yet deliver the complete control plane.
+
+### Step 2 — Create agents from conversation
+
+- Add a first-class `create_agent` tool callable from chat.
+- Build the outcome-first interview and access-request flow.
+- Convert the accepted proposal into the same durable agent contract used by the editor.
+- Open the new agent's conversation and guide it through a verified first outcome.
+
+### Step 3 — Give each agent an operating page
+
+- Add current work, routines, knowledge, tools, runtime status, activity, artifacts, cost, and approvals around the conversation.
+- Make failures and blocked access obvious and actionable.
+- Let operators pause, resume, reassign, inspect, and improve an agent without changing its identity.
+
+### Step 4 — Make successful work repeatable
+
+- Turn completed conversations into scheduled or event-driven routines.
+- Attribute every routine and run to an agent.
+- Deliver results into Overlay and selected external surfaces.
+- Track outcome quality, reliability, intervention rate, time saved, and cost.
+
+### Step 5 — Prove real organizational ROI
+
+- Dogfood recurring research, monitoring, admissions, legal review, and operational workflows.
+- Pair product telemetry with customer-defined value measures.
+- Use forward deployment to close the gap between a general agent platform and dependable work in each organization.
+
+## Near-term success criteria
+
+The first complete proof is not that a user sent an agent a message. It is that a user described a meaningful recurring job, created or connected an agent, granted the minimum required access, received a verifiable result, and then repeated that result with less intervention.
+
+We should be able to answer, for every active agent: What outcome does it own? What is it doing now? What can it access? What has it produced? What did it cost? Where is it blocked? How much value has it returned?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This file records user-visible and operational changes that reach `main`. Pull r
 
 ### Changed
 
+- Made Agents the first primary navigation item and default authenticated home. Selecting an agent now opens its conversation directly, while create and edit controls use the shared right-side panel (and its small-screen dialog presentation) instead of the authenticated directory grid.
 - Released the Agent Host and bridge protocol together at `0.3.5`, which forwards agents' advertised ACP slash commands (`available_commands_update`) to the transcript; production DM slash menus and the composer slash button activate once connected hosts are restarted on `0.3.5`.
 - Unified the list-page UI system: added shared `Tile`, `TileGrid`, `TileIcon`, `TileSkeleton`, `CreateTile`, `ListRow`, and `HeaderSearch` primitives to `@overlay/ui` and migrated the Projects, Knowledge, Agents, and Extensions (Connectors, Skills, MCP Servers) list pages plus the Files/Knowledge header onto them, so tiles, list rows, and page headers share one spacing, radius, hover, and dark-mode language.
 - Projects can now be archived and restored from a three-dot menu on each project tile, and the projects sidebar gained All/Archived subpages that list active and archived projects respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file records user-visible and operational changes that reach `main`. Pull r
 
 ### Added
 
+- Offline Bring-Your-Own-Agent environments now explain themselves in Settings → Environments: why the machine went quiet (asleep or connector closed), that Overlay cannot wake it remotely, and — on macOS — a one-click copy of the persistent-service install command so the connector survives Terminal restarts and logins. The enrollment setup prompt now nudges toward the persistent service for the same reason.
 - Workspace agents now have an access mode: **Only me** (`visibility: 'creator'`) or **Everyone in workspace** (`visibility: 'workspace'`, the default). Creator-only agents are hidden from the agents directory, workspace search, and direct reads for everyone but their creator (reported as not found, so their existence does not leak); only the creator can edit them, while workspace managers keep archive access as a safety valve. The agent editor has a matching Access control and directory tiles show an "Only me" badge. Backed by Postgres migration `0073_agent_visibility` (nullable column; existing agents stay workspace-visible) with no Convex migration needed.
 - Creator-only agents are now also gated on every invocation path: DMs with one by anyone but its creator return 404, @-mentions of one by non-creators silently produce no agent run (including in pre-existing DMs after an Everyone → Only me flip), and new creator-only agents no longer auto-join public channels. Flipping Only me → Everyone grants no retroactive channel joins.
 - Agent creation and editing moved from a dialog to dedicated full-page routes (`/app/agents/new` and `/app/agents/:id`) with Identity, Behavior, Access, Connection, and Danger-zone sections, a sticky save bar, and a post-create "Say hello" handoff that opens a DM with the new agent. Directory tiles now attribute each agent to its creator ("by {name}").
@@ -15,6 +16,7 @@ This file records user-visible and operational changes that reach `main`. Pull r
 
 ### Changed
 
+- The Agents roster now opens the most recently used agent per workspace and orders the sidebar by recency (unused agents stay alphabetical). A conversation open that fails no longer sticks on the blank state: it retries, then shows an explicit error with a manual Retry.
 - Made Agents the first primary navigation item and default authenticated home. Selecting an agent now opens its conversation directly, while create and edit controls use the shared right-side panel (and its small-screen dialog presentation) instead of the authenticated directory grid.
 - Released the Agent Host and bridge protocol together at `0.3.5`, which forwards agents' advertised ACP slash commands (`available_commands_update`) to the transcript; production DM slash menus and the composer slash button activate once connected hosts are restarted on `0.3.5`.
 - Unified the list-page UI system: added shared `Tile`, `TileGrid`, `TileIcon`, `TileSkeleton`, `CreateTile`, `ListRow`, and `HeaderSearch` primitives to `@overlay/ui` and migrated the Projects, Knowledge, Agents, and Extensions (Connectors, Skills, MCP Servers) list pages plus the Files/Knowledge header onto them, so tiles, list rows, and page headers share one spacing, radius, hover, and dark-mode language.
@@ -31,6 +33,7 @@ This file records user-visible and operational changes that reach `main`. Pull r
 
 ### Fixed
 
+- Pinned the Agent Host CLI restart/service hints, README, and launchd test to the released `0.3.5` line (they still pointed at `0.3.4`), and extended the release-gate script to assert all version pins together so the drift cannot recur.
 - Fixed Workspace → People showing the authenticated provider user ID instead of the person’s profile name; existing member principals are repaired from the current browser session, and newly created workspaces start with the correct owner name.
 - Allowed `data-remote-agent-commands` parts in the conversation message schema and BFF serialization: the Convex validator rejected connected-agent command events with 500s, and the BFF conversation serializer dropped the commands payload, leaving the agent DM slash menu empty after a page load.
 - Fixed the agent DM slash menu ignoring typed input: the composer kept its live text outside React state by design, so the slash-menu hook only ever saw programmatically set text — typing `/` did not open the menu, filtering and selection did not update, and choosing a command left the menu stuck open. Typing now refreshes composer state only while a slash token is on screen, preserving the no-re-render-per-keystroke behavior for normal text.

--- a/THESIS.md
+++ b/THESIS.md
@@ -1,0 +1,32 @@
+# Overlay thesis
+
+> **Overlay is the control plane for your AI workforce—create or connect agents, give them everything they need to work, and manage them from anywhere.**
+
+Overlay is an agent platform first. Chat and workspaces are interaction and collaboration surfaces, not the primary product.
+
+The agent is the durable unit of productivity. Each agent has an identity, an outcome to own, threads, tools, knowledge, credentials, permissions, routines, runtime access, activity, and an accountable history. Its identity remains stable whether it runs in Overlay Cloud, on a customer-controlled machine, or through another agent harness.
+
+Overlay owns the control plane around that work: creation, deployment, context, access, scheduling, approvals, observability, cost, audit, and improvement. Agents can use browsers, terminals, software, APIs, and connected computers to perform knowledge work. Humans can direct and supervise them from Overlay or from the communication surfaces their organizations already use.
+
+Slack, Microsoft Teams, Telegram, and similar products are distribution surfaces, not migration requirements. Overlay's existing chats, channels, files, projects, and collaboration features remain valuable, but they support the agent workforce rather than define the product.
+
+## Product principles
+
+1. **Start with the outcome.** Ask what work the agent should own before exposing models, tools, or orchestration.
+2. **Treat agents as first-class workers.** Give every agent a persistent identity, responsibilities, resources, access, status, and history.
+3. **Separate identity from execution.** An agent can change runtimes without losing its threads, knowledge, permissions, routines, or organizational role.
+4. **Meet people where they work.** Let teams invoke agents and receive results through existing communication surfaces while Overlay remains the place to configure and supervise them.
+5. **Make autonomy legible and governable.** Show what an agent is doing, what it changed, what it costs, when it needs approval, and how to stop or correct it.
+6. **Prove economic value.** Optimize for reliable completed outcomes and measurable return, not message volume or time spent in the interface.
+
+## North star
+
+Overlay should increase the number and quality of useful outcomes an organization can produce with the people, knowledge, and capital it already has.
+
+The product should reduce the time from describing a job to receiving the first verified result, then make that result repeatable with less human intervention. Useful supporting measures include successful autonomous runs, recurring outcomes delivered, approval burden, exception rate, time saved, operating cost, and retained active agents.
+
+## Initial product proof
+
+A user describes a recurring job, creates or connects an agent, grants the required resources, and chooses where results should appear. The agent completes the work, exposes its progress and evidence, asks for approval when necessary, and returns on schedule to do it again.
+
+Research, monitoring, and operational workflows are the first proving grounds because together they test synthesis, persistent observation, and real-world action.

--- a/docs/develop/bring-your-own-agents.md
+++ b/docs/develop/bring-your-own-agents.md
@@ -412,7 +412,10 @@ for a short, explicitly displayed window; the UI must show `Waiting for <environ
 Cancel and Retry. Commands are durable and claim-once. Revocation prevents new claims
 immediately; active credentials expire and leases terminate safely. Reconnect resumes from
 acknowledged command/event cursors. Duplicate sequences are acknowledged without reapplying;
-gaps are rejected with the next expected sequence.
+gaps are rejected with the next expected sequence. The Environments settings surface repeats
+the likely cause for an offline user-owned environment (asleep machine or closed connector),
+states that Overlay cannot wake it remotely, and offers the persistent-service install
+command on macOS.
 
 ## Supported platforms
 

--- a/docs/develop/bring-your-own-agents.md
+++ b/docs/develop/bring-your-own-agents.md
@@ -232,8 +232,8 @@ Claude, or equivalent authentication directory into a managed sandbox.
 Phase 7 makes `@layernorm/overlay-agent-host` and `@layernorm/overlay-agent-bridge-protocol` publishable packages and
 requires Node.js 24. The first production package line is `0.1.0`; Hermes support was released in
 the lockstep `0.2.0` package line under the shorter legacy names. The product-qualified public
-package names begin with lockstep `0.3.0`; the current PATH-safe release line is lockstep `0.3.4`. The application copies an exact
-`npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.4 overlay-agent-host ...`
+package names begin with lockstep `0.3.0`; the current PATH-safe release line is lockstep `0.3.5`. The application copies an exact
+`npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.5 overlay-agent-host ...`
 command rather than following npm `latest` or inheriting an unsupported system Node runtime. The host and
 protocol packages release together, the host depends on the exact protocol version, and the npm
 release workflow publishes compiled ESM plus declarations for both packages with provenance after

--- a/docs/develop/cache-components-design-decisions.md
+++ b/docs/develop/cache-components-design-decisions.md
@@ -46,11 +46,13 @@ resolving any blocking I/O (moving `cookies()`/`headers()` reads inside
 
 ### Batch 4 — Low-risk /app/* child routes (10 routes)
 
-14. `/app` (index) — `src/app/app/page.tsx` — Pure `redirect('/app/chat')`. Removed opt-out.
+14. `/app` (index) — `src/app/app/page.tsx` — Pure redirect to the authenticated
+    Agents home. Removed opt-out.
 15. `/app/memories` — `src/app/app/memories/page.tsx` — Pure redirect. Removed opt-out.
 16. `/app/outputs` — `src/app/app/outputs/page.tsx` — Pure redirect. Removed opt-out.
-17. `/app/agents` — `src/app/app/agents/page.tsx` — Reads `searchParams` only, no
-    session. Removed opt-out.
+17. `/app/agents` — `src/app/app/agents/page.tsx` — Resolves the showcase flag and
+    authenticated client-side agent conversation workspace together inside
+    `<Suspense>`. Removed opt-out.
 18. `/app/notes` — `src/app/app/notes/page.tsx` — Moved `getOverlaySession()` +
     `redirect()` inside new `<Suspense>` with `ChatRouteSkeleton` fallback.
 19. `/app/activity` — `src/app/app/activity/page.tsx` — Moved `getOverlaySession()`

--- a/docs/develop/customization.mdx
+++ b/docs/develop/customization.mdx
@@ -19,7 +19,7 @@ export const overlayAppShell = defineOverlayAppConfig({
     name: 'Acme AI',
     shortName: 'Acme',
     logoSrc: '/assets/acme-logo.png',
-    homeHref: '/app/chat',
+    homeHref: '/app/agents',
     supportEmail: 'it@acme.example',
   },
   navigation: [
@@ -41,7 +41,9 @@ export const overlayAppShell = defineOverlayAppConfig({
 
 Registries merge with defaults by `id`. If you provide an item with the same `id`, Overlay replaces that item’s metadata. Unspecified default items remain available.
 
-While Settings is open, the primary rail exposes a temporary return item after the normal navigation list. It uses the existing `X` icon and the label `Settings`, and returns the user to Chats; it should not be inserted at the top of the primary navigation.
+Agents lead the default primary navigation and `/app/agents` is the authenticated home. The authenticated Agents surface uses the contextual sidebar as its roster; selecting an agent opens that agent's direct conversation. The conversation header's settings control composes the existing agent editor inside `AppScreenSidePanel`, which is docked on desktop and presented as an overlay dialog on smaller screens. The full-page `/app/agents/new` and `/app/agents/:id` routes remain compatibility entry points.
+
+While Settings is open, the primary rail exposes a temporary return item after the normal navigation list. It uses the existing `X` icon and the label `Settings`, and returns the user to Agents; it should not be inserted at the top of the primary navigation.
 
 ## Component Keys
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28734,9 +28734,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21885,9 +21885,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -24800,9 +24800,9 @@
       }
     },
     "node_modules/jspdf/node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/jsx-ast-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "@workflow/world-postgres": "4.3.5",
         "@workos-inc/authkit-nextjs": "^2.14.0",
         "@workos-inc/node": "^8.7.0",
-        "@xmldom/xmldom": "^0.9.9",
+        "@xmldom/xmldom": "^0.9.12",
         "@xyflow/react": "^12.11.2",
         "ai": "^7.0.65",
         "better-auth": "^1.6.23",
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@authenio/xml-encryption/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -16262,9 +16262,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -25434,9 +25434,9 @@
       }
     },
     "node_modules/mammoth/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -30628,9 +30628,9 @@
       }
     },
     "node_modules/samlify/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -34451,9 +34451,9 @@
       }
     },
     "node_modules/xml-crypto/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3735,25 +3735,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }

--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "@workflow/world-postgres": "4.3.5",
     "@workos-inc/authkit-nextjs": "^2.14.0",
     "@workos-inc/node": "^8.7.0",
-    "@xmldom/xmldom": "^0.9.9",
+    "@xmldom/xmldom": "^0.9.12",
     "@xyflow/react": "^12.11.2",
     "ai": "^7.0.65",
     "better-auth": "^1.6.23",

--- a/packages/overlay-agent-host/README.md
+++ b/packages/overlay-agent-host/README.md
@@ -8,7 +8,7 @@ Node.js 24 or newer is required. Overlay's one-copy command supplies a pinned No
 when the machine's default `node` is older:
 
 ```sh
-npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.4 \
+npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.5 \
   overlay-agent-host connect <enrollment-code> \
   --server https://getoverlay.io \
   --kind vps \
@@ -68,7 +68,7 @@ network URL:
 The equivalent enrollment form is:
 
 ```sh
-npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.4 \
+npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.5 \
   overlay-agent-host connect <enrollment-code> \
   --server https://getoverlay.io \
   --kind vps \
@@ -92,9 +92,9 @@ Terminal closes and returns after login or process failure. Use the exact config
 `connect`:
 
 ```sh
-npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.4 \
+npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.5 \
   overlay-agent-host service install --config "$HOME/.overlay/agent-host/config.json"
-npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.4 \
+npx --yes --package node@24 --package @layernorm/overlay-agent-host@0.3.5 \
   overlay-agent-host service status --config "$HOME/.overlay/agent-host/config.json"
 ```
 

--- a/packages/overlay-agent-host/src/cli.ts
+++ b/packages/overlay-agent-host/src/cli.ts
@@ -19,7 +19,7 @@ import { verifyHermesAcpReadiness } from './hermes-readiness.js'
 import { assertSupportedNodeVersion } from './runtime-version.js'
 import { installLaunchAgent, launchAgentStatus, uninstallLaunchAgent } from './launchd.js'
 
-const PACKAGE_SPEC = '@layernorm/overlay-agent-host@0.3.4'
+const PACKAGE_SPEC = '@layernorm/overlay-agent-host@0.3.5'
 
 assertSupportedNodeVersion()
 

--- a/packages/overlay-agent-host/src/launchd.test.ts
+++ b/packages/overlay-agent-host/src/launchd.test.ts
@@ -8,7 +8,7 @@ test('macOS service definitions are restartable and escape paths safely', () => 
     environmentId: 'environment:one',
     configPath: "/Users/test/O'Reilly/config.json",
     stateDirectory: '/Users/test/Agent & Host',
-    packageSpec: '@layernorm/overlay-agent-host@0.3.4',
+    packageSpec: '@layernorm/overlay-agent-host@0.3.5',
     executablePath: '/Users/test/.local/bin:/opt/homebrew/bin:/usr/bin:/bin',
   })
   assert.match(plist, /KeepAlive/)

--- a/packages/overlay-app-core/src/app-shell.test.ts
+++ b/packages/overlay-app-core/src/app-shell.test.ts
@@ -14,7 +14,7 @@ import {
 test('resolveOverlayAppShellConfig merges registry overrides by id', () => {
   const shell = resolveOverlayAppShellConfig({
     navigation: [
-      { ...DEFAULT_OVERLAY_NAVIGATION[0]!, label: 'Assistant' },
+      { ...DEFAULT_OVERLAY_NAVIGATION.find((item) => item.id === 'chat')!, label: 'Assistant' },
       { id: 'admin', href: '/app/admin', label: 'Admin', icon: 'shield-check' },
     ],
     settingsPanels: [
@@ -37,6 +37,14 @@ test('resolveOverlayAppShellConfig merges registry overrides by id', () => {
   assert.equal(shell.featureModules.find((item) => item.id === 'files-knowledge')?.componentKey, 'enterprise.filesKnowledge')
   assert.equal(shell.sidebarActions.find((item) => item.id === 'chat.create')?.label, 'Start chat')
   assert.equal(shell.sidebarActions.find((item) => item.id === 'admin.invite')?.routePatterns[0], '/app/admin')
+})
+
+test('agents are the default home and lead the primary navigation', () => {
+  const shell = resolveOverlayAppShellConfig()
+
+  assert.equal(shell.brand.homeHref, '/app/agents')
+  assert.equal(DEFAULT_OVERLAY_NAVIGATION[0]?.id, 'agents')
+  assert.equal(DEFAULT_OVERLAY_NAVIGATION[1]?.id, 'chat')
 })
 
 test('resolveOverlayAppShellConfig filters disabled feature registries', () => {

--- a/packages/overlay-app-core/src/app-shell.ts
+++ b/packages/overlay-app-core/src/app-shell.ts
@@ -32,7 +32,7 @@ export const DEFAULT_OVERLAY_BRAND_CONFIG: OverlayBrandConfig = {
   shortName: 'overlay',
   logoSrc: '/assets/overlay-logo.png',
   logoAlt: '',
-  homeHref: '/app/chat',
+  homeHref: '/app/agents',
   supportEmail: 'divyansh@layernorm.co',
   organizationName: 'Overlay',
 }
@@ -106,19 +106,19 @@ export const DEFAULT_OVERLAY_FEATURE_FLAGS: readonly OverlayFeatureFlag[] = [
 
 export const DEFAULT_OVERLAY_NAVIGATION: readonly OverlayNavigationItem[] = [
   {
+    id: 'agents',
+    href: '/app/agents',
+    label: 'Agents',
+    icon: 'bot',
+    featureFlagId: 'agents',
+  },
+  {
     id: 'chat',
     href: '/app/chat',
     label: 'Chats',
     icon: 'message-square',
     requiredCapabilities: ['chat'],
     subviews: ['personal', 'dms', 'channels', 'activity', 'all'],
-  },
-  {
-    id: 'agents',
-    href: '/app/agents',
-    label: 'Agents',
-    icon: 'bot',
-    featureFlagId: 'agents',
   },
   { id: 'files', href: '/app/files', label: 'Files', icon: 'file-text', requiredCapabilities: ['files'] },
   {

--- a/scripts/verify-agent-host-release.mjs
+++ b/scripts/verify-agent-host-release.mjs
@@ -5,6 +5,8 @@ const hostPackage = JSON.parse(await readFile(new URL('../packages/overlay-agent
 const protocolPackage = JSON.parse(await readFile(new URL('../packages/overlay-agent-bridge-protocol/package.json', import.meta.url), 'utf8'))
 const enrollmentCommand = await readFile(new URL('../src/server/agents/agent-enrollment-command.ts', import.meta.url), 'utf8')
 const adapterManifests = await readFile(new URL('../packages/overlay-agent-host/src/adapter-manifests.ts', import.meta.url), 'utf8')
+const hostCli = await readFile(new URL('../packages/overlay-agent-host/src/cli.ts', import.meta.url), 'utf8')
+const environmentSettings = await readFile(new URL('../src/features/settings/components/AgentEnvironmentSettings.tsx', import.meta.url), 'utf8')
 
 assert.equal(hostPackage.name, '@layernorm/overlay-agent-host', 'host must publish under the product-qualified package name')
 assert.equal(protocolPackage.name, '@layernorm/overlay-agent-bridge-protocol', 'protocol must publish under the product-qualified package name')
@@ -22,6 +24,16 @@ assert.match(
   enrollmentCommand,
   new RegExp(`OVERLAY_AGENT_HOST_PACKAGE_VERSION = '${hostPackage.version.replaceAll('.', '\\.')}'`),
   'the application enrollment command must pin the released host version',
+)
+assert.match(
+  hostCli,
+  new RegExp(`PACKAGE_SPEC = '@layernorm/overlay-agent-host@${hostPackage.version.replaceAll('.', '\\.')}'`),
+  'the host CLI restart/service commands must pin the released host version',
+)
+assert.match(
+  environmentSettings,
+  new RegExp(`HOST_PACKAGE_SPEC = '@layernorm/overlay-agent-host@${hostPackage.version.replaceAll('.', '\\.')}'`),
+  'the environment settings recovery command must pin the released host version',
 )
 assert.match(adapterManifests, /CODEX_ACP_PACKAGE_VERSION = '1\.7\.0'/)
 assert.match(adapterManifests, /CLAUDE_AGENT_ACP_PACKAGE_VERSION = '0\.70\.0'/)

--- a/src/app/app/agents/page.tsx
+++ b/src/app/app/agents/page.tsx
@@ -1,11 +1,28 @@
+import { Suspense } from 'react'
 import { AgentsDirectory } from '@/features/agents/components/AgentsDirectory'
+import { AgentConversationWorkspace } from '@/features/agents/components/AgentConversationWorkspace'
+import { ChatRouteSkeleton } from '../_components/AppRouteSkeletons'
 
-export default async function AgentsPage({
+export default function AgentsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ showcase?: string | string[] }>
+}) {
+  return (
+    <Suspense fallback={<ChatRouteSkeleton />}>
+      <AgentsPageContent searchParams={searchParams} />
+    </Suspense>
+  )
+}
+
+async function AgentsPageContent({
   searchParams,
 }: {
   searchParams?: Promise<{ showcase?: string | string[] }>
 }) {
   const params = await searchParams
   const showcase = Array.isArray(params?.showcase) ? params.showcase[0] === '1' : params?.showcase === '1'
-  return <AgentsDirectory showcase={showcase} />
+  if (showcase) return <AgentsDirectory showcase />
+
+  return <AgentConversationWorkspace />
 }

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation'
+import { ROOT_APP_DESTINATION } from '@/shared/auth/root-entry'
 
 export default function AppPage() {
-  redirect('/app/chat')
+  redirect(ROOT_APP_DESTINATION)
 }

--- a/src/components/layout/AppSidebarInlinePanels.tsx
+++ b/src/components/layout/AppSidebarInlinePanels.tsx
@@ -56,6 +56,12 @@ import {
   AGENT_DIRECTORY_CHANGED_EVENT,
   type AgentDirectoryChangedEventDetail,
 } from '@/shared/workspace/sidebar-events'
+import {
+  getAgentOpenedAt,
+  getLastOpenedAgentId,
+  rememberAgentOpened,
+  sortAgentsByRecency,
+} from '@/shared/agents/last-agent-by-workspace'
 import { dispatchChatCreated } from '@/shared/chat/chat-title'
 
 type Project = ProjectSummary
@@ -419,6 +425,10 @@ export function ProjectsInlinePanel({
 const resourceRowClass =
   'flex h-8 w-full items-center gap-2 rounded-md px-2.5 text-left text-xs text-[var(--muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--foreground)]'
 
+// One initial auto-open plus two silent retries before surfacing the error
+// row; beyond that only an explicit retry attempts again.
+const MAX_AGENT_AUTO_OPEN_ATTEMPTS = 3
+
 export function AgentsInlinePanel({
   workspaceId,
   baseHref = '/app/agents',
@@ -434,9 +444,16 @@ export function AgentsInlinePanel({
   const [agents, setAgents] = useState<WorkspaceAgentDirectoryItem[]>([])
   const [loading, setLoading] = useState(true)
   const [openingAgentId, setOpeningAgentId] = useState<string | null>(null)
-  const autoOpenAttemptRef = useRef<string | null>(null)
+  const [openError, setOpenError] = useState<string | null>(null)
+  const autoOpenAttemptRef = useRef<{ agentId: string; attempts: number } | null>(null)
   const activeAgentId = searchParams?.get('agent') ?? searchParams?.get('agentId') ?? null
   const activeConversationId = searchParams?.get('id') ?? null
+
+  // Most recently used first; agents with no recorded use stay alphabetical.
+  const sortedAgents = useMemo(
+    () => sortAgentsByRecency(agents, getAgentOpenedAt(workspaceId)),
+    [agents, workspaceId],
+  )
 
   const loadAgents = useCallback(async (showLoading = true) => {
     if (!workspaceId) {
@@ -459,6 +476,7 @@ export function AgentsInlinePanel({
 
   useEffect(() => {
     autoOpenAttemptRef.current = null
+    setOpenError(null)
   }, [workspaceId])
 
   useEffect(() => {
@@ -481,6 +499,8 @@ export function AgentsInlinePanel({
       const { directMessage } = await overlayAppClient.conversations.createWorkspaceDirectMessage(workspaceId, {
         principalIds: [agent.principalId],
       })
+      rememberAgentOpened(workspaceId, agent.id)
+      setOpenError(null)
       dispatchChatCreated({
         chat: {
           _id: directMessage.conversationId,
@@ -503,16 +523,61 @@ export function AgentsInlinePanel({
     }
   }, [baseHref, onNavigate, openingAgentId, router, workspaceId])
 
+  // Remember agents opened through direct links or refreshes so recency
+  // ordering and the default selection cover every entry path.
+  useEffect(() => {
+    if (activeAgentId && sortedAgents.some((agent) => agent.id === activeAgentId)) {
+      rememberAgentOpened(workspaceId, activeAgentId)
+    }
+  }, [activeAgentId, sortedAgents, workspaceId])
+
+  const openAgentById = useCallback(async (
+    agent: WorkspaceAgentDirectoryItem,
+    navigation: 'push' | 'replace' = 'push',
+  ) => {
+    try {
+      await openAgent(agent, navigation)
+    } catch {
+      setOpenError(`Could not open ${agent.name}. Check your connection and retry.`)
+    }
+  }, [openAgent])
+
   useEffect(() => {
     if (loading || activeConversationId || openingAgentId) return
     if (!pathname.endsWith('/agents')) return
-    const targetAgent = activeAgentId
-      ? agents.find((agent) => agent.id === activeAgentId)
-      : agents[0]
-    if (!targetAgent || autoOpenAttemptRef.current === targetAgent.id) return
-    autoOpenAttemptRef.current = targetAgent.id
-    void openAgent(targetAgent, 'replace').catch(() => undefined)
-  }, [activeAgentId, activeConversationId, agents, loading, openAgent, openingAgentId, pathname])
+    if (sortedAgents.length === 0) return
+    const lastOpenedId = getLastOpenedAgentId(workspaceId)
+    const targetAgent = (activeAgentId ? sortedAgents.find((agent) => agent.id === activeAgentId) : undefined)
+      ?? (lastOpenedId ? sortedAgents.find((agent) => agent.id === lastOpenedId) : undefined)
+      ?? sortedAgents[0]
+    if (!targetAgent) return
+    const attempt = autoOpenAttemptRef.current
+    if (attempt && attempt.agentId === targetAgent.id && attempt.attempts >= MAX_AGENT_AUTO_OPEN_ATTEMPTS) return
+    autoOpenAttemptRef.current = {
+      agentId: targetAgent.id,
+      attempts: attempt && attempt.agentId === targetAgent.id ? attempt.attempts + 1 : 1,
+    }
+    // Silent retries up to the attempt cap; after that the error row offers
+    // a manual retry, so the main area can never stick on the blank state
+    // without telling the user why.
+    void openAgent(targetAgent, 'replace').catch(() => {
+      const latest = autoOpenAttemptRef.current
+      if (latest && latest.agentId === targetAgent.id && latest.attempts >= MAX_AGENT_AUTO_OPEN_ATTEMPTS) {
+        setOpenError(`Could not open ${targetAgent.name}. Check your connection and retry.`)
+      }
+    })
+  }, [activeAgentId, activeConversationId, sortedAgents, loading, openAgent, openingAgentId, pathname, workspaceId])
+
+  const retryOpen = useCallback(() => {
+    const lastOpenedId = getLastOpenedAgentId(workspaceId)
+    const targetAgent = (activeAgentId ? sortedAgents.find((agent) => agent.id === activeAgentId) : undefined)
+      ?? (lastOpenedId ? sortedAgents.find((agent) => agent.id === lastOpenedId) : undefined)
+      ?? sortedAgents[0]
+    if (!targetAgent) return
+    autoOpenAttemptRef.current = null
+    setOpenError(null)
+    void openAgentById(targetAgent, 'replace')
+  }, [activeAgentId, openAgentById, sortedAgents, workspaceId])
 
   return (
     <SidebarResourceList>
@@ -520,14 +585,14 @@ export function AgentsInlinePanel({
         <div className="flex items-center gap-2 px-2.5 py-2 text-xs text-[var(--muted-light)]">
           <Loader2 size={13} className="animate-spin" /> Loading agents...
         </div>
-      ) : agents.length ? (
-        agents.map((agent) => (
+      ) : sortedAgents.length ? (
+        sortedAgents.map((agent) => (
           <button
             key={agent.id}
             type="button"
             disabled={Boolean(openingAgentId)}
             className={`${resourceRowClass} ${activeAgentId === agent.id ? 'bg-[var(--surface-subtle)] text-[var(--foreground)]' : ''}`}
-            onClick={() => void openAgent(agent).catch(() => undefined)}
+            onClick={() => void openAgentById(agent)}
           >
             {openingAgentId === agent.id
               ? <Loader2 size={13} className="shrink-0 animate-spin" />
@@ -538,6 +603,18 @@ export function AgentsInlinePanel({
       ) : (
         <p className="px-2.5 py-2 text-xs text-[var(--muted-light)]">No agents yet</p>
       )}
+      {openError ? (
+        <div className="px-2.5 py-2">
+          <p role="alert" className="text-xs leading-4 text-red-500">{openError}</p>
+          <button
+            type="button"
+            onClick={retryOpen}
+            className="mt-1.5 rounded-md border border-[var(--border)] px-2 py-1 text-xs text-[var(--foreground)] hover:bg-[var(--surface-subtle)]"
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
     </SidebarResourceList>
   )
 }

--- a/src/components/layout/AppSidebarInlinePanels.tsx
+++ b/src/components/layout/AppSidebarInlinePanels.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState, type MouseEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from 'react'
 import Link from 'next/link'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import type { LucideIcon } from 'lucide-react'
 import {
   Archive,
@@ -56,6 +56,7 @@ import {
   AGENT_DIRECTORY_CHANGED_EVENT,
   type AgentDirectoryChangedEventDetail,
 } from '@/shared/workspace/sidebar-events'
+import { dispatchChatCreated } from '@/shared/chat/chat-title'
 
 type Project = ProjectSummary
 type ProjectChat = ProjectChatSummary
@@ -428,10 +429,14 @@ export function AgentsInlinePanel({
   onNavigate?: () => void
 }) {
   const router = useRouter()
+  const pathname = usePathname()
   const searchParams = useSearchParams()
   const [agents, setAgents] = useState<WorkspaceAgentDirectoryItem[]>([])
   const [loading, setLoading] = useState(true)
-  const activeAgentId = searchParams?.get('agent') ?? null
+  const [openingAgentId, setOpeningAgentId] = useState<string | null>(null)
+  const autoOpenAttemptRef = useRef<string | null>(null)
+  const activeAgentId = searchParams?.get('agent') ?? searchParams?.get('agentId') ?? null
+  const activeConversationId = searchParams?.get('id') ?? null
 
   const loadAgents = useCallback(async (showLoading = true) => {
     if (!workspaceId) {
@@ -453,6 +458,10 @@ export function AgentsInlinePanel({
   useEffect(() => { void loadAgents() }, [loadAgents])
 
   useEffect(() => {
+    autoOpenAttemptRef.current = null
+  }, [workspaceId])
+
+  useEffect(() => {
     const refreshAgents = (event: Event) => {
       const changedWorkspaceId = (event as CustomEvent<AgentDirectoryChangedEventDetail>).detail?.workspaceId
       if (!changedWorkspaceId || changedWorkspaceId === workspaceId) void loadAgents(false)
@@ -460,6 +469,50 @@ export function AgentsInlinePanel({
     window.addEventListener(AGENT_DIRECTORY_CHANGED_EVENT, refreshAgents)
     return () => window.removeEventListener(AGENT_DIRECTORY_CHANGED_EVENT, refreshAgents)
   }, [loadAgents, workspaceId])
+
+  const openAgent = useCallback(async (
+    agent: WorkspaceAgentDirectoryItem,
+    navigation: 'push' | 'replace' = 'push',
+  ) => {
+    if (openingAgentId) return
+    setOpeningAgentId(agent.id)
+    try {
+      if (!workspaceId) return
+      const { directMessage } = await overlayAppClient.conversations.createWorkspaceDirectMessage(workspaceId, {
+        principalIds: [agent.principalId],
+      })
+      dispatchChatCreated({
+        chat: {
+          _id: directMessage.conversationId,
+          title: directMessage.title,
+          lastModified: Date.now(),
+          conversationType: 'dm',
+        },
+      })
+      const params = new URLSearchParams({
+        agent: agent.id,
+        view: 'dms',
+        id: directMessage.conversationId,
+      })
+      const href = `${baseHref}?${params.toString()}`
+      if (navigation === 'replace') router.replace(href)
+      else router.push(href)
+      if (navigation === 'push') onNavigate?.()
+    } finally {
+      setOpeningAgentId(null)
+    }
+  }, [baseHref, onNavigate, openingAgentId, router, workspaceId])
+
+  useEffect(() => {
+    if (loading || activeConversationId || openingAgentId) return
+    if (!pathname.endsWith('/agents')) return
+    const targetAgent = activeAgentId
+      ? agents.find((agent) => agent.id === activeAgentId)
+      : agents[0]
+    if (!targetAgent || autoOpenAttemptRef.current === targetAgent.id) return
+    autoOpenAttemptRef.current = targetAgent.id
+    void openAgent(targetAgent, 'replace').catch(() => undefined)
+  }, [activeAgentId, activeConversationId, agents, loading, openAgent, openingAgentId, pathname])
 
   return (
     <SidebarResourceList>
@@ -472,13 +525,13 @@ export function AgentsInlinePanel({
           <button
             key={agent.id}
             type="button"
+            disabled={Boolean(openingAgentId)}
             className={`${resourceRowClass} ${activeAgentId === agent.id ? 'bg-[var(--surface-subtle)] text-[var(--foreground)]' : ''}`}
-            onClick={() => {
-              router.push(`${baseHref}?agent=${encodeURIComponent(agent.id)}`)
-              onNavigate?.()
-            }}
+            onClick={() => void openAgent(agent).catch(() => undefined)}
           >
-            <Bot size={13} className="shrink-0" />
+            {openingAgentId === agent.id
+              ? <Loader2 size={13} className="shrink-0 animate-spin" />
+              : <Bot size={13} className="shrink-0" />}
             <span className="truncate">{agent.name}</span>
           </button>
         ))

--- a/src/features/agents/components/AgentConversationWorkspace.tsx
+++ b/src/features/agents/components/AgentConversationWorkspace.tsx
@@ -9,6 +9,7 @@ import { AppScreenBody, AppScreenHeader, AppScreenShell } from '@overlay/modules
 import { DirectMessageExperience } from '@/features/chat/components/DirectMessageExperience'
 import { useWorkspace } from '@/features/workspaces/components/WorkspaceProvider'
 import { NEW_AGENT_EVENT } from '@/shared/workspace/sidebar-events'
+import { clearAgentOpened } from '@/shared/agents/last-agent-by-workspace'
 import { AgentEditorPage } from './AgentEditorPage'
 import { buildAgentsDirectoryHref, startAgentChat } from '../lib/agent-chat'
 
@@ -54,8 +55,9 @@ export function AgentConversationWorkspace() {
 
   const handleArchived = useCallback(() => {
     setEditorMode(null)
+    if (agentId) clearAgentOpened(activeWorkspaceId, agentId)
     router.replace(buildAgentsDirectoryHref(activeWorkspaceId))
-  }, [activeWorkspaceId, router])
+  }, [activeWorkspaceId, agentId, router])
 
   const editor = editorMode ? (
     <AgentEditorPage

--- a/src/features/agents/components/AgentConversationWorkspace.tsx
+++ b/src/features/agents/components/AgentConversationWorkspace.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Bot, Settings } from 'lucide-react'
+import type { WorkspaceAgentDirectoryItem } from '@overlay/workspace-contracts'
+import { Button } from '@overlay/ui/primitives'
+import { AppScreenBody, AppScreenHeader, AppScreenShell } from '@overlay/modules-react/shell'
+import { DirectMessageExperience } from '@/features/chat/components/DirectMessageExperience'
+import { useWorkspace } from '@/features/workspaces/components/WorkspaceProvider'
+import { NEW_AGENT_EVENT } from '@/shared/workspace/sidebar-events'
+import { AgentEditorPage } from './AgentEditorPage'
+import { buildAgentsDirectoryHref, startAgentChat } from '../lib/agent-chat'
+
+type EditorMode = 'new' | 'edit' | null
+
+export function AgentConversationWorkspace() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { activeWorkspaceId } = useWorkspace()
+  const agentId = searchParams?.get('agent') ?? searchParams?.get('agentId') ?? null
+  const conversationId = searchParams?.get('id') ?? null
+  const [editorMode, setEditorMode] = useState<EditorMode>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const openCreate = useCallback(() => {
+    setError(null)
+    setEditorMode('new')
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener(NEW_AGENT_EVENT, openCreate)
+    return () => window.removeEventListener(NEW_AGENT_EVENT, openCreate)
+  }, [openCreate])
+
+  const closeEditor = useCallback(() => setEditorMode(null), [])
+
+  const openCreatedAgent = useCallback(
+    (agent: WorkspaceAgentDirectoryItem) => {
+      setEditorMode(null)
+      setError(null)
+      void startAgentChat({
+        workspaceId: activeWorkspaceId,
+        agentId: agent.id,
+        agentPrincipalId: agent.principalId,
+        surface: 'agents',
+        push: (href) => router.push(href),
+      }).catch((chatError) => {
+        setError(chatError instanceof Error ? chatError.message : 'Could not open the new agent.')
+      })
+    },
+    [activeWorkspaceId, router],
+  )
+
+  const handleArchived = useCallback(() => {
+    setEditorMode(null)
+    router.replace(buildAgentsDirectoryHref(activeWorkspaceId))
+  }, [activeWorkspaceId, router])
+
+  const editor = editorMode ? (
+    <AgentEditorPage
+      key={`${editorMode}:${agentId ?? 'new'}`}
+      mode={editorMode}
+      agentId={editorMode === 'edit' ? (agentId ?? undefined) : undefined}
+      presentation="panel"
+      onClose={closeEditor}
+      onCreated={openCreatedAgent}
+      onArchived={handleArchived}
+    />
+  ) : null
+
+  const settingsButton = (
+    <button
+      type="button"
+      aria-label={agentId ? 'Agent settings' : 'Create agent'}
+      title={agentId ? 'Agent settings' : 'Create agent'}
+      onClick={() => setEditorMode(agentId ? 'edit' : 'new')}
+      className={`inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--foreground)] ${
+        editorMode ? 'bg-[var(--surface-subtle)] text-[var(--foreground)]' : 'text-[var(--muted)]'
+      }`}
+    >
+      <Settings size={15} />
+    </button>
+  )
+
+  if (conversationId) {
+    return (
+      <DirectMessageExperience
+        key={conversationId}
+        conversationId={conversationId}
+        headerActions={settingsButton}
+        externalRightPanel={editor}
+        externalRightPanelLabel="Agent settings"
+        onExternalRightPanelClose={closeEditor}
+      />
+    )
+  }
+
+  return (
+    <AppScreenShell
+      header={<AppScreenHeader title="Agents" actions={settingsButton} />}
+      rightPanel={editor}
+      rightPanelOpen={Boolean(editor)}
+      rightPanelWidth="lg"
+      rightPanelOverlayLabel="Agent settings"
+      onRightPanelClose={closeEditor}
+    >
+      <AppScreenBody className="flex min-h-full items-center justify-center p-6" padding="none">
+        <div className="max-w-sm text-center">
+          <span className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-[var(--surface-subtle)] text-[var(--muted)]">
+            <Bot size={18} />
+          </span>
+          <h1 className="mt-4 text-sm font-medium text-[var(--foreground)]">Your agents work from here</h1>
+          <p className="mt-1.5 text-xs leading-5 text-[var(--muted)]">
+            Select an agent to open its conversation, or create one for a new outcome.
+          </p>
+          {error ? (
+            <p role="alert" className="mt-3 text-xs text-red-500">
+              {error}
+            </p>
+          ) : null}
+          <Button variant="secondary" size="sm" className="mt-4" onClick={openCreate}>
+            Create agent
+          </Button>
+        </div>
+      </AppScreenBody>
+    </AppScreenShell>
+  )
+}

--- a/src/features/agents/components/AgentEditorPage.tsx
+++ b/src/features/agents/components/AgentEditorPage.tsx
@@ -9,7 +9,7 @@ import type {
   WorkspaceAgentDirectoryItem,
   WorkspaceAgentVisibility,
 } from '@overlay/workspace-contracts'
-import { AppScreenBody, AppScreenHeader, AppScreenShell } from '@overlay/modules-react/shell'
+import { AppScreenBody, AppScreenHeader, AppScreenShell, AppScreenSidePanel } from '@overlay/modules-react/shell'
 import { DEFAULT_MODEL_ID } from '@/shared/ai/gateway/model-types'
 import {
   getEnabledChatModels,
@@ -39,10 +39,22 @@ import {
 } from './AgentEditorForm'
 import { useByoConnection } from './use-byo-connection'
 
-export function AgentEditorPage({ mode, agentId, showcase = false }: {
+export function AgentEditorPage({
+  mode,
+  agentId,
+  showcase = false,
+  presentation = 'page',
+  onClose,
+  onCreated,
+  onArchived,
+}: {
   mode: 'new' | 'edit'
   agentId?: string
   showcase?: boolean
+  presentation?: 'page' | 'panel'
+  onClose?: () => void
+  onCreated?: (agent: WorkspaceAgentDirectoryItem) => void
+  onArchived?: () => void
 }) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -152,6 +164,7 @@ export function AgentEditorPage({ mode, agentId, showcase = false }: {
   }
 
   const directoryHref = buildAgentsDirectoryHref(activeWorkspaceId, showcase)
+  const closeEditor = () => onClose ? onClose() : router.push(directoryHref)
 
   const save = async () => {
     if (showcase) {
@@ -174,6 +187,7 @@ export function AgentEditorPage({ mode, agentId, showcase = false }: {
     setError(null)
     setSavedFlash(false)
     try {
+      const creating = !agent
       const saved = agent
         ? await overlayAppClient.agents.update(activeWorkspaceId, agent.id, input)
         : await overlayAppClient.agents.create(activeWorkspaceId, input)
@@ -186,15 +200,19 @@ export function AgentEditorPage({ mode, agentId, showcase = false }: {
         } catch (bindingError) {
           // Agent identity may already be durable even if its remote binding
           // fails. Land on the edit page so a retry never creates a duplicate.
-          router.push(`${buildAgentEditorHref(activeWorkspaceId, saved.agent.id)}?hello=1`)
+          setAgent(saved.agent)
+          if (presentation === 'page') {
+            router.push(`${buildAgentEditorHref(activeWorkspaceId, saved.agent.id)}?hello=1`)
+          }
           throw bindingError
         }
       } else if (binding === null && agent) {
         await overlayAppClient.agentEnvironments.disableBindings(activeWorkspaceId, saved.agent.id)
       }
       dispatchAgentDirectoryChanged(activeWorkspaceId)
-      if (!agent) {
-        router.push(`${buildAgentEditorHref(activeWorkspaceId, saved.agent.id)}?hello=1`)
+      if (creating) {
+        if (onCreated) onCreated(saved.agent)
+        else router.push(`${buildAgentEditorHref(activeWorkspaceId, saved.agent.id)}?hello=1`)
       } else {
         setAgent(saved.agent)
         setSavedFlash(true)
@@ -214,7 +232,8 @@ export function AgentEditorPage({ mode, agentId, showcase = false }: {
     try {
       await overlayAppClient.agents.archive(activeWorkspaceId, agent.id)
       dispatchAgentDirectoryChanged(activeWorkspaceId)
-      router.push(directoryHref)
+      if (onArchived) onArchived()
+      else router.push(directoryHref)
     } catch (archiveError) {
       setError(archiveError instanceof Error ? archiveError.message : 'Could not archive agent.')
     } finally {
@@ -240,13 +259,13 @@ export function AgentEditorPage({ mode, agentId, showcase = false }: {
     return agent?.name ?? 'Agent not found'
   }, [agent?.name, loading, mode])
 
-  return (
+  const editor = (
     <AppScreenShell
-      header={(
+      header={presentation === 'page' ? (
         <AppScreenHeader
           title={title}
           leading={(
-            <Button variant="ghost" size="sm" onClick={() => router.push(directoryHref)} aria-label="Back to agents">
+            <Button variant="ghost" size="sm" onClick={closeEditor} aria-label="Back to agents">
               <ArrowLeft size={14} /> Agents
             </Button>
           )}
@@ -260,7 +279,7 @@ export function AgentEditorPage({ mode, agentId, showcase = false }: {
             />
           )}
         />
-      )}
+      ) : undefined}
     >
       <AppScreenBody padding="lg" maxWidth="xl" className="min-h-full">
         {loading ? (
@@ -273,13 +292,13 @@ export function AgentEditorPage({ mode, agentId, showcase = false }: {
           <div className="mx-auto w-full max-w-2xl rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] p-8 text-center">
             <p className="text-sm font-medium text-[var(--foreground)]">Agent not found</p>
             <p className="mt-1 text-xs leading-5 text-[var(--muted)]">It may have been archived, or you may not have access to it.</p>
-            <Button variant="secondary" size="sm" className="mt-4" onClick={() => router.push(directoryHref)}>Back to agents</Button>
+            <Button variant="secondary" size="sm" className="mt-4" onClick={closeEditor}>Back to agents</Button>
           </div>
         ) : mode === 'new' && !canCreate ? (
           <div className="mx-auto w-full max-w-2xl rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] p-8 text-center">
             <p className="text-sm font-medium text-[var(--foreground)]">You cannot create agents in this workspace</p>
             <p className="mt-1 text-xs leading-5 text-[var(--muted)]">Guests can chat with agents but cannot create new ones.</p>
-            <Button variant="secondary" size="sm" className="mt-4" onClick={() => router.push(directoryHref)}>Back to agents</Button>
+            <Button variant="secondary" size="sm" className="mt-4" onClick={closeEditor}>Back to agents</Button>
           </div>
         ) : (
           <div className="mx-auto w-full max-w-2xl pb-24">
@@ -365,7 +384,7 @@ export function AgentEditorPage({ mode, agentId, showcase = false }: {
             <div className="sticky bottom-0 mt-8 border-t border-[var(--border)] bg-[var(--background)]/95 py-3 backdrop-blur">
               <div className="flex items-center gap-2">
                 <span className="flex-1" />
-                <EditorFooter mode={mode} busy={busy} valid={valid} onCancel={() => router.push(directoryHref)} onSave={save} />
+                <EditorFooter mode={mode} busy={busy} valid={valid} onCancel={closeEditor} onSave={save} />
               </div>
             </div>
           </div>
@@ -373,6 +392,21 @@ export function AgentEditorPage({ mode, agentId, showcase = false }: {
       </AppScreenBody>
     </AppScreenShell>
   )
+
+  if (presentation === 'panel') {
+    return (
+      <AppScreenSidePanel
+        title={title}
+        onClose={closeEditor}
+        closeLabel="Close agent settings"
+        bodyClassName="overflow-hidden"
+      >
+        {editor}
+      </AppScreenSidePanel>
+    )
+  }
+
+  return editor
 }
 
 function getShowcaseAgent(

--- a/src/features/agents/lib/agent-chat.ts
+++ b/src/features/agents/lib/agent-chat.ts
@@ -7,12 +7,18 @@ import { buildWorkspaceHref } from '@/features/workspaces/lib/workspace-routing'
 /** Opens (or creates) a one-to-one DM with an agent, then navigates to it. */
 export async function startAgentChat(args: {
   workspaceId: string | null
+  agentId?: string
   agentPrincipalId: string
   showcase?: boolean
+  surface?: 'agents' | 'chat'
   push(href: string): void
 }): Promise<void> {
+  const surface = args.surface ?? 'chat'
   if (args.showcase) {
-    args.push(`/app/chat?showcase=1&view=dms&id=${encodeURIComponent(args.agentPrincipalId)}`)
+    const basePath = surface === 'agents' ? '/app/agents' : '/app/chat'
+    const params = new URLSearchParams({ showcase: '1', view: 'dms', id: args.agentPrincipalId })
+    if (surface === 'agents' && args.agentId) params.set('agent', args.agentId)
+    args.push(`${basePath}?${params.toString()}`)
     return
   }
   if (!args.workspaceId) return
@@ -27,7 +33,10 @@ export async function startAgentChat(args: {
       conversationType: 'dm',
     },
   })
-  args.push(`${buildWorkspaceHref(args.workspaceId, '/app/chat')}?view=dms&id=${encodeURIComponent(directMessage.conversationId)}`)
+  const basePath = buildWorkspaceHref(args.workspaceId, surface === 'agents' ? '/app/agents' : '/app/chat')
+  const params = new URLSearchParams({ view: 'dms', id: directMessage.conversationId })
+  if (surface === 'agents' && args.agentId) params.set('agent', args.agentId)
+  args.push(`${basePath}?${params.toString()}`)
 }
 
 /** Canonical workspace-scoped href for the agent editor pages. */

--- a/src/features/agents/lib/byo-agent-setup.ts
+++ b/src/features/agents/lib/byo-agent-setup.ts
@@ -108,7 +108,7 @@ export function generatedAgentSetupPrompt(command: string) {
   return [
     'Connect this computer to Overlay, my AI workspace.',
     '',
-    'Run this command in the background so it keeps running after our session ends (for example with `nohup … &` on macOS or Linux), then check its output for a "Verify this phrase in Overlay: …" line and tell me the phrase so I can approve the connection. Leave the process running — it is the connector Overlay talks to. It is outbound-only and opens no ports.',
+    'Run this command in the background so it keeps running after our session ends (for example with `nohup … &` on macOS or Linux), then check its output for a "Verify this phrase in Overlay: …" line and tell me the phrase so I can approve the connection. Leave the process running — it is the connector Overlay talks to. It is outbound-only and opens no ports. For a permanent connector that survives Terminal restarts and logins, also run the `service install` command it prints (macOS) or enable its systemd unit (Linux); otherwise the connector goes offline when this shell exits.',
     '',
     command,
   ].join('\n')

--- a/src/features/chat/components/DirectMessageExperience.tsx
+++ b/src/features/chat/components/DirectMessageExperience.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from 'react'
 import {
   Archive,
@@ -209,12 +210,20 @@ export function DirectMessageExperience({
   conversationType = 'dm',
   draft = false,
   draftTitle,
+  headerActions,
+  externalRightPanel,
+  externalRightPanelLabel,
+  onExternalRightPanelClose,
 }: {
   conversationId: string
   showcase?: boolean
   conversationType?: 'dm' | 'channel'
   draft?: boolean
   draftTitle?: string
+  headerActions?: ReactNode
+  externalRightPanel?: ReactNode
+  externalRightPanelLabel?: string
+  onExternalRightPanelClose?: () => void
 }) {
   const { activeWorkspace, activeWorkspaceId } = useWorkspace()
   const { appDataCapabilities, capabilities } = useOverlayCapabilities()
@@ -1368,15 +1377,17 @@ export function DirectMessageExperience({
 
   // The attachment preview wins the slot while it is open; otherwise the room's
   // own panels share the shell surface the sources sidebar already uses.
-  const rightPanel = shellRightPanel ?? roomPanelContent
+  const rightPanel = shellRightPanel ?? externalRightPanel ?? roomPanelContent
   const rightPanelClose = shellRightPanel
     ? shellRightPanelClose
-    : roomPanelContent
-      ? () => {
-        setRoomPanel(null)
-        setThreadRootId(null)
-      }
-      : undefined
+    : externalRightPanel
+      ? onExternalRightPanelClose
+      : roomPanelContent
+        ? () => {
+          setRoomPanel(null)
+          setThreadRootId(null)
+        }
+        : undefined
 
   return (
     <>
@@ -1407,10 +1418,11 @@ export function DirectMessageExperience({
         contentClassName="flex min-h-0"
         rightPanel={rightPanel}
         rightPanelOpen={Boolean(rightPanel)}
-        rightPanelWidth={shellRightPanel ? shellRightPanelWidth : 380}
+        rightPanelWidth={shellRightPanel ? shellRightPanelWidth : externalRightPanel ? 'lg' : 380}
         rightPanelMode={shellRightPanelMode}
         onRightPanelClose={rightPanelClose}
         onRightPanelResize={shellRightPanelResize}
+        rightPanelOverlayLabel={externalRightPanel ? externalRightPanelLabel : undefined}
       >
         <div
           className="relative flex min-h-0 w-full min-w-0 flex-1 flex-col"
@@ -1450,6 +1462,7 @@ export function DirectMessageExperience({
             )}
             actions={(
               <div className="relative flex items-center gap-1">
+                {headerActions}
                 {pins.length > 0 ? (
                   <button
                     type="button"

--- a/src/features/settings/components/AgentEnvironmentSettings.tsx
+++ b/src/features/settings/components/AgentEnvironmentSettings.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { Laptop, RefreshCw, ShieldCheck, Trash2 } from 'lucide-react'
+import { Check, Copy, Laptop, RefreshCw, ShieldCheck, Trash2 } from 'lucide-react'
 import { useWorkspace } from '@/features/workspaces/components/WorkspaceProvider'
 import { overlayAppClient } from '@/shared/app/overlay-app-client'
 
@@ -24,6 +24,7 @@ export function AgentEnvironmentSettings() {
   const [editingRoots, setEditingRoots] = useState<string | null>(null)
   const [busy, setBusy] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [copiedCommandId, setCopiedCommandId] = useState<string | null>(null)
 
   const refresh = useCallback(async () => {
     if (!activeWorkspaceId) return
@@ -94,6 +95,18 @@ export function AgentEnvironmentSettings() {
     }
   }
 
+  async function copyServiceCommand(environment: Environment) {
+    const command = persistentServiceCommand(environment)
+    if (!command) return
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopiedCommandId(environment.id)
+      window.setTimeout(() => setCopiedCommandId((current) => (current === environment.id ? null : current)), 1500)
+    } catch {
+      setError('Could not copy to the clipboard')
+    }
+  }
+
   async function revoke(environmentId: string) {
     setBusy(environmentId)
     setError(null)
@@ -136,6 +149,13 @@ export function AgentEnvironmentSettings() {
                   {environment.platform ?? environment.kind}{environment.hostVersion ? ` · host ${environment.hostVersion}` : ''}
                   {environment.lastSeenAt ? ` · ${lastSeenLabel(environment.lastSeenAt)}` : ''}
                 </p>
+                {environment.status === 'offline' ? (
+                  <OfflineRecoveryHint
+                    environment={environment}
+                    copied={copiedCommandId === environment.id}
+                    onCopy={() => void copyServiceCommand(environment)}
+                  />
+                ) : null}
                 {environment.status === 'pending' ? (
                   <div className="mt-4 space-y-3 border-t border-[var(--border)] pt-4">
                     <div className="flex items-center gap-2 text-sm text-[var(--foreground)]"><ShieldCheck size={16} className="text-[var(--muted)]" /> Verify phrase: <strong>{environment.verificationPhrase ?? 'waiting'}</strong></div>
@@ -183,6 +203,58 @@ export function AgentEnvironmentSettings() {
 
 function parseRoots(value: string) {
   return value.split(/[,\n]/).map((root) => root.trim()).filter(Boolean)
+}
+
+// Keep in sync with OVERLAY_AGENT_HOST_PACKAGE_VERSION in
+// src/server/agents/agent-enrollment-command.ts; enforced by
+// scripts/verify-agent-host-release.mjs.
+const HOST_PACKAGE_SPEC = '@layernorm/overlay-agent-host@0.3.5'
+const DEFAULT_HOST_CONFIG_PATH = '~/.overlay/agent-host/config.json'
+
+/**
+ * One-time command that installs the host as a persistent macOS service so
+ * the environment survives Terminal restarts and logins. Only macOS has a
+ * single-command install; other platforms get the plain-language hint.
+ */
+function persistentServiceCommand(environment: Environment): string | null {
+  if (environment.kind === 'overlay_cloud') return null
+  if (!environment.platform?.startsWith('darwin')) return null
+  return `npx --yes --package node@24 --package ${HOST_PACKAGE_SPEC} overlay-agent-host service install --config ${DEFAULT_HOST_CONFIG_PATH}`
+}
+
+function OfflineRecoveryHint({ environment, copied, onCopy }: {
+  environment: Environment
+  copied: boolean
+  onCopy(): void
+}) {
+  const serviceCommand = persistentServiceCommand(environment)
+  return (
+    <div className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+      <p className="text-xs leading-5 text-[var(--foreground)]">
+        {environment.kind === 'overlay_cloud'
+          ? 'This managed environment is unreachable. Queued work will resume when it recovers.'
+          : 'This machine is offline — it may be asleep, or its connector was closed. Overlay can\u2019t wake it remotely: start the connector on that machine and anything still queued will pick up on its own. Runs that were interrupted can be resumed from the conversation.'}
+      </p>
+      {serviceCommand ? (
+        <div className="mt-2">
+          <div className="flex items-center gap-2">
+            <code className="min-w-0 flex-1 truncate rounded-md bg-[var(--background)] px-2 py-1.5 font-mono text-[11px] text-[var(--muted)]">{serviceCommand}</code>
+            <button
+              type="button"
+              onClick={onCopy}
+              aria-label="Copy persistent service command"
+              className="shrink-0 rounded-md p-1.5 text-[var(--muted)] hover:bg-[var(--surface-subtle)] hover:text-[var(--foreground)]"
+            >
+              {copied ? <Check size={13} /> : <Copy size={13} />}
+            </button>
+          </div>
+          <p className="mt-1 text-[11px] leading-4 text-[var(--muted)]">
+            Run this once on that Mac to keep the connector alive across Terminal restarts and logins (uses the default install location).
+          </p>
+        </div>
+      ) : null}
+    </div>
+  )
 }
 
 function lastSeenLabel(lastSeenAt: number) {

--- a/src/server/collaboration/phase3-characterization.test.ts
+++ b/src/server/collaboration/phase3-characterization.test.ts
@@ -57,15 +57,15 @@ test('Phase 3 exposes Personal-to-DM forking and a dedicated collaborative surfa
 })
 
 test('agent chats immediately publish their DM into the sidebar list', async () => {
-  const [directory, convexDirectMessages, postgresDirectMessages] = await Promise.all([
-    readFile(`${root}/src/features/agents/components/AgentsDirectory.tsx`, 'utf8'),
+  const [agentsPanel, convexDirectMessages, postgresDirectMessages] = await Promise.all([
+    readFile(`${root}/src/components/layout/AppSidebarInlinePanels.tsx`, 'utf8'),
     readFile(`${root}/convex/collaboration/directMessages.ts`, 'utf8'),
     readFile(`${root}/src/server/conversations/PostgresConversationCollaborationRepository.ts`, 'utf8'),
   ])
 
-  assert.match(directory, /createDirectMessage/)
-  assert.match(directory, /dispatchChatCreated/)
-  assert.match(directory, /conversationType: 'dm'/)
+  assert.match(agentsPanel, /createWorkspaceDirectMessage/)
+  assert.match(agentsPanel, /dispatchChatCreated/)
+  assert.match(agentsPanel, /conversationType: 'dm'/)
   assert.match(convexDirectMessages, /actorParticipant\?\.archivedAt/)
   assert.match(convexDirectMessages, /unarchived: true/)
   assert.match(postgresDirectMessages, /isNotNull\(conversationParticipants\.archivedAt\)/)

--- a/src/server/collaboration/phase5-characterization.test.ts
+++ b/src/server/collaboration/phase5-characterization.test.ts
@@ -12,6 +12,8 @@ test('Phase 5 enables the named Agents product surface', () => {
   assert.equal(flags.get('workspaces'), true)
   assert.equal(flags.get('channels'), true)
   assert.equal(flags.get('agents'), true)
+  assert.equal(overlayAppConfig.brand?.homeHref, '/app/agents')
+  assert.equal(overlayAppConfig.navigation?.[0]?.id, 'agents')
   assert.equal(overlayAppConfig.navigation?.some((item) => item.id === 'agents' && item.href === '/app/agents'), true)
 })
 

--- a/src/shared/agents/last-agent-by-workspace.test.ts
+++ b/src/shared/agents/last-agent-by-workspace.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  clearAgentOpened,
+  getAgentOpenedAt,
+  getLastOpenedAgentId,
+  rememberAgentOpened,
+  sortAgentsByRecency,
+} from './last-agent-by-workspace'
+
+const store = new Map<string, string>()
+
+test.beforeEach(() => {
+  store.clear()
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      localStorage: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          store.set(key, value)
+        },
+        removeItem: (key: string) => {
+          store.delete(key)
+        },
+      },
+    },
+  })
+})
+
+test('remembers the most recently opened agent per workspace', () => {
+  rememberAgentOpened('ws-a', 'agent-1', 1000)
+  rememberAgentOpened('ws-a', 'agent-2', 2000)
+  rememberAgentOpened('ws-b', 'agent-9', 3000)
+
+  assert.equal(getLastOpenedAgentId('ws-a'), 'agent-2')
+  assert.equal(getLastOpenedAgentId('ws-b'), 'agent-9')
+  assert.equal(getLastOpenedAgentId('ws-unknown'), null)
+})
+
+test('reopening an agent makes it most recent again', () => {
+  rememberAgentOpened('ws-a', 'agent-1', 1000)
+  rememberAgentOpened('ws-a', 'agent-2', 2000)
+  rememberAgentOpened('ws-a', 'agent-1', 3000)
+
+  assert.equal(getLastOpenedAgentId('ws-a'), 'agent-1')
+})
+
+test('sorts used agents by recency, then unused agents alphabetically', () => {
+  const agents = [
+    { id: 'c', name: 'Codex' },
+    { id: 'h', name: 'Hermes' },
+    { id: 'o', name: 'Overlay' },
+  ]
+  rememberAgentOpened('ws-a', 'o', 1000)
+  rememberAgentOpened('ws-a', 'c', 2000)
+
+  assert.deepEqual(
+    sortAgentsByRecency(agents, getAgentOpenedAt('ws-a')).map((agent) => agent.id),
+    ['c', 'o', 'h'],
+  )
+})
+
+test('falls back to alphabetical order with no recorded use', () => {
+  const agents = [
+    { id: 'h', name: 'Hermes' },
+    { id: 'o', name: 'Overlay' },
+    { id: 'c', name: 'Codex' },
+  ]
+  assert.deepEqual(
+    sortAgentsByRecency(agents, getAgentOpenedAt('ws-a')).map((agent) => agent.id),
+    ['c', 'h', 'o'],
+  )
+})
+
+test('clears a remembered agent when archived', () => {
+  rememberAgentOpened('ws-a', 'agent-1', 1000)
+  rememberAgentOpened('ws-a', 'agent-2', 2000)
+  clearAgentOpened('ws-a', 'agent-1')
+
+  assert.equal(getLastOpenedAgentId('ws-a'), 'agent-2')
+  assert.deepEqual(getAgentOpenedAt('ws-a'), { 'agent-2': 2000 })
+})
+
+test('ignores invalid stored values instead of crashing', () => {
+  store.set('overlay:last-agent-by-workspace', JSON.stringify({ 'ws-a': { ok: 123, bad: 'nope' } }))
+  assert.deepEqual(getAgentOpenedAt('ws-a'), { ok: 123 })
+  assert.equal(getLastOpenedAgentId('ws-a'), 'ok')
+})

--- a/src/shared/agents/last-agent-by-workspace.ts
+++ b/src/shared/agents/last-agent-by-workspace.ts
@@ -1,0 +1,116 @@
+/**
+ * Remembers when each agent was last opened per workspace so the Agents
+ * roster can default-select the most recently used agent and order the
+ * list by recency instead of alphabetically.
+ *
+ * This is a usage heuristic, not server-side run history: opening an agent
+ * is the closest client-side signal to "I am working with this agent".
+ * It persists in localStorage (guarded for private browsing) so recency
+ * survives restarts, unlike the session-scoped chat-restore preference.
+ */
+
+const STORAGE_KEY = 'overlay:last-agent-by-workspace'
+
+const MAX_ENTRIES = 200
+
+function workspaceKey(workspaceId: string | null | undefined): string {
+  return workspaceId || 'legacy'
+}
+
+type AgentRecencyMap = Record<string, Record<string, number>>
+
+function readMap(): AgentRecencyMap {
+  if (typeof window === 'undefined') return {}
+  try {
+    const storage = window.localStorage
+    const raw = storage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const out: AgentRecencyMap = {}
+    for (const [workspace, entries] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!entries || typeof entries !== 'object' || Array.isArray(entries)) continue
+      const cleaned: Record<string, number> = {}
+      for (const [agentId, openedAt] of Object.entries(entries as Record<string, unknown>)) {
+        if (agentId && typeof openedAt === 'number' && Number.isFinite(openedAt)) cleaned[agentId] = openedAt
+      }
+      if (Object.keys(cleaned).length > 0) out[workspace] = cleaned
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+function writeMap(map: AgentRecencyMap): void {
+  if (typeof window === 'undefined') return
+  try {
+    const entries = Object.entries(map)
+    const pruned: AgentRecencyMap =
+      entries.length <= MAX_ENTRIES
+        ? map
+        : Object.fromEntries(entries.slice(entries.length - MAX_ENTRIES))
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(pruned))
+  } catch {
+    // Private browsing / quota — lose the preference rather than crash chrome.
+  }
+}
+
+export function rememberAgentOpened(
+  workspaceId: string | null | undefined,
+  agentId: string,
+  now: number = Date.now(),
+): void {
+  if (!agentId || !Number.isFinite(now)) return
+  const map = readMap()
+  const key = workspaceKey(workspaceId)
+  map[key] = { ...(map[key] ?? {}), [agentId]: now }
+  writeMap(map)
+}
+
+/** Milliseconds epoch when each agent id was last opened in this workspace. */
+export function getAgentOpenedAt(workspaceId: string | null | undefined): Record<string, number> {
+  return readMap()[workspaceKey(workspaceId)] ?? {}
+}
+
+/** Most recently opened agent id in this workspace, or null when unknown. */
+export function getLastOpenedAgentId(workspaceId: string | null | undefined): string | null {
+  const entries = Object.entries(getAgentOpenedAt(workspaceId))
+  if (entries.length === 0) return null
+  entries.sort((a, b) => b[1] - a[1])
+  return entries[0]?.[0] ?? null
+}
+
+export function clearAgentOpened(
+  workspaceId: string | null | undefined,
+  agentId?: string,
+): void {
+  const map = readMap()
+  const key = workspaceKey(workspaceId)
+  if (agentId) {
+    if (!map[key]?.[agentId]) return
+    const rest = { ...(map[key] as Record<string, number>) }
+    delete rest[agentId]
+    if (Object.keys(rest).length === 0) delete map[key]
+    else map[key] = rest
+  } else {
+    delete map[key]
+  }
+  writeMap(map)
+}
+
+/**
+ * Orders agents by recency of use (most recent first). Agents with no
+ * recorded use fall back to alphabetical order after the used ones.
+ */
+export function sortAgentsByRecency<T extends { id: string; name: string }>(
+  agents: readonly T[],
+  openedAt: Record<string, number>,
+): T[] {
+  return [...agents].sort((a, b) => {
+    const aAt = openedAt[a.id] ?? Number.NEGATIVE_INFINITY
+    const bAt = openedAt[b.id] ?? Number.NEGATIVE_INFINITY
+    if (aAt !== bAt) return bAt - aAt
+    return a.name.localeCompare(b.name)
+  })
+}

--- a/src/shared/auth/root-entry.test.ts
+++ b/src/shared/auth/root-entry.test.ts
@@ -8,6 +8,7 @@ import {
 } from './root-entry'
 
 test('authenticated root sessions enter the real app', () => {
+  assert.equal(ROOT_APP_DESTINATION, '/app/agents')
   assert.equal(
     resolveRootEntryDestination(classifyRootSessionResponse({
       ok: true,

--- a/src/shared/auth/root-entry.ts
+++ b/src/shared/auth/root-entry.ts
@@ -1,4 +1,4 @@
-export const ROOT_APP_DESTINATION = '/app/chat'
+export const ROOT_APP_DESTINATION = '/app/agents'
 export const ROOT_SHOWCASE_DESTINATION = '/app/chat?showcase=1&id=showcase-welcome'
 
 export type RootSessionResolution =


### PR DESCRIPTION
## Outcome

Fixes two user-reported issues with the agent-first experience:

1. **Blank Agents landing** — opening `/app/agents` sometimes stuck on the 'Your agents work from here' empty state even with an agent highlighted in the sidebar. Root cause: the sidebar auto-open swallowed DM-creation failures and marked the agent attempted, so it never retried. The roster now also defaults to the most recently used agent per workspace and orders the secondary sidebar by recency of use.
2. **Stale BYOA environments** — local Mac connectors go offline (sleep/closed terminal) with no explanation and no path back. Offline environments in Settings now say why, state that Overlay cannot wake them remotely (outbound-only protocol), and offer the macOS persistent-service install command with one-click copy. Enrollment setup prompt nudges toward persistence.

## Decisions

- **Client-side open recency, not server last-run timestamps.** The directory contract has no per-agent activity timestamp; adding one is a cross-provider (Convex + Postgres + contracts) change. `src/shared/agents/last-agent-by-workspace.ts` mirrors the existing `last-chat-by-view` pattern but in guarded localStorage so recency survives restarts. Server-side last-active remains a noted follow-up in AGENT_PLAN.md.
- **Bounded auto-open retries (1+2), then a visible error + manual Retry** — never an infinite loop, never a silent blank page.
- **No auto-resume-on-reconnect.** Researched and deliberately deferred: duplicate-work risk if the user already started fresh, plus Eve missing-cursor fail-closed. Recorded as a Step-3 decision in AGENT_PLAN.md.
- **Version-pin repair included:** CLI restart/service hints, README, and launchd test still pinned host `0.3.4` while the release is `0.3.5`; the release-gate script now asserts all pins together.

## Touched systems

- `src/components/layout/AppSidebarInlinePanel.tsx` (AgentsInlinePanel: recency sort, default select, retry/error)
- `src/shared/agents/last-agent-by-workspace.{ts,test.ts}` (new)
- `src/features/agents/components/AgentConversationWorkspace.tsx` (clear recency on archive)
- `src/features/settings/components/AgentEnvironmentSettings.tsx` (offline recovery hint)
- `src/features/agents/lib/byo-agent-setup.ts` (persistence nudge)
- `packages/overlay-agent-host` (cli pin, README, launchd test), `scripts/verify-agent-host-release.mjs`
- Docs: `AGENT_PLAN.md`, `CHANGELOG.md`, `docs/develop/bring-your-own-agents.md` (offline-policy + release line)

## Risk and rollback

Low. Isolated UI behavior + copy changes; no API, schema, Convex, or protocol changes. Roll back with `git revert` of the three commits; worst case the roster returns to alphabetical/first-agent default.

## Checks run (all green in the feature worktree)

- `npx tsx --test src/shared/agents/last-agent-by-workspace.test.ts` — 6/6 pass
- `npm --prefix packages/overlay-agent-host test` — 25 pass, 1 pre-existing env-gated skip (live Hermes)
- `npm run verify:agent-host-release` — pinned and consistent at 0.3.5
- `npm run check:shared-isomorphic` — 149 modules pass
- ESLint on all touched files — 0 errors (1 pre-existing boundary warning)
- `tsc --noEmit` — clean
- `npm run build` — compiled successfully, 202/202 static pages
- `npm run docs:health` — OK

## Staging / browser evidence

Not yet — needs Integration QA on staging (log in, open /app/agents, confirm last-used agent opens; check an offline environment row in Settings). No hosted preview exists for feature branches by design.

## Migration / deployment

None. No migrations, no env vars, no Convex changes. Web-only.

## Base and head

- Base: `staging` (at 693d1405b at PR creation)
- Head: `codex/agent-recency` (3 commits from `origin/main` f25b87e0a)